### PR TITLE
feat: read-only mode for lane-time verb

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -50,9 +50,15 @@ class Adapter(ABC):
         with worklog_id="") when timetracking provider is 'none'."""
 
     @abstractmethod
-    def lane_time(self, key: str, role: str) -> Worklog:
-        """Record time for an ALREADY-EXITED lane (entry -> next exit), for
-        retroactive accounting (e.g. deploy-ready over QA lanes)."""
+    def lane_time(self, key: str, role: str, read_only: bool = False) -> Worklog:
+        """Time in the lane mapped from `role`, measured from the most recent
+        entry into that lane until its next exit (or until now if still there).
+
+        By default this RECORDS a retroactive worklog (e.g. deploy-ready over QA
+        lanes). With read_only=True it computes and returns the same duration but
+        records nothing (worklog_id=""), for display surfaces such as a board UI;
+        in that mode the timetracking provider is ignored so the duration is
+        available even when no time is being tracked."""
 
     @abstractmethod
     def doctor(self) -> list[Check]:

--- a/adapters/github.py
+++ b/adapters/github.py
@@ -325,7 +325,7 @@ class GithubAdapter(Adapter):
         return Worklog(key=key, role=from_role,
                        lane=self.config.role_to_lane(from_role), note=note)
 
-    def lane_time(self, key, role):
+    def lane_time(self, key, role, read_only=False):
         return Worklog(key=key, role=role, lane=self.config.role_to_lane(role))
 
     def doctor(self):

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -366,9 +366,11 @@ class JiraAdapter(Adapter):
         return Worklog(key=key, role=from_role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note=note)
 
-    def lane_time(self, key, role):
+    def lane_time(self, key, role, read_only=False):
         lane = self.config.role_to_lane(role)
-        if not self._provider_tracks_time():
+        # read_only computes for display regardless of time tracking; the
+        # recording path stays a no-op when the provider tracks no time.
+        if not read_only and not self._provider_tracks_time():
             return Worklog(key=key, role=role, lane=lane)
         entries = sorted(self._changelog_entries(key), key=lambda e: e[0])
         last_in = None
@@ -383,6 +385,9 @@ class JiraAdapter(Adapter):
                 exit_dt = _parse_iso(ts)
                 break
         secs = max(int((exit_dt - _parse_iso(last_in)).total_seconds()), 60)
+        if read_only:
+            return Worklog(key=key, role=role, lane=lane, seconds=secs,
+                           human=human_duration(secs))
         body = f"Lane: {lane}. Recorded retroactively by tkt."
         wl_id = self._post_worklog(key, secs, last_in, body)
         self._mark_non_billable(wl_id, secs, body)

--- a/adapters/linear.py
+++ b/adapters/linear.py
@@ -297,7 +297,7 @@ class LinearAdapter(Adapter):
         return Worklog(key=key, role=from_role,
                        lane=self.config.role_to_lane(from_role), note=note)
 
-    def lane_time(self, key, role):
+    def lane_time(self, key, role, read_only=False):
         return Worklog(key=key, role=role, lane=self.config.role_to_lane(role))
 
     def doctor(self):

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -389,9 +389,11 @@ class MarkdownAdapter(Adapter):
         return Worklog(key=key, role=from_role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note=note)
 
-    def lane_time(self, key, role):
+    def lane_time(self, key, role, read_only=False):
         lane = self.config.role_to_lane(role)
-        if self.config.timetracking.get("provider", "none") == "none":
+        # read_only computes for display regardless of time tracking; the
+        # recording path stays a no-op when no provider is configured.
+        if not read_only and self.config.timetracking.get("provider", "none") == "none":
             return Worklog(key=key, role=role, lane=lane)
         history = sorted(self._read_history(key), key=lambda h: h["ts"])
         last_in = None
@@ -407,6 +409,9 @@ class MarkdownAdapter(Adapter):
                 exit_dt = ts
                 break
         secs = max(int((exit_dt - last_in).total_seconds()), 60)
+        if read_only:
+            return Worklog(key=key, role=role, lane=lane, seconds=secs,
+                           human=human_duration(secs))
         wl_id = self._append_worklog(key, role, lane, secs, "retroactive")
         return Worklog(key=key, role=role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note="retroactive")

--- a/adapters/openkanban.py
+++ b/adapters/openkanban.py
@@ -241,7 +241,7 @@ class OpenKanbanAdapter(Adapter):
         return Worklog(key=key, role=from_role,
                        lane=self.config.role_to_lane(from_role), note=note)
 
-    def lane_time(self, key, role):
+    def lane_time(self, key, role, read_only=False):
         return Worklog(key=key, role=role, lane=self.config.role_to_lane(role))
 
     def doctor(self):

--- a/core/cli.py
+++ b/core/cli.py
@@ -93,6 +93,8 @@ def build_parser() -> argparse.ArgumentParser:
     sp = add("lane-time")
     sp.add_argument("key")
     sp.add_argument("--role", required=True)
+    sp.add_argument("--read-only", action="store_true", dest="read_only",
+                    help="compute and print the duration without recording a worklog")
 
     sp = add("create")
     sp.add_argument("--type", required=True, dest="issue_type")
@@ -228,9 +230,11 @@ def main(argv: list[str]) -> int:
                 print(f"{wl.key}  {wl.role}: {wl.human}  worklog={where}")
 
         elif args.verb == "lane-time":
-            wl = adapter.lane_time(args.key, args.role)
+            wl = adapter.lane_time(args.key, args.role, read_only=args.read_only)
             if args.json:
                 print(json.dumps(wl.to_dict(), indent=2))
+            elif args.read_only:
+                print(f"{wl.key}  {wl.role}: {wl.human}")
             else:
                 where = wl.worklog_id or "(no time tracking)"
                 print(f"{wl.key}  {wl.role}: {wl.human}  worklog={where}")


### PR DESCRIPTION
## Summary

Adds a `--read-only` flag to `tkt lane-time` (and a `read_only` kwarg on the adapter contract) that computes a ticket's time-in-lane **without recording a worklog**. Until now both timing verbs (`worklog`, `lane-time`) mutated the time-tracking store on every call, so there was no pure read of time-in-lane — which a board UI needs to show per-card lane time without polluting worklogs.

## Motivation

Unblocks tktban TKB-2 ("show time-in-lane from history sidecar"): tktban speaks only the tkt verb contract and must not read backend storage directly, but no read-only timing verb existed.

## Behaviour

`tkt lane-time KEY --role ROLE --read-only [--json]`:
- Same entry→exit (or entry→now if still in the lane) duration as the recording path.
- No worklog written (`worklog_id=""`, `note=""`).
- Timetracking provider ignored, so the duration is available even when `provider = "none"`.

The default (recording) behaviour is unchanged.

## Changes
- `adapters/base.py`: `lane_time(key, role, read_only=False)` contract + docstring.
- `adapters/markdown.py`, `adapters/jira.py`: compute-and-return without writing when `read_only`.
- `adapters/github.py`, `linear.py`, `openkanban.py`: accept the kwarg (stubs unchanged).
- `core/cli.py`: `--read-only` flag + plain-text output line.

## Testing
- Manual (no test suite in repo): `--read-only` x2 against a markdown board added **0** rows to `worklog.jsonl` and returned the correct duration; default `lane-time` still appended a row. CLI help/JSON/plain output verified.