### PR TITLE
fix: view folds non-Acceptance sections into description

### DIFF
--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -162,7 +162,11 @@ class MarkdownAdapter(Adapter):
                 section = "acceptance"
                 continue
             if stripped.startswith("## "):
-                section = None
+                # Any other section (Comments, etc.) — mark it distinctly, not
+                # None, so its body isn't folded into the description. None is
+                # reserved for the preamble between the summary and the first
+                # `## ` heading, which is the actual description.
+                section = "other"
                 continue
             if section == "acceptance" and stripped.startswith(("-", "*")):
                 acceptance.append(stripped[1:].strip())


### PR DESCRIPTION
Fixes **TKT-2**.

## Bug
`tkt view` (markdown adapter `_to_ticket`) built `description` by collecting any body line while `section is None`. A non-Acceptance `## ` heading (e.g. `## Comments`) reset `section` back to `None` — the same state as the preamble — so content under it was folded into `description`. The raw markdown was correct; only the normalized field was wrong.

## Fix
Mark non-Acceptance `## ` headings as `"other"` instead of `None`, so `description` only collects the preamble prose between the summary and the first `## ` heading. This matches `_split_body` (used by the `edit` verb), so `view` and `edit` now agree on what the description is.

One-line behavior change; only ever *shrinks* `description` for tickets that have extra `##` sections — strictly an improvement for every consumer.

## Validation
Live against a throwaway ticket with description + Acceptance + Comments:
- `description` = the two preamble lines only; the comment does **not** leak
- `acceptance` parsing unchanged

## Impact
Removes the description pre-fill caveat noted on the tktban editor (TKB-6): the editor now pre-fills from a clean `description`.