### PR TITLE
fix: honor --config/--json before the verb

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -40,13 +40,24 @@ def _print_ticket_list(tickets: list[Ticket], as_json: bool) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     # Shared flags usable on either side of the verb (tkt --json view X == tkt view X --json).
+    # SUPPRESS defaults are load-bearing: --config/--json live on both the top-level
+    # parser and every subparser (via parents). With an ordinary default, the
+    # subparser copy re-applies its default and clobbers a value the top-level
+    # parser already set, so `tkt --config X view K` silently loses --config.
+    # SUPPRESS means an absent copy writes nothing; whichever side supplied the flag
+    # wins. Real defaults are seeded once on the top-level parser below.
     common = argparse.ArgumentParser(add_help=False)
-    common.add_argument("--config", help="path to .sdlc/config.toml (else auto-discover)")
-    common.add_argument("--json", action="store_true", help="emit JSON where supported")
+    common.add_argument("--config", default=argparse.SUPPRESS,
+                        help="path to .sdlc/config.toml (else auto-discover)")
+    common.add_argument("--json", action="store_true", default=argparse.SUPPRESS,
+                        help="emit JSON where supported")
 
     p = argparse.ArgumentParser(
         prog="tkt", description="Provider-agnostic ticketing CLI", parents=[common]
     )
+    # NB: do NOT seed these with parser.set_defaults() — that mutates the shared
+    # action's .default (parents= copies actions by reference), undoing SUPPRESS
+    # and reviving the clobber. Baseline defaults are applied post-parse in main().
     sub = p.add_subparsers(dest="verb", required=True)
 
     def add(name):
@@ -130,6 +141,13 @@ def _subst(value: str, pkg: str, ticket: str, slug: str) -> str:
 def main(argv: list[str]) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    # --config/--json use SUPPRESS defaults so a flag given before the verb isn't
+    # clobbered by the subparser's copy. Apply their baseline defaults here, only
+    # when neither side supplied the flag.
+    if not hasattr(args, "config"):
+        args.config = None
+    if not hasattr(args, "json"):
+        args.json = False
 
     try:
         # `init` runs before any config exists — handle it before Config.load().


### PR DESCRIPTION
## Bug

`tkt --config X <verb>` silently ignored `--config` and fell back to auto-discovery; the same affected `--json` placed before the verb. Only `tkt <verb> … --config X` (after the verb) worked.

```
# before this fix:
tkt --config fixture/config.toml cfg queries --json   # → returned the AUTO-DISCOVERED config's queries, not the fixture's
```

## Root cause

`--config` and `--json` are shared flags declared once on a `common` parent and attached — via `parents=[common]` — to both the top-level parser and every subparser. argparse copies parent actions **by reference**, so the same action objects are shared. When a flag is given before the verb, the top-level parser sets it; then the subparser re-applies that action's *default*, overwriting the value. Result: the pre-verb value is lost.

## Fix

- Give the shared flags `default=argparse.SUPPRESS`, so an absent subparser copy writes nothing and whichever side supplied the flag wins.
- Apply the baseline defaults (`config=None`, `json=False`) **post-parse** in `main()`.
- Explicitly **not** `parser.set_defaults(...)`: it mutates the shared action's `.default`, which would undo `SUPPRESS` and revive the clobber. (Comment in code notes this so it isn't "simplified" back.)

## Verification

```
tkt --config FIX cfg queries --json        # → FIX's queries ✓
tkt --config FIX --json view K             # → valid JSON from FIX's board ✓
tkt cfg queries --config FIX --json        # → still works ✓
tkt view K                                 # → auto-discover + human output unchanged ✓
```

Surfaced while building `tktban`, which works around the bug by passing config via `TKT_CONFIG`; with this fix `--config` is reliable on either side.