### PR TITLE
feat: make SDLC pack harness-agnostic with OpenCode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.sdlc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,12 @@ Pure stdlib, Python 3.11+ (uses `tomllib`). No third-party deps, no build step.
 ./tkt <verb> ...              # run the CLI from the repo (or symlink ./tkt onto PATH)
 ./tkt doctor                  # validate a project's auth + reachability + board model
 ./tkt view KEY --json         # normalized ticket shape skills parse
-./tkt init --provider markdown --link-skills --sample   # scaffold a project's .sdlc/
+./tkt init --provider markdown --link-harness claude --sample   # scaffold a project's .sdlc/
 ```
+
+Use `--link-harness opencode` for OpenCode, `--link-harness all` for every known
+harness, or `--global` to install into user harness config instead of the project.
+`--link-skills` is deprecated and now means `--link-harness claude`.
 
 There is **no test suite, linter config, or Makefile** in this repo. "Validation"
 of an adapter means running `tkt doctor` / the read verbs live against a real backend
@@ -78,7 +82,7 @@ string. This is the core abstraction that lets one skill drive an 8-lane Jira bo
 
 No skill changes are ever required — that's the point of the split.
 
-## Skill pack (`skills/`, `agents/`)
+## Skill pack (`skills/`, `agents/`, `commands/`)
 
 The `skills/*/SKILL.md` files are the provider-agnostic SDLC pipeline (select → triage →
 plan → open-pr → ci-fix → self-review → respond-to-review → deploy, orchestrated by

--- a/PLAN.md
+++ b/PLAN.md
@@ -220,15 +220,27 @@ Validate each with `tkt doctor` + a dry run.
   live-validated; projectv2 + mutations need scope/consent.)
 - Docs: README Install / Use-in-a-project / verb contract / per-provider notes.
 
+### Phase 5 — Harness-agnostic packaging ✅
+- Refactored `tkt init` to support multiple agent harnesses.
+- Added `--link-harness <claude|opencode|all>` and `--global`.
+- Deprecated `--link-skills` (now an alias for `--link-harness claude`).
+- Added `harnesses/<name>/manifest.toml` so new harnesses need only a manifest.
+- Added OpenCode slash commands under `commands/` as thin skill wrappers.
+- Marked all skills with `compatibility: [claude, opencode]` frontmatter.
+- Updated README, CLAUDE.md, and this plan.
+
 ---
 
 ## 5. Plug-into-a-new-project flow (end state)
 
-1. Copy `skills/` pack + `tkt` adapter into the project's `.claude/` (or a shared plugin).
-2. `sdlc init` → choose provider, answer prompts → writes `.sdlc/config.toml`.
+1. Copy `skills/` pack + `tkt` adapter into the project's `.claude/`, `.opencode/`,
+   or a shared plugin.
+2. `tkt init --provider <name> --link-harness <claude|opencode|all>` → writes
+   `.sdlc/config.toml` and symlinks the pack into the harness directories.
 3. Export auth env vars named in `config.ticketing.auth_env`.
 4. `tkt doctor` → green.
-5. Invoke `automated-sdlc`. Same skills, new backend.
+5. Invoke `automated-sdlc` (Claude skill) or `/automated-sdlc` (OpenCode command).
+   Same skills, new backend.
 
 ---
 
@@ -243,5 +255,6 @@ Validate each with `tkt doctor` + a dry run.
   `[board.ownership]`) lets the orchestrator stay generic — confirm that's wanted vs
   keeping gates in skill prose.
 - **Where the pack lives**: per-repo `.claude/` copy (drifts) vs a shared OMC-style
-  plugin (single source, versioned). Recommend plugin.
+  plugin (single source, versioned). Recommend plugin. Now also supports
+  `.opencode/` and global harness installs via `tkt init --link-harness --global`.
 ```

--- a/README.md
+++ b/README.md
@@ -30,23 +30,33 @@ Fastest path — scaffold with `tkt init`:
 
 ```sh
 cd my-project
-tkt init --provider markdown --link-skills --sample
-#   writes .sdlc/config.toml, symlinks skills/ + agents/ into .claude/,
-#   and (markdown) drops a starter ticket. --provider: jira|markdown|github|linear.
+tkt init --provider markdown --link-harness opencode --sample
+#   writes .sdlc/config.toml, installs skills/agents/commands into .opencode/,
+#   and (markdown) drops a starter ticket.
+#   --provider: jira|markdown|github|linear
+#   --link-harness: claude|opencode|all
+#   --global: install into user harness config instead of the project
 $EDITOR .sdlc/config.toml         # adjust roles/queries/repo to taste
 tkt doctor                        # validate auth + board model
 ```
 
 `tkt init` flags: `--provider` (required non-interactively; prompts on a TTY),
 `--dir` (target, default cwd), `--force` (overwrite existing config),
-`--link-skills` (symlink the pack into `.claude/`), `--sample` (markdown starter
-ticket). It refuses to clobber an existing `.sdlc/config.toml` without `--force`.
+`--link-harness` (install the pack for a harness; `all` installs every known
+harness), `--global` (install into user config instead of project dir),
+`--sample` (markdown starter ticket). It refuses to clobber an existing
+`.sdlc/config.toml` without `--force`.
+
+The legacy `--link-skills` flag is deprecated; it is now an alias for
+`--link-harness claude` and prints a deprecation warning.
 
 Manual equivalent, if you prefer:
 
 ```sh
 mkdir -p .sdlc && cp ~/Development/tkt/examples/config.markdown.toml .sdlc/config.toml
-ln -s ~/Development/tkt/skills/* .claude/skills/
+ln -s ~/Development/tkt/skills/* .opencode/skills/
+ln -s ~/Development/tkt/agents/* .opencode/agents/
+ln -s ~/Development/tkt/commands/* .opencode/commands/
 ```
 
 Config discovery order: `--config <path>` → `$TKT_CONFIG` → nearest `.sdlc/config.toml`
@@ -235,12 +245,17 @@ originals — every ticketing/board call now goes through `tkt`):
 `agents/ticket-researcher.md` is the read-only lookup subagent (provider-agnostic
 port of the old `jira-researcher`).
 
-To activate in a project, copy these into the project's `.claude/skills/` (and
-`agents/`) — or symlink. They depend only on `tkt` + `.sdlc/config.toml`, so the
-same skill set runs against any configured backend. Skills speak in **roles**
+To activate in a project, copy these into the project's `.claude/skills/`,
+`.opencode/skills/`, and corresponding `commands/` (or symlink via `tkt init
+--link-harness`). They depend only on `tkt` + `.sdlc/config.toml`, so the same
+skill set runs against any configured backend. Skills speak in **roles**
 (`in_progress`, `review`, `done`, ...) and read toolchain/VCS/deploy settings via
 `tkt cfg` (e.g. `tkt cfg build.test --pkg X`, `tkt cfg vcs.branch_fmt --ticket K
 --slug s`), so nothing about Jira/pnpm/GitHub is baked into skill text.
+
+OpenCode users additionally get slash commands (`.opencode/commands/`) that load
+the matching skill, e.g. `/triage-ticket ABC-123` or `/automated-sdlc`. Commands
+are thin wrappers — the skill remains the source of truth.
 
 VCS (PR/CI/merge via `gh`) and infra (preview/deploy) remain GitHub/cloud-shaped;
 repo, branch formats, reviewers, and workflow names are all config-driven, and

--- a/commands/automated-sdlc.md
+++ b/commands/automated-sdlc.md
@@ -1,0 +1,7 @@
+---
+description: Run the automated SDLC pipeline from ticket selection through deploy
+---
+
+Load and use the `automated-sdlc` skill. If a starting ticket key is provided, pass it along:
+
+$ARGUMENTS

--- a/commands/check-blockers.md
+++ b/commands/check-blockers.md
@@ -1,0 +1,7 @@
+---
+description: Classify blocked tickets and recommend unblock actions
+---
+
+Load and use the `check-blockers` skill. If a query hint is provided, pass it along:
+
+$ARGUMENTS

--- a/commands/complete-deliverable.md
+++ b/commands/complete-deliverable.md
@@ -1,0 +1,7 @@
+---
+description: Complete a non-PR deliverable ticket and transition it straight to Done
+---
+
+Load and use the `complete-deliverable` skill for ticket $1:
+
+$ARGUMENTS

--- a/commands/hotfix-revert.md
+++ b/commands/hotfix-revert.md
@@ -1,0 +1,7 @@
+---
+description: Run the hotfix revert flow for a production regression
+---
+
+Load and use the `hotfix-revert` skill. If a ticket key is provided, pass it along:
+
+$ARGUMENTS

--- a/commands/open-pr.md
+++ b/commands/open-pr.md
@@ -1,0 +1,7 @@
+---
+description: Commit, push, open a PR, request reviewers, and move the ticket to review
+---
+
+Load and use the `open-pr` skill for ticket $1:
+
+$ARGUMENTS

--- a/commands/plan-ticket.md
+++ b/commands/plan-ticket.md
@@ -1,0 +1,7 @@
+---
+description: Produce a structured implementation plan for a ticket
+---
+
+Load and use the `plan-ticket` skill for ticket $1:
+
+$ARGUMENTS

--- a/commands/resume-from-revise.md
+++ b/commands/resume-from-revise.md
@@ -1,0 +1,7 @@
+---
+description: Resume the SDLC pipeline after a human revise fix
+---
+
+Load and use the `resume-from-revise` skill for ticket $1:
+
+$ARGUMENTS

--- a/commands/select-ticket.md
+++ b/commands/select-ticket.md
@@ -1,0 +1,7 @@
+---
+description: Discover and select the next ticket to work on
+---
+
+Load and use the `select-ticket` skill. If a tier or query hint is provided, pass it along:
+
+$ARGUMENTS

--- a/commands/triage-ticket.md
+++ b/commands/triage-ticket.md
@@ -1,0 +1,7 @@
+---
+description: Triage a ticket — read it, summarize requirements, move to In Progress
+---
+
+Load and use the `triage-ticket` skill for ticket $1:
+
+$ARGUMENTS

--- a/core/cli.py
+++ b/core/cli.py
@@ -128,7 +128,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--dir", default=".", help="project dir to scaffold (default cwd)")
     sp.add_argument("--force", action="store_true", help="overwrite existing config")
     sp.add_argument("--link-skills", action="store_true",
-                    help="symlink skills/ + agents/ into .claude/")
+                    help="deprecated: use --link-harness claude")
+    sp.add_argument("--link-harness", default="",
+                    help="install skills/agents/commands for a harness (claude|opencode|all)")
+    sp.add_argument("--global", action="store_true", dest="global_",
+                    help="install into user harness config instead of project dir")
     sp.add_argument("--sample", action="store_true",
                     help="markdown: also write a starter ticket")
 
@@ -167,7 +171,8 @@ def main(argv: list[str]) -> int:
         if args.verb == "init":
             from .scaffold import init as scaffold_init
             return scaffold_init(args.provider, args.dir, args.force,
-                                 args.link_skills, args.sample, interactive=True)
+                                 args.link_skills, args.link_harness,
+                                 args.global_, args.sample, interactive=True)
 
         config = Config.load(args.config)
 

--- a/core/scaffold.py
+++ b/core/scaffold.py
@@ -1,10 +1,12 @@
 """`tkt init` — scaffold a project: write .sdlc/config.toml from an example,
-optionally link the skill pack into .claude/, and print next steps.
+optionally install the skill pack into one or more agent harnesses, and print
+next steps.
 
 Runs BEFORE config exists, so it never calls Config.load().
 """
 import shutil
 import sys
+import tomllib
 from pathlib import Path
 
 from .errors import ConfigError, UsageError
@@ -16,6 +18,22 @@ def available_providers() -> list[str]:
     ex = PACK_ROOT / "examples"
     return sorted(p.name[len("config."):-len(".toml")]
                   for p in ex.glob("config.*.toml"))
+
+
+def available_harnesses() -> list[str]:
+    root = PACK_ROOT / "harnesses"
+    if not root.exists():
+        return []
+    names = []
+    for manifest in root.glob("*/manifest.toml"):
+        try:
+            with manifest.open("rb") as f:
+                data = tomllib.load(f)
+            if "harness" in data and "name" in data["harness"]:
+                names.append(data["harness"]["name"])
+        except Exception:
+            continue
+    return sorted(names)
 
 
 _STARTER_TICKET = """\
@@ -37,7 +55,8 @@ Created by `tkt init --sample`. Edit or delete this file.
 
 
 def init(provider: str | None, target_dir: str, force: bool,
-         link_skills: bool, sample: bool, interactive: bool) -> int:
+         link_skills: bool, link_harness: str, global_: bool,
+         sample: bool, interactive: bool) -> int:
     providers = available_providers()
 
     if not provider:
@@ -78,7 +97,22 @@ def init(provider: str | None, target_dir: str, force: bool,
             print(f"wrote {starter}  (starter ticket; --sample)")
 
     if link_skills:
-        _link_pack(target)
+        print(
+            "warning: --link-skills is deprecated; use --link-harness claude instead",
+            file=sys.stderr,
+        )
+        _link_harness(target, "claude", global_)
+
+    if link_harness:
+        harnesses = available_harnesses()
+        requested = harnesses if link_harness == "all" else [link_harness]
+        for name in requested:
+            if name not in harnesses:
+                raise ConfigError(
+                    f"unknown harness '{name}'. Available: {', '.join(harnesses)}"
+                )
+        for name in requested:
+            _link_harness(target, name, global_)
 
     print()
     print("Next steps:")
@@ -92,26 +126,53 @@ def init(provider: str | None, target_dir: str, force: bool,
     else:
         print("  2. (markdown: no auth needed)")
     print(f"  3. {_tkt_invocation()} doctor")
-    if not link_skills:
-        print("  4. Activate skills: tkt init --link-skills (or copy skills/ into .claude/skills/)")
+    if not link_harness and not link_skills:
+        print("  4. Activate skills: tkt init --link-harness <claude|opencode|all>")
     return 0
 
 
-def _link_pack(target: Path) -> None:
-    claude = target / ".claude"
-    for kind in ("skills", "agents"):
-        srcdir = PACK_ROOT / kind
+def _load_manifest(name: str) -> dict:
+    manifest = PACK_ROOT / "harnesses" / name / "manifest.toml"
+    if not manifest.exists():
+        raise ConfigError(f"missing harness manifest: {manifest}")
+    with manifest.open("rb") as f:
+        return tomllib.load(f)
+
+
+def _link_harness(target: Path, name: str, global_: bool) -> None:
+    data = _load_manifest(name)
+    harness = data.get("harness", {})
+    mappings = harness.get("mappings", [])
+    if not mappings:
+        print(f"  harness '{name}' has no mappings; skipping")
+        return
+
+    print(f"  linking harness: {name}")
+    for mapping in mappings:
+        kind = mapping.get("kind")
+        source = mapping.get("source")
+        target_key = "global_target" if global_ else "target"
+        dest_template = mapping.get(target_key)
+        if not kind or not source or not dest_template:
+            continue
+
+        srcdir = PACK_ROOT / source
         if not srcdir.exists():
             continue
-        dstdir = claude / kind
-        dstdir.mkdir(parents=True, exist_ok=True)
+
+        dest = Path(dest_template.replace("~", str(Path.home())))
+        if not dest.is_absolute():
+            dest = target / dest
+        dest = dest.expanduser().resolve()
+        dest.mkdir(parents=True, exist_ok=True)
+
         for item in sorted(srcdir.iterdir()):
-            link = dstdir / item.name
+            link = dest / item.name
             if link.exists() or link.is_symlink():
-                print(f"  skip (exists): {link}")
+                print(f"    skip (exists): {link}")
                 continue
             link.symlink_to(item.resolve())
-            print(f"  linked {link} -> {item.resolve()}")
+            print(f"    linked {link} -> {item.resolve()}")
 
 
 def _tkt_invocation() -> str:

--- a/harnesses/claude/manifest.toml
+++ b/harnesses/claude/manifest.toml
@@ -1,0 +1,15 @@
+[harness]
+name = "claude"
+description = "Anthropic Claude Code agent harness"
+
+[[harness.mappings]]
+kind = "skills"
+source = "skills"
+target = ".claude/skills"
+global_target = "~/.claude/skills"
+
+[[harness.mappings]]
+kind = "agents"
+source = "agents"
+target = ".claude/agents"
+global_target = "~/.claude/agents"

--- a/harnesses/opencode/manifest.toml
+++ b/harnesses/opencode/manifest.toml
@@ -1,0 +1,21 @@
+[harness]
+name = "opencode"
+description = "OpenCode agent harness"
+
+[[harness.mappings]]
+kind = "skills"
+source = "skills"
+target = ".opencode/skills"
+global_target = "~/.config/opencode/skills"
+
+[[harness.mappings]]
+kind = "agents"
+source = "agents"
+target = ".opencode/agents"
+global_target = "~/.config/opencode/agents"
+
+[[harness.mappings]]
+kind = "commands"
+source = "commands"
+target = ".opencode/commands"
+global_target = "~/.config/opencode/commands"

--- a/skills/automated-sdlc/SKILL.md
+++ b/skills/automated-sdlc/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: automated-sdlc
 description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Automated SDLC

--- a/skills/check-blockers/SKILL.md
+++ b/skills/check-blockers/SKILL.md
@@ -2,7 +2,9 @@
 name: check-blockers
 description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
 model: claude-haiku-4-5
-allowed-tools: [Bash, Read]
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Check Blockers

--- a/skills/ci-fix/SKILL.md
+++ b/skills/ci-fix/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ci-fix
 description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # CI Fix

--- a/skills/complete-deliverable/SKILL.md
+++ b/skills/complete-deliverable/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: complete-deliverable
 description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Complete Deliverable

--- a/skills/deploy-preview/SKILL.md
+++ b/skills/deploy-preview/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: deploy-preview
 description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Deploy Preview

--- a/skills/deploy-ready/SKILL.md
+++ b/skills/deploy-ready/SKILL.md
@@ -2,6 +2,9 @@
 name: deploy-ready
 description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
 disable-model-invocation: true
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Deploy Ready

--- a/skills/hotfix-revert/SKILL.md
+++ b/skills/hotfix-revert/SKILL.md
@@ -2,6 +2,9 @@
 name: hotfix-revert
 description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
 disable-model-invocation: true
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Hotfix Revert

--- a/skills/open-pr/SKILL.md
+++ b/skills/open-pr/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: open-pr
 description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Open PR

--- a/skills/plan-ticket/SKILL.md
+++ b/skills/plan-ticket/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: plan-ticket
 description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Plan Ticket

--- a/skills/respond-to-review/SKILL.md
+++ b/skills/respond-to-review/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: respond-to-review
 description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Respond to Review

--- a/skills/resume-from-revise/SKILL.md
+++ b/skills/resume-from-revise/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: resume-from-revise
 description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Resume From Revise

--- a/skills/select-ticket/SKILL.md
+++ b/skills/select-ticket/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: select-ticket
 description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
-allowed-tools: [Bash, Read]
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Select Ticket

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: self-review
 description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Self-Review

--- a/skills/triage-ticket/SKILL.md
+++ b/skills/triage-ticket/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: triage-ticket
 description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
-allowed-tools: [Bash, Read, Edit]
+compatibility:
+  - claude
+  - opencode
 ---
 
 # Triage Ticket


### PR DESCRIPTION
## What

Makes the SDLC skill pack harness-agnostic with first-class OpenCode support.

- Adds harnesses/<name>/manifest.toml so new harnesses only need a manifest.
- Replaces tkt init --link-skills with --link-harness <claude|opencode|all>.
- Adds --global to install skills/agents/commands into user harness config.
- Deprecates --link-skills with a stderr warning (now alias for --link-harness claude).
- Adds thin OpenCode slash-command wrappers under commands/ that load the matching skill.
- Marks all skills with compatibility: [claude, opencode] frontmatter.
- Updates README, PLAN, and CLAUDE.md.
- Ignores local .sdlc/ directory.

## Why

The pack workflow logic was already provider-agnostic via tkt, but packaging was hardcoded to Claude Code (--link-skills only installed into .claude/). OpenCode already reads Claude-style SKILL.md files, so skills work as-is; the missing pieces were install targets and slash-entrypoints.

## Validation

- ./tkt init --provider markdown --link-harness opencode --sample correctly installs .opencode/skills/, .opencode/agents/, and .opencode/commands/.
- ./tkt init --provider markdown --link-skills prints deprecation warning and installs to .claude/.
- --global installs into ~/.config/opencode/ / ~/.claude/.
- python3 -m compileall and LSP diagnostics pass on changed Python files.