### PR TITLE
feat: add edit verb for ticket content and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ Every adapter implements these. Read verbs accept `--json` (either side of the v
 | `tkt lane-time KEY --role ROLE` | log time for an already-exited lane (entry→exit) | worklog / `--json` |
 | `tkt create --type T --summary S [--priority P] [--assignee A] [--body B] [--project P]` | create a ticket | new key / `--json` ticket |
 | `tkt link KEY --to OTHER --type T` | link KEY → OTHER (`T` = outward description: `blocks`, `is blocked by`, `Fixes`, …) | confirmation |
+| `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L]` | edit content/fields in place (only flags passed change; status excluded — use `transition`) | normalized ticket / `--json` |
 | `tkt init --provider P [--dir D] [--force] [--link-skills] [--sample]` | scaffold `.sdlc/config.toml` (+ optionally link the pack) | next-steps summary |
 | `tkt lane ROLE` | resolve ROLE → provider lane name | string (config-only, no backend) |
 | `tkt cfg DOTTED.KEY [--pkg X] [--ticket K] [--slug S]` | read a config value; substitutes `{pkg}`/`{key}`/`{key-lower}`/`{slug}` | string / `--json` |
 | `tkt doctor` | validate auth + reachability + board model | checks; exit 1 if any fail |
 
-`create`/`link` are optional verbs — adapters opt in (jira + markdown support them);
-a backend without them returns a clear "not supported" error rather than failing to load.
+`create`/`link`/`edit` are optional verbs — adapters opt in (markdown supports all
+three; jira supports create/link); a backend without them returns a clear "not
+supported" error rather than failing to load.
 
 Errors always go to stderr with a non-zero exit (2 config, 3 provider, 4 not-found,
 64 usage) — skills can branch on exit code and never get a silent failure.

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -78,3 +78,21 @@ class Adapter(ABC):
         """Link `key` to `to` with a provider link type (e.g. 'is blocked by',
         'blocks', 'relates to', 'Fixes', 'duplicates')."""
         raise ProviderError(f"link not supported by provider '{self.config.provider}'")
+
+    def edit(
+        self,
+        key: str,
+        summary: str | None = None,
+        body: str | None = None,
+        priority: str | None = None,
+        assignee: str | None = None,
+        add_labels: list[str] | None = None,
+        remove_labels: list[str] | None = None,
+    ) -> Ticket:
+        """Edit a ticket's content/fields in place; return it normalized.
+
+        Only the arguments that are not None are changed (an empty string is a
+        valid value, e.g. clearing the assignee). Status is intentionally NOT
+        editable here — lane moves go through `transition` so history/worklog
+        stay correct."""
+        raise ProviderError(f"edit not supported by provider '{self.config.provider}'")

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -305,6 +305,70 @@ class MarkdownAdapter(Adapter):
             fm["links"] = cur
         self._write_raw(key, fm, body)
 
+    @staticmethod
+    def _split_body(doc: str) -> tuple[str, str, str]:
+        """Split a ticket body into (summary, description, rest).
+
+        summary = the first `# ` heading; description = the prose between it and
+        the first `## ` section; rest = that first `## ` section onward
+        (Acceptance, Comments, ...), preserved verbatim so an edit doesn't drop
+        acceptance criteria or the comment log."""
+        summary = ""
+        desc_lines: list[str] = []
+        rest_lines: list[str] = []
+        seen_summary = False
+        in_rest = False
+        for line in doc.splitlines():
+            s = line.strip()
+            if in_rest:
+                rest_lines.append(line)
+            elif not seen_summary and s.startswith("# "):
+                summary = s[2:].strip()
+                seen_summary = True
+            elif s.startswith("## "):
+                in_rest = True
+                rest_lines.append(line)
+            else:
+                desc_lines.append(line)
+        return summary, "\n".join(desc_lines).strip(), "\n".join(rest_lines).strip()
+
+    def edit(self, key, summary=None, body=None, priority=None, assignee=None,
+             add_labels=None, remove_labels=None):
+        fm, doc = self._read_raw(key)
+
+        if priority is not None:
+            fm["priority"] = priority
+        if assignee is not None:
+            fm["assignee"] = assignee
+
+        if add_labels or remove_labels:
+            cur = fm.get("labels", []) or []
+            if isinstance(cur, str):
+                cur = [cur]
+            cur = list(cur)
+            for lbl in (add_labels or []):
+                if lbl not in cur:
+                    cur.append(lbl)
+            for lbl in (remove_labels or []):
+                if lbl in cur:
+                    cur.remove(lbl)
+            fm["labels"] = cur
+
+        # Only rebuild the body when summary/description actually change, so a
+        # pure frontmatter edit leaves the markdown (and its Comments) untouched.
+        if summary is not None or body is not None:
+            cur_summary, cur_desc, rest = self._split_body(doc)
+            new_summary = cur_summary if summary is None else summary
+            new_desc = cur_desc if body is None else body
+            doc = f"# {new_summary}\n"
+            if new_desc:
+                doc += f"\n{new_desc}\n"
+            if rest:
+                doc += f"\n{rest}\n"
+
+        self._write_raw(key, fm, doc)
+        return self.view(key)
+
     def worklog(self, key, from_role, note="", billable=False):
         lane = self.config.role_to_lane(from_role)
         if self.config.timetracking.get("provider", "none") == "none":

--- a/core/cli.py
+++ b/core/cli.py
@@ -107,6 +107,17 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--to", required=True, dest="to")
     sp.add_argument("--type", required=True, dest="link_type")
 
+    sp = add("edit")
+    sp.add_argument("key")
+    # default=None means "field not supplied" → leave unchanged (an empty string
+    # is still a valid value, e.g. --assignee "" to clear it).
+    sp.add_argument("--summary", default=None)
+    sp.add_argument("--body", default=None)
+    sp.add_argument("--priority", default=None)
+    sp.add_argument("--assignee", default=None)
+    sp.add_argument("--add-label", action="append", default=[], dest="add_label")
+    sp.add_argument("--remove-label", action="append", default=[], dest="remove_label")
+
     sp = add("lane")
     sp.add_argument("role")
 
@@ -237,6 +248,17 @@ def main(argv: list[str]) -> int:
         elif args.verb == "link":
             adapter.link(args.key, args.to, args.link_type)
             print(f"{args.key} {args.link_type} {args.to}")
+
+        elif args.verb == "edit":
+            t = adapter.edit(
+                args.key, summary=args.summary, body=args.body,
+                priority=args.priority, assignee=args.assignee,
+                add_labels=args.add_label, remove_labels=args.remove_label,
+            )
+            if args.json:
+                print(json.dumps(t.to_dict(), indent=2))
+            else:
+                _print_ticket_human(t)
 
         elif args.verb == "doctor":
             checks = adapter.doctor()


### PR DESCRIPTION
Implements **TKT-1** — the blocker for tktban TKB-6 (in-TUI ticket editing).

## What
A backend-agnostic `edit` verb so a ticket's content/fields can be changed through the verb contract, instead of writing the backend's storage directly (which would break agnosticism — the reason tktban couldn't offer an editor).

```
tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L ...] [--remove-label L ...]
```

Only the flags passed are changed (`None` = leave as-is; `--assignee ""` clears). **Status is intentionally excluded** — lane moves stay with `transition` so history/worklog remain correct.

## How
- `base.Adapter.edit` — optional verb (like `create`/`link`), defaults to a clear "not supported" `ProviderError` so adapters opt in; jira/github/linear/openkanban inherit the default until they implement it.
- `core/cli.py` — `edit` subparser + dispatch; string flags default to `None`, labels are `append`.
- `adapters/markdown.py` — rewrites frontmatter (priority/assignee/labels) and body via a new `_split_body`, which **preserves the `## Acceptance` and `## Comments` sections verbatim**. Body is only rebuilt when summary/description change, so a pure frontmatter edit leaves the markdown untouched.
- `README.md` — documents `edit` in the verb table and the optional-verb note.

## Validation
tkt has no test suite (per CLAUDE.md) — validated by running the real verb against a throwaway board:
- edit summary / body / priority / assignee / add+remove labels each apply correctly
- unspecified fields stay unchanged; **status stays put**; Acceptance + Comments preserved
- `create` → `edit` round-trips

## Note (pre-existing, out of scope)
The normalized `view` folds any non-`Acceptance` `##` section (e.g. `## Comments`) into the `description` field — a quirk in `_to_ticket`, not introduced here. `edit`/`_split_body` handle sections correctly; worth a separate follow-up if the view field matters.