### PR TITLE
feat(harness): port SDLC skills to agent formats

### DIFF
--- a/.agents/skills/automated-sdlc/SKILL.md
+++ b/.agents/skills/automated-sdlc/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: automated-sdlc
+description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+---
+
+# Automated SDLC
+
+End-to-end pipeline from "what should I work on?" to "shipped." Orchestrates
+sub-skills with explicit human gates and per-lane time annotation. **Every
+ticketing/board operation goes through `tkt`**, so the same pipeline runs on Jira,
+GitHub Issues+Projects, Linear, qi, or a markdown board — the backend and board
+shape are declared in `.sdlc/config.toml`.
+
+## Prerequisites
+
+- `tkt doctor` passes (ticketing auth + board model reachable).
+- `gh` authenticated (for the PR/CI/merge phases).
+- Toolchain for local build/test (commands resolved via `tkt cfg build.*`).
+- Docker running if your tests need it.
+- On the default branch, up to date.
+
+## Board lanes (roles)
+
+Skills speak in canonical **roles**; `.sdlc/config.toml` `[board.roles]` maps each
+to the provider's actual lane name. Default flow:
+
+```
+backlog → todo → in_progress → review → qa_ready → qa → deploy_ready → done
+```
+
+Side roles: `revise`, `blocked`, `cancelled`. Print a literal lane name with
+`tkt lane <role>`. A board that lacks a lane (e.g. a markdown board with no
+`qa_ready`) simply doesn't define that role — type routing (below) keeps such
+tickets on the short flow.
+
+## Ownership of transitions
+
+Driven by `[board.ownership]` in config. Default:
+
+| Transition (role→role) | Owner |
+| --- | --- |
+| backlog → todo | Human (refinement) |
+| todo → in_progress | **Agent** (after select + triage) |
+| in_progress → review | **Agent** (on PR open) |
+| review → revise | Reviewer — or `respond-to-review` if changes requested mid-loop |
+| revise → in_progress → review | **Agent** (`resume-from-revise`) |
+| review → qa_ready | **Agent** (QA promotion gate; PR stays open) |
+| qa_ready → qa | **Human (QA)** |
+| qa → revise / qa → deploy_ready | **Human (QA)** |
+| deploy_ready → done | **Human** (until the deploy workflow truly deploys) |
+
+## Lane-time annotation
+
+Every agent-driven transition out of a lane records lane time via **one command**:
+
+```shell
+tkt worklog "$KEY" --from-role <role> --note "<context>" --json
+```
+
+`tkt worklog` finds the most recent entry into that lane (paging the provider's
+full changelog/history), computes elapsed time, writes the canonical time entry
+(e.g. a Jira/Tempo worklog, or a local JSONL row), and returns
+`{human, worklog_id, seconds}`. It is a **no-op** (empty `worklog_id`) when
+`[timetracking].provider = "none"`. Then post the human-readable comment embedding
+both values:
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened" --json)
+tkt comment "$KEY" "PR opened. Time in In Progress: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+Annotate on: in_progress → review, review → qa_ready, deploy_ready → done, any
+revise → in_progress, and any agent-driven transition to `blocked`. (This replaces
+the old hand-rolled `annotate_lane_time` shell/Python helper entirely — the
+changelog pagination + billable logic now live inside the provider adapter.)
+
+Use `--billable` only for client/billable work (provider-dependent; ignored where
+the backend has no billable concept).
+
+## Pipeline
+
+### Phase 0: Select ticket
+
+**Invoke `select-ticket`.** Auto-selects Tier 1/2 (assigned); recommends Tier 3–5.
+Drops candidates with unresolved blockers. If nothing across all tiers → stop with
+a "nothing to work on" report.
+
+### Phase 1: Triage
+
+**Invoke `triage-ticket`** with the key. Transitions `todo → in_progress`. Returns
+the ticket `type` and `type_class`.
+
+### Phase 1.5: Route by type
+
+```shell
+CLASS=$(tkt view "$KEY" --json | jq -r .type_class)
+case "$CLASS" in
+  full_sdlc)   : ;;                               # continue to Phase 2
+  deliverable) echo "→ complete-deliverable"; ;;  # invoke complete-deliverable, then stop
+  *)           # unknown: fall back to lane availability
+    HAS_REVIEW=$(tkt view "$KEY" --json | jq -r '[.transitions[]? == (env.REVIEW_LANE)] | any')
+    ;;
+esac
+```
+
+`full_sdlc` (Story/Bug) → full pipeline. `deliverable` (Task/Sub-task/Chore/Epic/
+Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
+`deliverable` sets are defined in `[issue_types]`.
+
+### Phase 2: Plan
+
+**Invoke `plan-ticket`.** Output: files, test strategy, risks. External dep missing
+→ see "External blocker handling".
+
+### Phase 3: Implement + test
+
+1. Branch: `git checkout -b "$(tkt cfg vcs.branch_fmt --ticket "$KEY" --slug "<slug>")"`
+2. Implement per plan.
+3. After each logical unit, run the configured toolchain:
+
+   ```shell
+   eval "$(tkt cfg build.build --pkg "<pkg>")"
+   eval "$(tkt cfg build.typecheck)"
+   eval "$(tkt cfg build.test --pkg "<pkg>")"
+   ```
+
+4. If tests fail → invoke `debug` → loop back.
+
+### Phase 4: Self-review (adversarial)
+
+**Invoke `self-review`** in a loop until clean.
+
+### Phase 5: Open PR
+
+**Invoke `open-pr`** — pushes, opens the PR, requests reviewers, and (for
+`full_sdlc`) transitions `in_progress → review` with lane-time annotation.
+
+### Phase 6: CI loop
+
+**Invoke `ci-fix`** — wait → diagnose → fix → push → repeat until green.
+
+### Phase 7: Review loop
+
+**Invoke `respond-to-review`** — handle all reviewer feedback. Loop until no
+unaddressed comments and the PR is approved. If a reviewer moves the ticket to
+`revise` mid-loop, `respond-to-review` flips it back to `in_progress` while pushing
+fixes, then back to `review`.
+
+### Phase 8: Preview env confirmation
+
+After CI is green, confirm the preview URL is live. **Invoke `deploy-preview`** to
+comment the URL on the ticket (it does not transition).
+
+### Phase 9: Promote to qa_ready (human QA gate)
+
+PR stays **open**. Transition + annotate:
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role review --note "Approved — promoting to QA" --json)
+tkt transition "$KEY" qa_ready
+tkt comment "$KEY" "Preview: <url>. PR open and approved, awaiting QA. \
+Time in review (incl. loops): $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+**Stop here.** QA owns the next move: `qa_ready → qa` (testing), then `→ deploy_ready`
+(pass, pipeline resumes at Phase 10) or `→ revise` (fail, resume via
+`resume-from-revise`).
+
+### Phase 10: Deploy
+
+**Invoke `deploy-ready`** — picks up `deploy_ready` tickets, merges the open PR,
+watches the deploy workflow, gates manual prod deploy, then handles the final
+`done` transition per your project's deploy contract.
+
+## Side flows
+
+### External blocker handling
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Blocked — <desc>" --json)
+tkt transition "$KEY" blocked
+tkt comment "$KEY" "BLOCKED: <desc>. Waiting on: <who>. Need: <what unblocks>. \
+Time in In Progress before blocking: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+Then stop. Run `check-blockers` periodically to recommend unblock actions.
+
+### Revise (QA failure)
+
+When QA moves a ticket to `revise`, a human dev fixes it, then runs
+`/resume-from-revise <KEY>` — annotates revise time and re-enters Phases 6–9.
+
+### Production regression / revert
+
+Invoke `hotfix-revert` — fast-track: highest-priority hotfix ticket, revert the
+offending commit, single human signoff, skip review/QA loops.
+
+## Decision points
+
+| Condition | Action |
+| --- | --- |
+| Tests fail 3× after debug | Stop, comment, `tkt transition "$KEY" blocked`, request human help |
+| CI flake (infra, not code) | `gh run rerun <id> --failed`; don't count against budget |
+| Reviewer "request changes" | Loop via `respond-to-review` until approved |
+| Merge conflicts | `git fetch && git rebase origin/main` → resolve → re-push |
+| Ticket unclear / spec gap | `tkt transition "$KEY" blocked` with a clarifying comment |
+| Scope > 400 LOC | Stop, recommend splitting via `plan-ticket` |
+| Production regression | Invoke `hotfix-revert` |
+
+## Abort conditions
+
+Stop and notify (comment on the ticket) on: 3+ non-converging review cycles;
+infrastructure CI failure; scope > ~400 lines (split needed); external blocker
+unresolved > 24h.

--- a/.agents/skills/check-blockers/SKILL.md
+++ b/.agents/skills/check-blockers/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: check-blockers
+description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
+model: claude-haiku-4-5
+allowed-tools: [Bash, Read]
+---
+
+# Check Blockers
+
+Scans blocked tickets, summarizes why each is stuck, recommends next steps. All
+ticketing via `tkt`.
+
+## When to use
+
+- Standup prep — a "blocked items" rollup
+- Ad-hoc triage of stuck work
+- After a dependency is reported unblocked
+
+## Scope
+
+Default to the current user's blocked tickets. Define the queries in config:
+
+```toml
+[queries]
+blocked      = '... status = blocked AND assignee = currentUser() ...'   # --mine
+blocked_team = '... status = blocked ...'                                 # --team
+```
+
+## Steps
+
+### 1. Query blocked tickets
+
+```shell
+tkt list --query blocked --json        # or blocked_team for --team
+```
+
+### 2. Classify each blocker
+
+Read recent comments + links (`tkt view "$K" --json`) to determine type:
+
+| Signal | Type | Action |
+| --- | --- | --- |
+| unresolved `blocked_by` link → open ticket | internal dep | check blocker status; ping owner |
+| "waiting on <team>" / external system | external dep | verify in their channel; direct ask |
+| "design needed" / "spec missing" | spec gap | schedule a design sync |
+| "credentials" / "access" / "token" | access gap | IT/security request |
+| no update > 7 days | stale | ping blocker owner |
+| no blocker comment | undocumented | add a blocker comment first |
+
+### 3. For internal-dep blockers, check the blocker recursively
+
+```shell
+for B in $(tkt blockers "$K" --json | jq -r '.[].key'); do
+  BSTATE=$(tkt view "$B" --json | jq -r .status_role)
+  echo "$K blocked by $B (status: $BSTATE)"
+done
+```
+
+- blocker is `done`/`deploy_ready` → recommend **unblock now** (move `$K` to `todo`/`in_progress`)
+- blocker is `in_progress`/`review` → ETA-ping its assignee
+- blocker is itself `blocked` → flag chain blocker, recommend escalation
+
+### 4. Build the report
+
+```
+<KEY> | <priority> | <summary>
+  Blocker: <type>
+  Detail: <one line>
+  Recommended next step: <action>
+```
+
+Group by recommended action for batch responses.
+
+### 5. Auto-unblock candidates (confirm before transitioning)
+
+List tickets whose blocker is verifiably resolved. Do **not** transition
+automatically:
+
+```
+Auto-unblock candidates (confirm first):
+  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress
+```
+
+### 6. Optional nudge on stale blockers (after human confirms)
+
+```shell
+tkt comment "$K" "Blocker check: blocked <N> days. Blocker <B> status: <status>. Next: <action>."
+```
+
+## Output
+
+A markdown report grouped by action type (ready to unblock / needs ping / external
+/ stale).
+
+## Scheduling
+
+```
+/schedule weekday 9am /check-blockers --mine
+```

--- a/.agents/skills/ci-fix/SKILL.md
+++ b/.agents/skills/ci-fix/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ci-fix
+description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+---
+
+# CI Fix
+
+Monitor CI on a PR. When checks fail, diagnose from logs, fix, push again, loop
+until green. Git host operations use `gh`; toolchain + ticketing come from
+`.sdlc/config.toml` via `tkt cfg` / `tkt`.
+
+## Input
+
+- PR number (`$PR`) and the ticket key (`$KEY`, for the stuck-escalation comment)
+
+## Steps
+
+### 1. Check / wait for CI
+
+```shell
+gh pr checks "$PR"                                  # one-shot read
+
+# Wait until nothing is pending (stable bucket enum; don't text-grep).
+until [ "$(gh pr checks "$PR" --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+  sleep 15
+done
+gh pr checks "$PR"
+```
+
+All pass after settling → done. **Do not** poll with a text grep — `skipping`
+rows and check names containing `pass` cause false early exits.
+
+### 2. Identify failed checks
+
+```shell
+gh pr checks "$PR" --json name,state,link | jq '.[] | select(.state == "FAILURE")'
+```
+
+### 3. Get failure logs
+
+```shell
+gh run view <run-id> --log-failed | head -200
+```
+
+### 4. Diagnose
+
+| Pattern | Likely cause | Fix |
+| --- | --- | --- |
+| `Type error` | type-check | fix type |
+| `Test failed` | regression | fix code or test |
+| `ECONNREFUSED` | service not up in CI | check CI service step |
+| `Module not found` | bad import / missing ext | fix import path |
+| `Lint error` | style | `eval "$(tkt cfg build.lint)" -- --fix` (if supported) |
+| branch behind | stale | `git rebase origin/$(tkt cfg vcs.default_branch)` |
+
+### 5. Apply the minimal fix
+
+Fix only the CI failure. Do not refactor unrelated code.
+
+### 6. Rebuild locally (config toolchain)
+
+```shell
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+eval "$(tkt cfg build.typecheck)"
+```
+
+### 7. Push
+
+```shell
+git add -A
+git commit -m "fix(<scope>): resolve CI failure — <brief>"
+git push
+```
+
+### 8. Loop
+
+Repeat from step 1. **Max 3 iterations.** If still failing:
+
+```shell
+gh pr comment "$PR" --body "CI failing after 3 fix attempts. Needs human investigation. Last failure: <summary>"
+tkt comment "$KEY" "CI failing after 3 attempts on PR #$PR — needs human investigation."
+```
+
+### 9. Flaky tests
+
+Non-deterministic failure (passes locally, random timeout): `gh run rerun <run-id> --failed`
+**once**. If it fails again, treat as real.
+
+## Output
+
+- CI status: green / still failing
+- Fixes applied (commits)
+- If stuck: the unresolved failure

--- a/.agents/skills/complete-deliverable/SKILL.md
+++ b/.agents/skills/complete-deliverable/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: complete-deliverable
+description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+---
+
+# Complete Deliverable
+
+For tickets whose `type_class` is `deliverable` — they produce something other
+than merged feature code (config change, ADR/decision doc, design doc, demo/Loom,
+POC, spike notes, runbook). Their lanes are just `todo → in_progress → done`
+(+ `blocked`, `cancelled`). Ticketing via `tkt`.
+
+## When the orchestrator routes here
+
+`automated-sdlc` checks `tkt view "$KEY" --json | jq -r .type_class` after triage.
+`deliverable` → this skill instead of Plan → Implement → PR → Review.
+
+## Input
+
+- Ticket key (already in `in_progress` from `triage-ticket`)
+
+## Steps
+
+### 1. Determine the deliverable
+
+Read `description` + `acceptance`. Classify into: config change, ADR/decision,
+design doc, spike/research, demo/video, POC, runbook, or other — each resolves to
+an artifact URL. If the expected deliverable is ambiguous, comment a clarifying
+question and stop. Don't guess.
+
+### 2. Do the work
+
+Execute it. A config change may still open a tiny PR (CI + one self-review pass,
+**no QA loop**). Docs/spikes produce a published page or a file in the repo.
+
+### 3. Record lane time and transition to Done
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Deliverable shipped — <summary>" --json)
+tkt comment "$KEY" "Deliverable complete: <summary>.
+Link: <url>
+Time in In Progress: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+tkt transition "$KEY" done
+```
+
+## Edge cases
+
+- **Config change needing a PR** (workflow files, shared tsconfig, infra constants,
+  the skill pack itself): open a small PR, CI runs, skip the QA loop, merge after a
+  single self-review. Then comment + `tkt transition "$KEY" done`. Do not route to
+  `qa_ready`. `open-pr` auto-detects the missing review lane (via `type_class`) and
+  leaves the ticket in `in_progress` until this step.
+- **Sub-task under a parent Story**: complete and mark the sub-task `done`. Do not
+  transition the parent.
+- **Spike with no concrete next step**: comment findings + a recommended follow-up
+  ticket, mark `done`. The follow-up is a separate Story.
+- **Blocked deliverable**: `tkt worklog "$KEY" --from-role in_progress` then
+  `tkt transition "$KEY" blocked` with a blocker comment (see `automated-sdlc` →
+  External blocker handling).
+
+## Output
+
+- Deliverable link
+- Time spent
+- Confirmation the Done transition succeeded

--- a/.agents/skills/deploy-preview/SKILL.md
+++ b/.agents/skills/deploy-preview/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: deploy-preview
+description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+---
+
+# Deploy Preview
+
+Confirm an ephemeral preview environment for a PR, extract the service URL, and
+link it back to the ticket. Git host via `gh`; ticketing via `tkt`. The
+URL-extraction step is **project-specific** (depends on your hosting) — the rest
+is portable.
+
+## Input
+
+- PR number (`$PR`), ticket key (`$KEY`)
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+PREVIEW_WF=$(tkt cfg deploy.preview_workflow 2>/dev/null || echo "")
+```
+
+## Steps
+
+### 1. Verify the preview deployment triggered
+
+```shell
+gh pr checks "$PR" --repo "$REPO" | grep -i preview || true
+# If a dedicated workflow exists and didn't auto-run:
+[ -n "$PREVIEW_WF" ] && gh workflow run "$PREVIEW_WF" --repo "$REPO" -f pr_number="$PR"
+```
+
+### 2. Wait for deployment
+
+```shell
+[ -n "$PREVIEW_WF" ] && gh run list --workflow="$PREVIEW_WF" --repo "$REPO" \
+  --branch="$(git branch --show-current)" --limit=1 --json status,databaseId
+```
+
+### 3. Extract the preview URL — PROJECT-SPECIFIC
+
+This depends on where previews live. Replace with your project's method. Examples:
+
+```shell
+# AWS CloudFormation/CDK stack output:
+# aws cloudformation describe-stacks --stack-name <stack-pr-$PR> \
+#   --query "Stacks[0].Outputs[?OutputKey=='ServiceUrl'].OutputValue" --output text --region <region>
+
+# Or: a URL the preview workflow prints / a deterministic pattern:
+# PREVIEW_URL="https://pr-$PR.preview.example.com"
+```
+
+### 4. Verify health (project-specific)
+
+```shell
+curl -sf "<preview-url>/health" || echo "preview health check failed"
+```
+
+### 5. Post the URL to the ticket
+
+```shell
+tkt comment "$KEY" "Preview environment: <preview-url> (PR #$PR). Health: passing."
+```
+
+### 6. Post the URL to the PR
+
+Always pass `$PR` explicitly (don't let `gh` infer from the current branch):
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "## Preview Environment
+🔗 <preview-url>
+✅ Health: passing
+Destroyed when this PR closes/merges."
+```
+
+### 7. Do NOT transition the ticket
+
+`deploy-preview` posts the URL only. Standalone → transitioning is the caller's
+choice. From `automated-sdlc` → Phase 9 owns the `qa_ready` transition after the
+URL is confirmed; transitioning here would jump the gate.
+
+## Output
+
+- Preview URL, health status, ticket + PR updated

--- a/.agents/skills/deploy-ready/SKILL.md
+++ b/.agents/skills/deploy-ready/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: deploy-ready
+description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
+disable-model-invocation: true
+---
+
+# Deploy Ready
+
+Resumes the SDLC once a human moves a ticket through `qa_ready → qa → deploy_ready`.
+Ticketing via `tkt`; Git host via `gh`. Repo + workflow names from
+`.sdlc/config.toml`.
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DEFAULT_BRANCH=$(tkt cfg vcs.default_branch)
+STAGING_WF=$(tkt cfg deploy.staging_workflow)
+PROD_WF=$(tkt cfg deploy.production_workflow)
+```
+
+> ⚠️ **Deploy-contract note (project-specific):** whether a green workflow run means
+> "code is live" depends on your pipeline. If your deploy workflow only builds/auths
+> (stub), do **not** auto-transition tickets to `done` — leave them in `deploy_ready`
+> for a human to confirm prod traffic. Set this expectation per project.
+
+## Steps
+
+### 1. Identify deploy_ready tickets
+
+```shell
+tkt list --query deploy_ready --json   # define [queries].deploy_ready in config
+```
+
+If multiple, take highest-priority + oldest. One at a time.
+
+### 2. Annotate QA-lane times (retroactive, per lane)
+
+For each already-exited QA lane, record entry→exit with `tkt lane-time` (which,
+unlike `tkt worklog`, measures a closed interval rather than entry→now):
+
+```shell
+for ROLE in qa_ready qa deploy_ready; do
+  tkt lane-time "$KEY" --role "$ROLE" --json 2>/dev/null || true
+done
+```
+
+Then a summary comment (worklogs are canonical; comment is for skimmers):
+
+```shell
+tkt comment "$KEY" "QA lanes recorded (qa_ready / qa / deploy_ready). Proceeding to merge + staging."
+```
+
+### 3. Find the PR
+
+```shell
+gh pr list --repo "$REPO" --search "$KEY in:title,body" --state open \
+  --json number,headRefName,mergeable,reviewDecision
+```
+
+Abort with a comment if no PR or not approved.
+
+### 4. Merge
+
+`--auto` returns when *enqueued*, not landed. Poll for `MERGED` before reading the
+merge SHA:
+
+```shell
+gh pr merge "$PR" --repo "$REPO" --$(tkt cfg vcs.merge) --auto
+for _ in $(seq 1 60); do
+  STATE=$(gh pr view "$PR" --repo "$REPO" --json state --jq .state)
+  [ "$STATE" = "MERGED" ] && break; sleep 10
+done
+[ "$STATE" != "MERGED" ] && { echo "PR did not merge within 10 min"; exit 1; }
+```
+
+### 5. Watch the staging workflow (match by merge commit)
+
+Don't take the latest run — match the merge `headSha`:
+
+```shell
+MERGE_SHA=$(gh pr view "$PR" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow="$STAGING_WF" --repo "$REPO" --branch="$DEFAULT_BRANCH" \
+    --limit=10 --json databaseId,headSha \
+    | jq -r --arg sha "$MERGE_SHA" '.[] | select(.headSha==$sha) | .databaseId' | head -1)
+  [ -n "$RUN_ID" ] && break; sleep 10
+done
+[ -z "$RUN_ID" ] && { echo "no staging run for $MERGE_SHA"; exit 1; }
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status
+```
+
+On failure: read logs, fix forward if small, else escalate. Annotate the ticket.
+
+### 6. Hand off to QE (if applicable) + comment
+
+```shell
+tkt comment "$KEY" "Staging workflow succeeded for $MERGE_SHA. Handing off to QE for smoke/regression (out-of-band)."
+```
+
+### 7. Present the production deploy gate
+
+Production deploy is **manual**:
+
+```shell
+echo "Staging done. Run manually: gh workflow run $PROD_WF --repo $REPO --ref $DEFAULT_BRANCH [--field version=<tag>]"
+tkt comment "$KEY" "Staging succeeded for $MERGE_SHA. Production deploy ready — manual human trigger required."
+```
+
+### 8. Monitor production deploy (once triggered)
+
+```shell
+gh run watch <prod-run-id> --repo "$REPO" --exit-status
+```
+
+### 9. Identify shipped tickets — transition per the deploy contract
+
+```shell
+git fetch origin "$DEFAULT_BRANCH" --tags
+SHIPPED=$(git log <prev-prod-tag>..origin/"$DEFAULT_BRANCH" --format='%s %b' \
+  | grep -oE '[A-Z]+-[0-9]+' | sort -u)
+```
+
+If your prod workflow truly deploys → transition each to `done`:
+
+```shell
+# for K in $SHIPPED; do tkt transition "$K" done; done
+```
+
+If it's a build/auth stub → comment and leave in `deploy_ready` for human Done:
+
+```shell
+for K in $SHIPPED; do
+  tkt comment "$K" "Production workflow completed. Verify prod traffic, then transition to Done."
+done
+```
+
+### 10. Post-deploy notes (only if notable)
+
+Comment only on friction (CD retry, staging fix, runner outage, time ≫ median):
+
+```shell
+tkt comment "$KEY" "Deploy notes: <what slowed it down> | extra time: <Xh Ym>"
+```
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction

--- a/.agents/skills/hotfix-revert/SKILL.md
+++ b/.agents/skills/hotfix-revert/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: hotfix-revert
+description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
+disable-model-invocation: true
+---
+
+# Hotfix Revert
+
+Fast lane for production issues. Reverts a problematic change, opens a hotfix
+ticket at highest priority, runs an accelerated pipeline. Ticketing via `tkt`
+(incl. `tkt create` / `tkt link`); Git host via `gh`.
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DEFAULT_BRANCH=$(tkt cfg vcs.default_branch)
+STAGING_WF=$(tkt cfg deploy.staging_workflow)
+PROD_WF=$(tkt cfg deploy.production_workflow)
+```
+
+## When to use
+
+- A prod deploy caused a regression and the bad commit/PR is known
+- A merged PR must be backed out before the next planned deploy
+
+## Skips vs. standard SDLC
+
+Ticket selection (created here), plan/self-review loops (one pass), QA gate
+(skipped), multi-cycle review (one signoff), QE staging (out-of-band).
+
+## Steps
+
+### 1. Identify the change to revert
+
+Required input: a **merged PR number**. (Commit SHA / ticket key → resolve to a PR
+first with `gh pr list --repo "$REPO" --search "<x>"`.)
+
+```shell
+TARGET_SHA=$(gh pr view <n> --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+TARGET_TICKET=$(gh pr view <n> --repo "$REPO" --json body --jq '.body' | grep -oE '[A-Z]+-[0-9]+' | head -1)
+```
+
+### 2. Create the hotfix ticket
+
+```shell
+HOTFIX_KEY=$(tkt create --type Bug \
+  --summary "HOTFIX: revert <original-summary> (reverts $TARGET_TICKET)" \
+  --priority Highest --assignee "$(tkt whoami)" \
+  --body "Hotfix for $TARGET_TICKET. Reverting $TARGET_SHA. Fast-track: single signoff, skip QA.")
+
+# Link hotfix → original. "Fixes" is the outward description (HOTFIX Fixes TARGET).
+tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
+tkt transition "$HOTFIX_KEY" in_progress
+```
+
+### 3. Create the revert branch
+
+For squash-merged history use `git revert <sha>` (no `-m`; `-m 1` is only for true
+two-parent merge commits):
+
+```shell
+SLUG="revert-${TARGET_SHA:0:8}"
+git fetch origin
+git checkout -b "$(tkt cfg vcs.hotfix_fmt --ticket "$HOTFIX_KEY" --slug "$SLUG")" "origin/$DEFAULT_BRANCH"
+git revert --no-edit "$TARGET_SHA"
+```
+
+Conflicts → resolve minimally, no unrelated changes.
+
+### 4. Single self-review pass
+
+Invoke `self-review` **once** (no loop). The revert is mechanical.
+
+### 5. Open the hotfix PR
+
+```shell
+git push -u origin HEAD
+HOTFIX_URL=$(tkt view "$HOTFIX_KEY" --json | jq -r .url)
+gh pr create --repo "$REPO" --title "hotfix($HOTFIX_KEY): revert $TARGET_TICKET" --label hotfix \
+  --body "## Hotfix
+Reverts $TARGET_SHA (from $TARGET_TICKET). Ticket: $HOTFIX_URL
+Production incident — bypassing standard QA per hotfix policy. Single signoff."
+tkt transition "$HOTFIX_KEY" review
+```
+
+### 6. Request human signoff (skip the bot loop)
+
+```shell
+gh pr edit <pr> --repo "$REPO" --add-reviewer <oncall-handle>
+```
+
+Wait for **one** approval. Don't loop on feedback — if significant changes are
+requested, abort hotfix and escalate.
+
+### 7. Monitor CI (required checks only)
+
+```shell
+gh pr checks <pr> --repo "$REPO" --watch --required
+```
+
+Required check fails → fix forward minimally or abort.
+
+### 8. Merge
+
+```shell
+gh pr merge <pr> --repo "$REPO" --$(tkt cfg vcs.merge) --auto
+for _ in $(seq 1 60); do
+  STATE=$(gh pr view <pr> --repo "$REPO" --json state --jq .state)
+  [ "$STATE" = "MERGED" ] && break; sleep 10
+done
+[ "$STATE" != "MERGED" ] && { echo "hotfix PR did not merge within 10 min"; exit 1; }
+```
+
+### 9. Watch staging (match merge commit)
+
+```shell
+MERGE_SHA=$(gh pr view <pr> --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow="$STAGING_WF" --repo "$REPO" --branch="$DEFAULT_BRANCH" \
+    --limit=10 --json databaseId,headSha \
+    | jq -r --arg sha "$MERGE_SHA" '.[] | select(.headSha==$sha) | .databaseId' | head -1)
+  [ -n "$RUN_ID" ] && break; sleep 10
+done
+[ -z "$RUN_ID" ] && { echo "no staging run for $MERGE_SHA"; exit 1; }
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status
+```
+
+Staging fails → comment on the ticket, escalate, do not proceed to prod.
+
+### 10. Production deploy (single signoff)
+
+```shell
+echo "Staging green. Run: gh workflow run $PROD_WF --repo $REPO --ref $DEFAULT_BRANCH --field version=hotfix-$HOTFIX_KEY"
+# After the human triggers it:
+gh run watch <prod-run-id> --repo "$REPO" --exit-status
+```
+
+### 11. Comment on both tickets — transition per deploy contract
+
+```shell
+WL=$(tkt worklog "$HOTFIX_KEY" --from-role in_progress --note "Hotfix run complete — awaiting verification" --json)
+tkt comment "$HOTFIX_KEY" "Production workflow completed. Verify the revert serves prod traffic, then transition to Done. \
+Agent lane time: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+tkt comment "$TARGET_TICKET" "Reverted by $HOTFIX_KEY due to a production regression. Redo the work with the regression addressed before re-attempting."
+# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done
+```
+
+## Output
+
+- Hotfix ticket key, PR URL, prod deploy URL, total elapsed time

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: open-pr
+description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a pull request, and move the ticket
+to its `review` lane. Ticketing via `tkt`; Git host via `gh`. All repo-specific
+values (repo, branch format, reviewers, commit conventions, build commands) come
+from `.sdlc/config.toml`.
+
+## Input
+
+- Feature branch with changes
+- Ticket key (`$KEY`)
+- Implementation summary
+
+## Steps
+
+### 1. Stage and commit
+
+```shell
+git add -A
+git commit -m "<type>(<scope>): <description>"   # Conventional Commits
+```
+
+Scope = primary affected package. Imperative, lowercase, no period, < 72 chars.
+Multiple logical changes → multiple commits.
+
+### 2. Rebase on the default branch
+
+```shell
+git fetch origin
+git rebase origin/main    # or your default branch
+```
+
+Resolve conflicts, then `git rebase --continue`.
+
+### 3. Push
+
+```shell
+git push -u origin HEAD
+```
+
+### 4. Create the PR
+
+Pull repo + reviewer config from `tkt`:
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+gh pr create --repo "$REPO" \
+  --title "<type>(<scope>): <description>" \
+  --body "## Summary
+
+<one paragraph>
+
+## Ticket
+
+$(tkt view "$KEY" --json | jq -r .url)
+
+## Changes
+- <bullets>
+
+## Testing
+- <how tested>
+
+## Checklist
+- [x] Tests added/updated
+- [x] Lint/typecheck pass"
+```
+
+### 5. Request reviewers
+
+```shell
+PR=<pr-number>
+REPO=$(tkt cfg vcs.repo)
+for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
+  gh api -X POST "repos/$REPO/pulls/$PR/requested_reviewers" -f "reviewers[]=$R" 2>/dev/null \
+    || gh pr edit "$PR" --repo "$REPO" --add-reviewer "$R" 2>/dev/null \
+    || echo "Note: reviewer '$R' not addable — skipping"
+done
+```
+
+### 6. Transition the ticket (only if it has a review lane)
+
+`full_sdlc` tickets (Story/Bug) go to the `review` lane immediately on PR open.
+`deliverable` tickets (Task/Spike/…) have no review lane — leave them in
+`in_progress`; `complete-deliverable` handles their final transition. Branch on
+`type_class` (no need to enumerate live transitions):
+
+```shell
+CLASS=$(tkt view "$KEY" --json | jq -r .type_class)
+PR_URL=$(gh pr view "$PR" --repo "$(tkt cfg vcs.repo)" --json url --jq .url)
+
+if [ "$CLASS" = "full_sdlc" ]; then
+  # Annotate time in in_progress, then move to review.
+  WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL" --json)
+  tkt transition "$KEY" review
+  tkt comment "$KEY" "PR opened: $PR_URL. Review requested. Time in In Progress: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+else
+  tkt comment "$KEY" "PR opened: $PR_URL. Review requested. (Deliverable type — staying in In Progress until merge + Done.)"
+fi
+```
+
+`tkt worklog` is a no-op (returns an empty `worklog_id`) when the project's
+`[timetracking].provider = "none"`, so this works unchanged on backends with no
+time tracking — the comment just shows `(no time tracking)`.
+
+## Output
+
+- PR URL + number
+- Whether reviewers were added or skipped

--- a/.agents/skills/plan-ticket/SKILL.md
+++ b/.agents/skills/plan-ticket/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: plan-ticket
+description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens
+BEFORE any code changes. Ticketing access via `tkt`.
+
+## Input
+
+From `triage-ticket`: ticket key, summary, acceptance criteria, affected packages.
+Re-read anytime with `tkt view "$KEY" --json`.
+
+## Steps
+
+### 1. Read existing code
+
+For each affected package, read the relevant entry points (route handlers, types,
+schemas, tests, API specs). Keep this mapping in the project's own conventions
+doc — the skill is repo-agnostic.
+
+### 2. Identify change scope
+
+Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
+or shared-lib change. Note the typical files touched for each.
+
+### 3. Produce the plan
+
+```markdown
+## Implementation Plan — <KEY>
+
+### Summary
+<one sentence>
+
+### Changes
+1. `<path>` — <what to add/change>
+2. ...
+
+### Test Strategy
+- New tests: <describe>
+- Modified tests: <describe>
+- Regression: run the suite for affected packages
+
+### Risks
+- <anything that could go wrong / external schema or API deps>
+
+### Out of Scope
+- <things this ticket does NOT cover>
+
+### Estimated Size
+- ~<N> files, ~<N> lines
+- If >400 lines: recommend splitting into <subtasks>
+```
+
+Build/test commands come from config — don't hardcode the toolchain:
+
+```shell
+tkt cfg build.build --pkg "<pkg>"     # e.g. pnpm turbo build --filter=<pkg>
+tkt cfg build.test  --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+### 4. Validate plan against acceptance criteria
+
+For each criterion in the ticket's `acceptance`, confirm the plan covers it.
+Note any gap.
+
+### 5. Check if the ticket needs splitting
+
+If estimated size > 400 lines:
+
+```shell
+tkt comment "$KEY" "Scope is large (~N lines). Recommend splitting into: 1) <sub>, 2) <sub>"
+```
+
+Pause and ask for confirmation before proceeding with a large ticket.
+
+## Output
+
+The implementation plan as structured markdown, ready to drive implementation.

--- a/.agents/skills/respond-to-review/SKILL.md
+++ b/.agents/skills/respond-to-review/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: respond-to-review
+description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+---
+
+# Respond to Review
+
+Read PR review comments (bot + human), address each, push fixes, loop until
+approved. Git host via `gh`; all ticketing via `tkt`. Repo/reviewers from
+`.sdlc/config.toml`.
+
+## Input
+
+- PR number (`$PR`)
+- Ticket key (`$KEY`)
+
+```shell
+REPO=$(tkt cfg vcs.repo); OWNER=${REPO%/*}; NAME=${REPO#*/}
+```
+
+## Ticket state during this skill
+
+A "changes requested" review puts the ticket in the `revise` lane. While
+addressing feedback, move it back to `in_progress`; after pushing fixes and
+re-requesting review, move to `review`. Both are agent-driven → annotate lane time
+with `tkt worklog`:
+
+```shell
+# Exiting revise → in_progress:
+WL=$(tkt worklog "$KEY" --from-role revise --note "Addressing review feedback" --json)
+tkt transition "$KEY" in_progress
+tkt comment "$KEY" "Addressing review feedback. Time in Revise: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+(Skip the revise annotation if the ticket wasn't in `revise` — e.g. first review
+round straight from `review`.)
+
+## Steps
+
+### 1. Fetch review comments (bot + humans)
+
+```shell
+gh pr view "$PR" --repo "$REPO" --json reviews,reviewRequests,comments,reviewDecision
+
+# Inline comments — always paginate.
+gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100" \
+  --jq '.[] | {id, path, line, body, user: .user.login, in_reply_to_id}'
+```
+
+Identify automated-reviewer comments by `user.login` (e.g. `*copilot*[bot]`, or
+whatever your `vcs.reviewers` lists). Track unresolved ones separately.
+
+Resolved-thread state (paginate via `pageInfo.hasNextPage`):
+
+```shell
+CURSOR=null
+while : ; do
+  RESP=$(gh api graphql -f query='
+    query($owner:String!, $repo:String!, $pr:Int!, $after:String) {
+      repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
+        reviewThreads(first:100, after:$after) {
+          pageInfo { hasNextPage endCursor }
+          nodes { id isResolved comments(first:1){ nodes { author{login} body } } }
+        } } } }' \
+    -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CURSOR")
+  echo "$RESP" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
+  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<"$RESP")" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<"$RESP")
+done
+```
+
+### 2. Categorize each comment
+
+Change request → make the change. Question → reply. Suggestion → apply if valid,
+else explain. Nit → apply. Blocker → must fix. Out of scope → acknowledge, create
+a follow-up with `tkt create` if warranted.
+
+### 3. Address change requests
+
+For each: make the change, verify it builds/tests (`tkt cfg build.*`), reply on the
+thread:
+
+```shell
+gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
+  -f body="Fixed in <sha>. <brief explanation>"
+```
+
+### 4. Reply to questions
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "Re: <question> — <answer>"
+```
+
+### 5. Commit and push
+
+```shell
+git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+```
+
+### 6. Re-request review + move back to review lane
+
+```shell
+for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
+  gh api -X POST "repos/$OWNER/$NAME/pulls/$PR/requested_reviewers" -f "reviewers[]=$R" 2>/dev/null || true
+done
+
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — fixes pushed, re-review requested" --json)
+tkt transition "$KEY" review
+tkt comment "$KEY" "Pushed fixes, re-requested review. Time in In Progress (revise cycle): \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+### 7. Loop until clean
+
+Re-fetch after each push. Exit only when **all** hold:
+
+- No automated-reviewer comments on unresolved threads
+- `reviewDecision == APPROVED` (a pending/`REVIEW_REQUIRED` state is NOT enough)
+- No new comments in the last poll
+
+Cap at **5** cycles. If a bot repeats the same nit after 2 attempts, reply with a
+one-line "won't fix" justification and resolve the thread.
+
+### 8. If stuck after 5 cycles
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "5 review cycles complete. Remaining items need human judgment — requesting sync review."
+WL=$(tkt worklog "$KEY" --from-role review --note "Review cycling unresolved after 5 attempts" --json)
+tkt comment "$KEY" "Review cycling unresolved after 5 attempts — needs human sync. \
+Time in review so far: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+(`$KEY` is the ticket; `$PR` is the PR number — unrelated. Always pass `$PR`
+explicitly to `gh pr comment`.)
+
+### 9. On loop exit, annotate review lane time
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role review --note "Review loop complete. Cycles: <N>" --json)
+tkt comment "$KEY" "Review loop complete. Cycles: <N>. Time in review (this round): \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items

--- a/.agents/skills/resume-from-revise/SKILL.md
+++ b/.agents/skills/resume-from-revise/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: resume-from-revise
+description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+---
+
+# Resume From Revise
+
+Picks up tickets that landed in `revise` after a failed QA round and a human dev
+fix. Re-enters the automation loop. Ticketing via `tkt`; build via `tkt cfg`.
+
+Invoke as `/resume-from-revise <KEY>` or `/resume-from-revise` (infer from branch).
+
+## Steps
+
+### 1. Resolve the ticket
+
+If no arg, infer from branch (`feature/<key-lower>-...` → `<KEY>`).
+
+```shell
+tkt view "$KEY" --json | jq -r .status_role   # must be "revise"
+```
+
+If not `revise`, stop and ask.
+
+### 2. Annotate revise time
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role revise --note "Resuming from revise — human fix complete" --json)
+tkt comment "$KEY" "Resuming from revise — fix complete. Time in Revise: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+### 3. Transition back to in_progress
+
+```shell
+tkt transition "$KEY" in_progress
+```
+
+The agent owns the work again while it pushes/re-reviews.
+
+### 4. Verify local state (config toolchain)
+
+```shell
+git status
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+```
+
+If tests fail: stop and surface. Do not push broken code.
+
+### 5. Push
+
+```shell
+git push
+```
+
+### 6. Re-run automation subset
+
+In sequence: `ci-fix` → `respond-to-review` → `deploy-preview`. Each annotates its
+own added time via `tkt worklog` on exit.
+
+### 7. Promote back to qa_ready
+
+Verify approval first (same canonical criterion as `respond-to-review`):
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DECISION=$(gh pr view "$PR" --repo "$REPO" --json reviewDecision --jq .reviewDecision)
+[ "$DECISION" != "APPROVED" ] && { echo "PR not approved (decision=${DECISION:-pending})"; exit 1; }
+
+# Annotate the in_progress portion of this revise cycle.
+WL1=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — in_progress portion" --json)
+
+# respond-to-review may already have moved it to review; only transition if not.
+CUR=$(tkt view "$KEY" --json | jq -r .status_role)
+[ "$CUR" != "review" ] && tkt transition "$KEY" review
+WL2=$(tkt worklog "$KEY" --from-role review --note "Revise cycle — re-review portion" --json)
+
+tkt transition "$KEY" qa_ready
+tkt comment "$KEY" "Re-review complete and approved. Back in qa_ready — preview updated: <url>. \
+In Progress (revise): $(echo "$WL1" | jq -r .human) (worklog $(echo "$WL1" | jq -r .worklog_id)) | \
+review (re-review): $(echo "$WL2" | jq -r .human) (worklog $(echo "$WL2" | jq -r .worklog_id))."
+```
+
+QA picks it back up.
+
+## Output
+
+- PR URL, preview URL
+- Total time added by the revise cycle

--- a/.agents/skills/select-ticket/SKILL.md
+++ b/.agents/skills/select-ticket/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: select-ticket
+description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
+allowed-tools: [Bash, Read]
+---
+
+# Select Ticket
+
+Entry point for the automated SDLC. Finds the right ticket to work next.
+**All ticketing access goes through `tkt`** (the provider-agnostic CLI) — this
+skill never calls Jira/GitHub/Linear directly. Backend + board shape come from
+`.sdlc/config.toml`.
+
+**Auto-selects at Tier 1 or Tier 2** (top candidate after the query's own sort;
+first hit wins, never blocks on ties). Tiers 3–5 only ever return a ranked
+recommendation list and wait for a human pick — the agent never auto-selects
+unassigned work.
+
+## Prerequisites
+
+- `tkt doctor` passes (auth + board model reachable).
+- `tkt` on PATH (or invoke via its path, e.g. `~/Development/tkt/tkt`).
+
+## Selection tiers (stop at first non-empty)
+
+Tiers map to named queries in `.sdlc/config.toml` `[queries]` (`tier1`…`tier5`).
+The default mapping mirrors the original flow:
+
+```
+Tier 1: To Do + Highest priority + assigned to me   → auto-select
+Tier 2: To Do + any priority     + assigned to me   → auto-select (query sorts by priority)
+Tier 3: To Do + Highest priority + unassigned       → recommend (human picks)
+Tier 4: To Do + any priority     + unassigned       → recommend (human picks)
+Tier 5: Backlog                                       → recommend for promotion
+```
+
+A project that doesn't define a given tier query simply skips it (see Steps).
+
+## Steps
+
+### 1. Identify current user
+
+```shell
+tkt whoami
+```
+
+`currentUser()` inside the tier queries is resolved by the provider, so no email
+variable is needed.
+
+### 2. Run tiers in order until one returns selectable tickets
+
+```shell
+TKT=tkt   # or the repo path, e.g. ~/Development/tkt/tkt
+
+# is_blocked KEY -> prints "1" if the ticket has unresolved blockers.
+is_blocked() { [ "$("$TKT" blockers "$1" --json | jq 'length')" -gt 0 ] && echo 1; }
+
+for N in 1 2 3 4 5; do
+  # A defined-but-empty tier exits 0 with []; an undefined tier exits non-zero.
+  OUT=$("$TKT" list --tier "$N" --json 2>/dev/null) || continue
+  [ "$(echo "$OUT" | jq 'length')" -gt 0 ] || continue
+
+  # Filter blockers per-candidate via `tkt blockers` (authoritative on every
+  # backend — some list paths don't carry link data, e.g. Jira via acli).
+  SELECTABLE='[]'
+  for K in $(echo "$OUT" | jq -r '.[].key'); do
+    [ -n "$(is_blocked "$K")" ] && continue
+    SELECTABLE=$(echo "$OUT" | jq --arg k "$K" --argjson acc "$SELECTABLE" \
+      '$acc + [.[] | select(.key == $k)]')
+  done
+  [ "$(echo "$SELECTABLE" | jq 'length')" -gt 0 ] || continue
+
+  echo "TIER=$N"
+  echo "$SELECTABLE" > /tmp/tkt_candidates.json
+  break
+done
+```
+
+`tkt blockers` returns only **unresolved** blockers (a blocker that's Done is
+dropped), so a non-empty result means genuinely blocked.
+
+### 3. Auto-select (Tier 1 / Tier 2) or recommend (Tier 3+)
+
+- **Tier 1 or 2** → pick the first selectable candidate (assigned work is implicit
+  consent), emit `SELECTED: <KEY>`, hand off to `triage-ticket`.
+
+  ```shell
+  if [ "$TIER" = "1" ] || [ "$TIER" = "2" ]; then
+    KEY=$(jq -r '.[0].key' /tmp/tkt_candidates.json)
+    echo "SELECTED: $KEY"
+  fi
+  ```
+
+- **Tier 3 / 4 / 5** → print up to 5 ranked recommendations and stop. Do not
+  transition. Include **Type** (and `type_class`) so the reader knows whether the
+  ticket runs the full SDLC (`full_sdlc`) or the deliverable short-circuit.
+
+### Recommendation output format
+
+| Key | Type | type_class | Priority | Summary | Effort (S/M/L) | Est. tokens | Est. wall time | Blockers? | Why this one |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+Estimate guidance:
+
+- **Effort**: S ≤ 100 LOC, M 100–400, L > 400 (infer from acceptance criteria).
+- **Tokens**: S ≈ 50k, M ≈ 150k, L ≈ 400k.
+- **Wall time**: S ≈ 30 min, M ≈ 2 h, L ≈ half-day (excl. human review).
+- **Why this one**: one line citing priority, dependency readiness, or alignment.
+
+For Tier 5, label them "promotion candidates — in backlog, not To Do; promote one
+to To Do before work starts."
+
+## Output
+
+- `SELECTED: <KEY>` (auto path) → proceed to `triage-ticket`
+- OR a recommendation table with a clear "waiting for pick" message

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: self-review
+description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass,
+BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
+`.sdlc/config.toml` via `tkt cfg`; this skill has no ticketing coupling.
+
+## Steps
+
+### 1. Generate the diff
+
+```shell
+git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
+```
+
+### 2. Review as adversary
+
+Hostile-reviewer mindset. Check every changed file for:
+
+| Category | Look for |
+| --- | --- |
+| **Security** | injection, auth bypass, secrets in code, unvalidated input |
+| **Types** | unjustified loose types, missing null checks, unguarded casts |
+| **Errors** | unhandled rejections, missing error responses, wrong status codes |
+| **Tests** | new code without tests; tests that assert nothing meaningful |
+| **Style** | project lint conventions; debug logging left in |
+| **Breaking** | changed shared exports / existing API contracts |
+| **Performance** | N+1 queries, missing indexes, unbounded loops, large payloads |
+| **Edge cases** | empty arrays, nulls, concurrency, expired tokens |
+
+Project-specific rules (import conventions, error types, logging) belong in the
+project's own conventions doc — read them and apply.
+
+### 3. List findings
+
+Per issue: file+line, severity (**blocker** / **warning** / **nit**), description,
+suggested fix.
+
+### 4. Fix blockers and warnings
+
+Fix all blocker + warning items. Don't skip.
+
+### 5. Rebuild and re-test (config toolchain)
+
+```shell
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+eval "$(tkt cfg build.typecheck)"
+```
+
+### 6. Loop
+
+Repeat until a pass yields **zero blockers and zero warnings**. Max 3 passes; if
+still finding blockers, stop and flag for human review.
+
+## Output
+
+- Passes completed
+- Issues found/fixed (count by severity)
+- Remaining nits
+- Confidence: high / medium / low

--- a/.agents/skills/triage-ticket/SKILL.md
+++ b/.agents/skills/triage-ticket/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: triage-ticket
+description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
+allowed-tools: [Bash, Read, Edit]
+---
+
+# Triage Ticket
+
+Read a ticket, extract actionable requirements, transition to the `in_progress`
+lane, and start time tracking. All access via `tkt`; backend/board from
+`.sdlc/config.toml`.
+
+## Prerequisites
+
+- `tkt doctor` passes.
+
+## Lanes
+
+Skills speak in **roles**, not literal lane names. The default board roles:
+
+```
+backlog → todo → in_progress → review → qa_ready → qa → deploy_ready → done
+```
+
+Side roles: `revise`, `blocked`, `cancelled`. Resolve a role to the provider's
+actual lane string with `tkt lane <role>` when you need to print it.
+
+## Input
+
+- Ticket key (e.g. from `select-ticket`). If none provided, invoke `select-ticket`
+  first rather than asking.
+
+## Steps
+
+### 1. Read the ticket
+
+```shell
+tkt view "$KEY" --json > /tmp/tkt_ticket.json
+```
+
+Extract from the normalized shape:
+
+- `type` + `type_class` — `full_sdlc` (Story/Bug) vs `deliverable` (Task/Epic/…);
+  drives Phase 1.5 routing in `automated-sdlc`.
+- `summary`, `description`, `acceptance`
+- `labels`, `components`, `priority`
+- `blocked_by` (unresolved entries mean you should not have been routed here)
+
+### 2. Identify affected packages
+
+Map ticket content (summary/description/labels/components) to your repo's
+packages. Keep a project-specific keyword→package table in the project's own docs
+or `CLAUDE.md`; this skill stays generic. Example shape:
+
+| Keyword | Package |
+| --- | --- |
+| auth, JWT, token | `@scope/auth` |
+| cart, hold | `@scope/cart-service` |
+
+### 3. Move to In Progress
+
+```shell
+tkt transition "$KEY" in_progress
+```
+
+### 4. Start time tracking
+
+Entry time is recorded implicitly by the provider's history/changelog; `tkt
+worklog ... --from-role in_progress` later computes elapsed time from this entry.
+Nothing to do here beyond the transition.
+
+### 5. Add a work-start comment
+
+```shell
+tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+```
+
+## Output
+
+Provide to the next skill:
+
+- Ticket key
+- `type` + `type_class` (so the orchestrator routes full SDLC vs deliverable)
+- Summary
+- Acceptance criteria (bullet list)
+- Affected packages
+- Any blockers/unknowns identified

--- a/.agents/workflows/deploy-ready.md
+++ b/.agents/workflows/deploy-ready.md
@@ -1,0 +1,46 @@
+---
+name: deploy-ready
+description: Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt.
+trigger: manual
+---
+
+# Deploy Ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets:
+   ```shell
+   // turbo
+   tkt list --query deploy_ready --json
+   ```
+2. Annotate QA-lane times:
+   ```shell
+   // turbo
+   for ROLE in qa_ready qa deploy_ready; do
+     tkt lane-time "$KEY" --role "$ROLE" --json 2>/dev/null || true
+   done
+   ```
+3. Find the PR:
+   ```shell
+   // turbo
+   gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body" --state open
+   ```
+4. Merge:
+   ```shell
+   // turbo
+   gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto
+   ```
+   Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.agents/workflows/open-pr.md
+++ b/.agents/workflows/open-pr.md
@@ -1,0 +1,42 @@
+---
+name: open-pr
+description: Commit, push, open a PR, request reviewers, and move the ticket to review via tkt.
+trigger: manual
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit:
+   ```shell
+   // turbo
+   git add -A && git commit -m "<type>(<scope>): <description>"
+   ```
+2. Rebase on default branch:
+   ```shell
+   // turbo
+   git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)
+   ```
+3. Push:
+   ```shell
+   // turbo
+   git push -u origin HEAD
+   ```
+4. Create PR:
+   ```shell
+   // turbo
+   REPO=$(tkt cfg vcs.repo)
+   gh pr create --repo "$REPO" --title "..." --body "..."
+   ```
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate with `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.agents/workflows/plan-ticket.md
+++ b/.agents/workflows/plan-ticket.md
@@ -1,0 +1,43 @@
+---
+name: plan-ticket
+description: Analyze a triaged ticket and produce a structured implementation plan via tkt.
+trigger: manual
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   // turbo
+   tkt view "$KEY" --json
+   ```
+2. Read existing code for affected packages.
+3. Classify the change scope.
+4. Produce a markdown plan:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy
+   - Risks
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment and pause for confirmation.
+
+Build/test commands come from config:
+```shell
+// turbo
+tkt cfg build.build --pkg "<pkg>"
+// turbo
+tkt cfg build.test --pkg "<pkg>"
+// turbo
+tkt cfg build.typecheck
+```
+
+## Rules
+
+- Never hardcode the toolchain.
+- All ticketing access goes through `tkt`.

--- a/.agents/workflows/respond-to-review.md
+++ b/.agents/workflows/respond-to-review.md
@@ -1,0 +1,34 @@
+---
+name: respond-to-review
+description: Read PR review comments, address each, push fixes, and loop until approved via tkt.
+trigger: manual
+---
+
+# Respond to Review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision:
+   ```shell
+   // turbo
+   REPO=$(tkt cfg vcs.repo)
+   gh pr view "$PR" --repo "$REPO" --json reviews,reviewRequests,comments,reviewDecision
+   ```
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply.
+3. Make changes and reply on threads.
+4. Commit and push:
+   ```shell
+   // turbo
+   git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+   ```
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.agents/workflows/select-ticket.md
+++ b/.agents/workflows/select-ticket.md
@@ -1,0 +1,37 @@
+---
+name: select-ticket
+description: Discover and select the next ticket to work on via tkt.
+trigger: manual
+---
+
+# Select Ticket
+
+Find the right ticket to work next. All ticketing access goes through `tkt`.
+
+## Steps
+
+1. Verify `tkt doctor` passes and `tkt` is on PATH.
+2. Identify current user:
+   ```shell
+   // turbo
+   tkt whoami
+   ```
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets:
+   ```shell
+   // turbo
+   tkt list --tier N --json
+   ```
+4. Filter out blocked tickets with `tkt blockers KEY --json`.
+5. **Tier 1/2** (assigned): auto-select, emit `SELECTED: <KEY>`, proceed to `triage-ticket`.
+6. **Tier 3/4/5** (unassigned/backlog): print up to 5 ranked recommendations and wait for human pick.
+
+## Recommendation format
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+Estimate guidance: S ≤ 100 LOC / ~50k tokens / ~30 min; M 100–400 LOC / ~150k tokens / ~2 h; L > 400 LOC / ~400k tokens / half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- All ticketing access goes through `tkt`.

--- a/.agents/workflows/self-review.md
+++ b/.agents/workflows/self-review.md
@@ -1,0 +1,42 @@
+---
+name: self-review
+description: Adversarial self-review of changes before PR via tkt config.
+trigger: manual
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff:
+   ```shell
+   // turbo
+   git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
+   ```
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test:
+   ```shell
+   // turbo
+   tkt cfg build.build --pkg "<pkg>"
+   // turbo
+   tkt cfg build.test --pkg "<pkg>"
+   // turbo
+   tkt cfg build.typecheck
+   ```
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.agents/workflows/triage-ticket.md
+++ b/.agents/workflows/triage-ticket.md
@@ -1,0 +1,38 @@
+---
+name: triage-ticket
+description: Read a ticket, move it to in_progress, and start work via tkt.
+trigger: manual
+---
+
+# Triage Ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   // turbo
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   // turbo
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   // turbo
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.augment/commands/deploy-ready.md
+++ b/.augment/commands/deploy-ready.md
@@ -1,0 +1,21 @@
+# /deploy-ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge and poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys.
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.augment/commands/open-pr.md
+++ b/.augment/commands/open-pr.md
@@ -1,0 +1,18 @@
+# /open-pr
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `full_sdlc`: `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.

--- a/.augment/commands/plan-ticket.md
+++ b/.augment/commands/plan-ticket.md
@@ -1,0 +1,19 @@
+# /plan-ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Steps
+
+1. Read the ticket: `tkt view "$KEY" --json`.
+2. Read existing code for affected packages.
+3. Classify the change scope.
+4. Produce a markdown plan: Summary, Changes, Test Strategy, Risks, Out of Scope, Estimated Size.
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment and pause for confirmation.
+
+Build/test commands come from `tkt cfg`.
+
+## Rules
+
+- Never hardcode the toolchain.
+- All ticketing access goes through `tkt`.

--- a/.augment/commands/respond-to-review.md
+++ b/.augment/commands/respond-to-review.md
@@ -1,0 +1,18 @@
+# /respond-to-review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply.
+3. Make changes and reply on threads.
+4. Commit and push.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until approved and no unresolved comments. Max 5 cycles.
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- All ticketing access goes through `tkt`.

--- a/.augment/commands/select-ticket.md
+++ b/.augment/commands/select-ticket.md
@@ -1,0 +1,23 @@
+# /select-ticket
+
+Discover and select the next ticket to work on via `tkt`.
+
+## Steps
+
+1. Verify `tkt doctor` passes and `tkt` is on PATH.
+2. Identify current user: `tkt whoami`.
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets.
+4. Filter out blocked tickets with `tkt blockers KEY --json`.
+5. **Tier 1/2** (assigned): auto-select, emit `SELECTED: <KEY>`, proceed to `triage-ticket`.
+6. **Tier 3/4/5** (unassigned/backlog): print up to 5 ranked recommendations and wait for human pick.
+
+## Recommendation format
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+Estimate guidance: S ≤ 100 LOC / ~50k tokens / ~30 min; M 100–400 LOC / ~150k tokens / ~2 h; L > 400 LOC / ~400k tokens / half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- All ticketing access goes through `tkt`.

--- a/.augment/commands/self-review.md
+++ b/.augment/commands/self-review.md
@@ -1,0 +1,17 @@
+# /self-review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity, description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.augment/commands/triage-ticket.md
+++ b/.augment/commands/triage-ticket.md
@@ -1,0 +1,20 @@
+# /triage-ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket: `tkt view "$KEY" --json`.
+   Extract: key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress: `tkt transition "$KEY" in_progress`.
+4. Add a work-start comment: `tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"`.
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.clinerules/workflows/deploy-ready.md
+++ b/.clinerules/workflows/deploy-ready.md
@@ -1,0 +1,27 @@
+# /deploy-ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.clinerules/workflows/open-pr.md
+++ b/.clinerules/workflows/open-pr.md
@@ -1,0 +1,24 @@
+# /open-pr
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch: `git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)`.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate with `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Output
+
+- PR URL + number
+- Reviewer status
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.clinerules/workflows/plan-ticket.md
+++ b/.clinerules/workflows/plan-ticket.md
@@ -1,0 +1,37 @@
+# /plan-ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
+3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+4. Produce a markdown plan:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy (new / modified / regression)
+   - Risks (including external schema/API deps)
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment on the ticket and pause for confirmation.
+
+Build/test commands come from config:
+```shell
+tkt cfg build.build --pkg "<pkg>"
+tkt cfg build.test --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+## Output
+
+Structured markdown plan, ready to drive implementation.
+
+## Rules
+
+- Never hardcode the toolchain.
+- All ticketing access goes through `tkt`.

--- a/.clinerules/workflows/respond-to-review.md
+++ b/.clinerules/workflows/respond-to-review.md
@@ -1,0 +1,25 @@
+# /respond-to-review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.clinerules/workflows/select-ticket.md
+++ b/.clinerules/workflows/select-ticket.md
@@ -1,0 +1,26 @@
+# /select-ticket
+
+Discover and select the next ticket to work on via `tkt`.
+
+## Steps
+
+1. Verify `tkt doctor` passes and `tkt` is on PATH.
+2. Identify current user:
+   ```shell
+   tkt whoami
+   ```
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets.
+4. Filter out blocked tickets with `tkt blockers KEY --json`.
+5. **Tier 1/2** (assigned): auto-select, emit `SELECTED: <KEY>`, proceed to `triage-ticket`.
+6. **Tier 3/4/5** (unassigned/backlog): print up to 5 ranked recommendations and wait for human pick.
+
+## Recommendation format
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+Estimate guidance: S ≤ 100 LOC / ~50k tokens / ~30 min; M 100–400 LOC / ~150k tokens / ~2 h; L > 400 LOC / ~400k tokens / half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- All ticketing access goes through `tkt`.

--- a/.clinerules/workflows/self-review.md
+++ b/.clinerules/workflows/self-review.md
@@ -1,0 +1,24 @@
+# /self-review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.clinerules/workflows/triage-ticket.md
+++ b/.clinerules/workflows/triage-ticket.md
@@ -1,0 +1,29 @@
+# /triage-ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.continue/prompts/deploy-ready.prompt
+++ b/.continue/prompts/deploy-ready.prompt
@@ -1,0 +1,21 @@
+---
+name: deploy-ready
+description: Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt.
+invokable: true
+---
+
+# Deploy Ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+Production deploy is manual.

--- a/.continue/prompts/open-pr.prompt
+++ b/.continue/prompts/open-pr.prompt
@@ -1,0 +1,19 @@
+---
+name: open-pr
+description: Commit, push, open a PR, request reviewers, and move the ticket to review via tkt.
+invokable: true
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `full_sdlc`: `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+Repo/reviewers from `tkt cfg`. Conventional Commits.

--- a/.continue/prompts/plan-ticket.prompt
+++ b/.continue/prompts/plan-ticket.prompt
@@ -1,0 +1,18 @@
+---
+name: plan-ticket
+description: Analyze a triaged ticket and produce a structured implementation plan via tkt.
+invokable: true
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+1. Read the ticket with `tkt view "$KEY" --json`.
+2. Read existing code for affected packages.
+3. Classify the change scope.
+4. Produce a markdown plan with Summary, Changes, Test Strategy, Risks, Out of Scope, Estimated Size.
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment and pause for confirmation.
+
+Build/test commands come from `tkt cfg`.

--- a/.continue/prompts/respond-to-review.prompt
+++ b/.continue/prompts/respond-to-review.prompt
@@ -1,0 +1,19 @@
+---
+name: respond-to-review
+description: Read PR review comments, address each, push fixes, and loop until approved via tkt.
+invokable: true
+---
+
+# Respond to Review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until approved and no unresolved comments. Max 5 cycles.
+
+Output: review status, comments addressed, outstanding items.

--- a/.continue/prompts/select-ticket.prompt
+++ b/.continue/prompts/select-ticket.prompt
@@ -1,0 +1,19 @@
+---
+name: select-ticket
+description: Discover and select the next ticket to work on via tkt.
+invokable: true
+---
+
+# Select Ticket
+
+Find the right ticket to work next. All ticketing access goes through `tkt`.
+
+1. Verify `tkt doctor` passes.
+2. Identify current user: `tkt whoami`.
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets.
+4. Filter out blocked tickets with `tkt blockers KEY --json`.
+5. Auto-select Tier 1/2 assigned work; recommend Tier 3/4/5 and wait for human pick.
+
+Recommendation columns: Key, Type, type_class, Priority, Summary, Effort (S/M/L), Est. tokens, Est. wall time, Blockers?, Why this one.
+
+Never auto-select unassigned work.

--- a/.continue/prompts/self-review.prompt
+++ b/.continue/prompts/self-review.prompt
@@ -1,0 +1,18 @@
+---
+name: self-review
+description: Adversarial self-review of changes before PR via tkt config.
+invokable: true
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+Output: passes completed, issues by severity, remaining nits, confidence.

--- a/.continue/prompts/triage-ticket.prompt
+++ b/.continue/prompts/triage-ticket.prompt
@@ -1,0 +1,18 @@
+---
+name: triage-ticket
+description: Read a ticket, move it to in_progress, and start work via tkt.
+invokable: true
+---
+
+# Triage Ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+1. `tkt view "$KEY" --json` — extract key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. `tkt transition "$KEY" in_progress`.
+4. `tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"`.
+
+Output: key, type + type_class, summary, acceptance, affected packages, blockers/unknowns.
+
+Never transition a blocked ticket.

--- a/.cursor/commands/deploy-ready.md
+++ b/.cursor/commands/deploy-ready.md
@@ -1,0 +1,42 @@
+# /deploy-ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch the staging workflow, gate manual production deploy, and comment status. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets:
+   ```shell
+   tkt list --query deploy_ready --json
+   ```
+2. Annotate QA-lane times retroactively:
+   ```shell
+   for ROLE in qa_ready qa deploy_ready; do
+     tkt lane-time "$KEY" --role "$ROLE" --json 2>/dev/null || true
+   done
+   ```
+3. Find the PR:
+   ```shell
+   gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body" --state open
+   ```
+4. Merge:
+   ```shell
+   gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto
+   ```
+   Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual; never auto-deploy to prod.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.cursor/commands/open-pr.md
+++ b/.cursor/commands/open-pr.md
@@ -1,0 +1,40 @@
+# /open-pr
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit:
+   ```shell
+   git add -A
+   git commit -m "<type>(<scope>): <description>"
+   ```
+2. Rebase on default branch:
+   ```shell
+   git fetch origin
+   git rebase origin/$(tkt cfg vcs.default_branch)
+   ```
+3. Push:
+   ```shell
+   git push -u origin HEAD
+   ```
+4. Create PR:
+   ```shell
+   REPO=$(tkt cfg vcs.repo)
+   gh pr create --repo "$REPO" --title "..." --body "..."
+   ```
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Transition based on `type_class`:
+   - `full_sdlc`: `tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL"` then `tkt transition "$KEY" review`
+   - `deliverable`: comment and stay in `in_progress`
+
+## Output
+
+- PR URL + number
+- Reviewer status
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.cursor/commands/plan-ticket.md
+++ b/.cursor/commands/plan-ticket.md
@@ -1,0 +1,80 @@
+# /plan-ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Input
+
+- Ticket key (e.g. from `triage-ticket`)
+- Summary, acceptance criteria, affected packages
+
+## Steps
+
+### 1. Read the ticket
+
+```shell
+tkt view "$KEY" --json
+```
+
+Extract: `key`, `type` + `type_class`, `summary`, `acceptance`, affected packages.
+
+### 2. Read existing code
+
+For each affected package, read relevant entry points (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc.
+
+### 3. Identify change scope
+
+Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+
+### 4. Produce the plan
+
+```markdown
+## Implementation Plan — <KEY>
+
+### Summary
+<one sentence>
+
+### Changes
+1. `<path>` — <what to add/change>
+2. ...
+
+### Test Strategy
+- New tests: <describe>
+- Modified tests: <describe>
+- Regression: run the suite for affected packages
+
+### Risks
+- <anything that could go wrong / external schema or API deps>
+
+### Out of Scope
+- <things this ticket does NOT cover>
+
+### Estimated Size
+- ~<N> files, ~<N> lines
+- If >400 lines: recommend splitting into <subtasks>
+```
+
+Build/test commands come from config:
+
+```shell
+tkt cfg build.build --pkg "<pkg>"
+tkt cfg build.test --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+### 5. Validate against acceptance criteria
+
+For each criterion, confirm the plan covers it. Note gaps.
+
+### 6. Check for splitting
+
+If estimated size > 400 lines:
+
+```shell
+tkt comment "$KEY" "Scope is large (~N lines). Recommend splitting into: 1) <sub>, 2) <sub>"
+```
+
+Pause and ask for confirmation before proceeding with a large ticket.
+
+## Output
+
+The implementation plan as structured markdown, ready to drive implementation.

--- a/.cursor/commands/respond-to-review.md
+++ b/.cursor/commands/respond-to-review.md
@@ -1,0 +1,35 @@
+# /respond-to-review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision:
+   ```shell
+   REPO=$(tkt cfg vcs.repo)
+   OWNER=${REPO%/*}
+   NAME=${REPO#*/}
+   gh pr view "$PR" --repo "$REPO" --json reviews,reviewRequests,comments,reviewDecision
+   gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100"
+   ```
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix.
+3. Make changes and reply on threads.
+4. Commit and push:
+   ```shell
+   git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+   ```
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.cursor/commands/select-ticket.md
+++ b/.cursor/commands/select-ticket.md
@@ -1,0 +1,31 @@
+# /select-ticket
+
+Discover and select the next ticket to work on via `tkt`.
+
+## Steps
+
+1. Verify prerequisites:
+   - `tkt doctor` passes
+   - `tkt` on PATH
+2. Identify current user:
+   ```shell
+   tkt whoami
+   ```
+3. Run tiers 1–5 in order until one returns selectable tickets:
+   ```shell
+   tkt list --tier N --json
+   ```
+   Filter out blocked tickets with `tkt blockers KEY --json`.
+4. **Tier 1 or 2** (assigned work):
+   - Emit `SELECTED: <KEY>`
+   - Hand off to `triage-ticket`
+5. **Tier 3–5** (unassigned/backlog):
+   - Print up to 5 ranked candidates
+   - Include: Key, Type, type_class, Priority, Summary, Effort (S/M/L), Est. tokens, Est. wall time, Blockers?, Why this one
+   - Wait for human pick
+
+## Rules
+
+- Never auto-select unassigned work
+- All ticketing access goes through `tkt`
+- `type_class` (`full_sdlc` or `deliverable`) determines downstream routing

--- a/.cursor/commands/self-review.md
+++ b/.cursor/commands/self-review.md
@@ -1,0 +1,35 @@
+# /self-review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff:
+   ```shell
+   git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
+   ```
+2. Review as adversary across:
+   - Security: injection, auth bypass, secrets, unvalidated input
+   - Types: loose types, missing null checks
+   - Errors: unhandled rejections, wrong status codes
+   - Tests: new code without tests, meaningless assertions
+   - Style: lint conventions, debug logging
+   - Breaking: changed shared exports / API contracts
+   - Performance: N+1 queries, unbounded loops
+   - Edge cases: empty arrays, nulls, concurrency
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.cursor/commands/triage-ticket.md
+++ b/.cursor/commands/triage-ticket.md
@@ -1,0 +1,29 @@
+# /triage-ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, description, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.cursor/skills/deploy-ready/SKILL.md
+++ b/.cursor/skills/deploy-ready/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: deploy-ready
+description: 'Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Deploy Ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch the
+staging workflow, gate manual production deploy. Ticketing via `tkt`; Git host via
+`gh`. Repo/workflow names from `.sdlc/config.toml` via `tkt cfg`.
+
+## Steps
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.cursor/skills/open-pr/SKILL.md
+++ b/.cursor/skills/open-pr/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: open-pr
+description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane. Provider-agnostic via tkt; VCS via gh. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a pull request, and move the ticket
+to its `review` lane. Ticketing via `tkt`; Git host via `gh`. Repo-specific values
+from `.sdlc/config.toml` via `tkt cfg`.
+
+## Steps
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch: `git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)`.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate with `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Output
+
+- PR URL + number
+- Reviewer status
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.cursor/skills/plan-ticket/SKILL.md
+++ b/.cursor/skills/plan-ticket/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: plan-ticket
+description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens
+BEFORE any code changes. Ticketing access via `tkt`.
+
+## Steps
+
+1. Read the ticket: `tkt view "$KEY" --json`.
+2. Read existing code for affected packages.
+3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+4. Produce a markdown plan:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy
+   - Risks
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment and pause for confirmation.
+
+Build/test commands come from config:
+```shell
+tkt cfg build.build --pkg "<pkg>"
+tkt cfg build.test --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+## Output
+
+Structured markdown plan, ready to drive implementation.

--- a/.cursor/skills/respond-to-review/SKILL.md
+++ b/.cursor/skills/respond-to-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: respond-to-review
+description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing via tkt. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Respond to Review
+
+Read PR review comments, address each, push fixes, loop until approved. Git host
+via `gh`; all ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.cursor/skills/select-ticket/SKILL.md
+++ b/.cursor/skills/select-ticket/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: select-ticket
+description: 'Discover and select the next ticket to work on via tkt. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Select Ticket
+
+Find the right ticket to work next. All ticketing access goes through `tkt`.
+
+## Prerequisites
+
+- `tkt doctor` passes.
+- `tkt` on PATH.
+
+## Steps
+
+1. Identify current user: `tkt whoami`.
+2. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets:
+   ```shell
+   tkt list --tier N --json
+   ```
+3. Filter out blocked tickets with `tkt blockers KEY --json`.
+4. **Tier 1 or 2** (assigned work): auto-select the first candidate, emit `SELECTED: <KEY>`, and hand off to `triage-ticket`.
+5. **Tier 3–5** (unassigned/backlog): print up to 5 ranked recommendations and wait for a human pick.
+
+## Recommendation output
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+Estimate guidance:
+- Effort: S ≤ 100 LOC, M 100–400, L > 400.
+- Tokens: S ≈ 50k, M ≈ 150k, L ≈ 400k.
+- Wall time: S ≈ 30 min, M ≈ 2 h, L ≈ half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- `type_class` tells you if the ticket is `full_sdlc` or `deliverable`.

--- a/.cursor/skills/self-review/SKILL.md
+++ b/.cursor/skills/self-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: self-review
+description: 'Adversarial self-review of changes before PR. Build commands via tkt config; no ticketing. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass,
+BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
+`.sdlc/config.toml` via `tkt cfg`.
+
+## Steps
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.cursor/skills/triage-ticket/SKILL.md
+++ b/.cursor/skills/triage-ticket/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: triage-ticket
+description: 'Read a ticket, move it to in_progress, and start work via tkt. Invoke as slash command, not automatically.'
+disable-model-invocation: true
+allowed-tools: [Bash, Read, Edit]
+---
+
+# Triage Ticket
+
+Read a ticket, extract actionable requirements, transition to the `in_progress`
+lane, and start time tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.gemini/commands/automated-sdlc.toml
+++ b/.gemini/commands/automated-sdlc.toml
@@ -1,0 +1,26 @@
+description = "End-to-end SDLC pipeline from ticket selection to shipped via tkt."
+
+prompt = """
+Run the automated SDLC pipeline. Orchestrates sub-skills with explicit human gates and lane-time annotation.
+
+Pipeline:
+1. `select-ticket` — find next work
+2. `triage-ticket` — move to `in_progress`
+3. Route by `type_class`:
+   - `full_sdlc` → continue
+   - `deliverable` → invoke `complete-deliverable`, then stop
+4. `plan-ticket` — implementation plan
+5. Implement + test using `tkt cfg build.*`
+6. `self-review` — adversarial review loop
+7. `open-pr` → `review`
+8. `ci-fix` — green CI loop
+9. `respond-to-review` — approve loop
+10. `deploy-preview` — confirm preview URL
+11. Promote to `qa_ready` and stop for human QA
+12. `deploy-ready` — merge, staging, prod gate
+
+Rules:
+- All ticketing via `tkt`
+- All repo/toolchain values via `tkt cfg`
+- Lane times annotated with `tkt worklog` (no-op when `[timetracking].provider = "none"`)
+"""

--- a/.gemini/commands/check-blockers.toml
+++ b/.gemini/commands/check-blockers.toml
@@ -1,0 +1,22 @@
+description = "Review blocked tickets, classify blockers, and recommend unblock actions via tkt."
+
+prompt = """
+Scan blocked tickets, summarize why each is stuck, and recommend next steps. All access via `tkt`.
+
+Steps:
+1. `tkt list --query blocked --json` (or `blocked_team` for --team)
+2. For each ticket, read `tkt view "$K" --json` to classify blocker type:
+   - internal dep, external dep, spec gap, access gap, stale, undocumented
+3. For internal deps, check blocker recursively with `tkt blockers` + `tkt view`
+4. Build a report grouped by recommended action
+5. List auto-unblock candidates but do NOT transition without confirmation
+6. Optionally nudge stale blockers with `tkt comment`
+
+Output:
+Markdown report grouped by action type: ready to unblock / needs ping / external / stale
+
+Rules:
+- Default scope: current user's blocked tickets
+- Never auto-transition
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/ci-fix.toml
+++ b/.gemini/commands/ci-fix.toml
@@ -1,0 +1,21 @@
+description = "Monitor CI on a PR, diagnose failures, fix, and loop until green via tkt."
+
+prompt = """
+Monitor CI on a PR. When checks fail, diagnose from logs, fix, push again, loop until green. Git host via `gh`; build + ticketing via `tkt`.
+
+Steps:
+1. Wait for CI to settle (no pending checks) using `gh pr checks "$PR" --json bucket`
+2. Identify failed checks: `gh pr checks "$PR" --json name,state,link | jq '... select(.state == "FAILURE")'`
+3. Get logs: `gh run view <run-id> --log-failed | head -200`
+4. Diagnose pattern: type error, test failure, ECONNREFUSED, module not found, lint, stale branch
+5. Apply the minimal fix only
+6. Rebuild/re-test via `tkt cfg build.*`
+7. Commit and push: `git commit -m "fix(<scope>): resolve CI failure — <brief>" && git push`
+8. Loop. Max 3 iterations; escalate if still failing
+
+Rules:
+- Toolchain from `tkt cfg`
+- Rerun flaky failures once; second failure is real
+- `tkt worklog` is a no-op when `[timetracking].provider = "none"`
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/complete-deliverable.toml
+++ b/.gemini/commands/complete-deliverable.toml
@@ -1,0 +1,21 @@
+description = "Short-circuit flow for deliverable ticket types via tkt."
+
+prompt = """
+For tickets whose `type_class` is `deliverable` (Task, Sub-task, Epic, Chore, Spike). Produce the artifact, comment the link, log lane time, and transition to `done`. All access via `tkt`.
+
+Steps:
+1. Read `tkt view "$KEY" --json` — classify deliverable: config change, ADR, design doc, spike, demo, POC, runbook, other
+2. Produce the artifact. Config changes may open a tiny PR with one self-review pass (no QA loop)
+3. Record lane time and transition:
+   ```shell
+   WL=$(tkt worklog "$KEY" --from-role in_progress --note "Deliverable shipped" --json)
+   tkt comment "$KEY" "Deliverable complete: <summary>. Link: <url>. Time: $(echo "$WL" | jq -r .human)"
+   tkt transition "$KEY" done
+   ```
+
+Rules:
+- Don't guess ambiguous deliverables; comment and stop
+- Complete sub-tasks only, not the parent Story
+- Blocked deliverables: `tkt transition "$KEY" blocked` with a comment
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/deploy-preview.toml
+++ b/.gemini/commands/deploy-preview.toml
@@ -1,0 +1,19 @@
+description = "Confirm preview environment for a PR, extract URL, and post to ticket + PR via tkt."
+
+prompt = """
+Confirm an ephemeral preview environment for a PR, extract the service URL, and link it back to the ticket and PR. Git host via `gh`; ticketing via `tkt`.
+
+Steps:
+1. Verify preview deployment triggered (`gh pr checks` or `gh workflow run "$PREVIEW_WF"`)
+2. Wait for deployment to finish
+3. Extract preview URL — PROJECT-SPECIFIC (stack output, workflow log, deterministic pattern)
+4. Verify health with `curl -sf <url>/health` (project-specific)
+5. Comment URL on ticket: `tkt comment "$KEY" "Preview environment: <url> ..."`
+6. Comment URL on PR: `gh pr comment "$PR" --repo "$REPO" --body "## Preview Environment\n🔗 <url>\n✅ Health: passing"`
+7. Do NOT transition the ticket
+
+Rules:
+- URL extraction is project-specific; replace with your own method
+- Always pass `$PR` explicitly to `gh pr comment`
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/deploy-ready.toml
+++ b/.gemini/commands/deploy-ready.toml
@@ -1,0 +1,22 @@
+description = "Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt."
+
+prompt = """
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+Steps:
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`
+3. Find PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`
+5. Watch staging workflow matched by merge commit SHA
+6. Comment and hand off to QE
+7. Present production deploy gate (manual)
+8. Monitor production deploy once triggered
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`
+
+Rules:
+- Repo/workflow names from `tkt cfg`
+- Production deploy is manual; never auto-deploy
+- `tkt lane-time` is a no-op when `[timetracking].provider = "none"`
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/hotfix-revert.toml
+++ b/.gemini/commands/hotfix-revert.toml
@@ -1,0 +1,28 @@
+description = "Revert a bad production change and fast-track a hotfix ticket via tkt."
+
+prompt = """
+Fast lane for production regressions. Revert a problematic change, create a highest-priority hotfix ticket, and run an accelerated PR → staging → prod pipeline. Ticketing via `tkt`; Git host via `gh`.
+
+Steps:
+1. Identify merged PR to revert; resolve to TARGET_SHA and TARGET_TICKET
+2. Create hotfix ticket:
+   ```shell
+   HOTFIX_KEY=$(tkt create --type Bug --summary "HOTFIX: revert ..." --priority Highest --assignee "$(tkt whoami)" ...)
+   tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
+   tkt transition "$HOTFIX_KEY" in_progress
+   ```
+3. Create revert branch from `origin/$(tkt cfg vcs.default_branch)`; `git revert --no-edit "$TARGET_SHA"`
+4. Run `self-review` once (mechanical revert)
+5. Open hotfix PR, label hotfix, transition to `review`
+6. Request one human signoff; do not loop on feedback
+7. Watch required CI checks
+8. Merge and poll until `MERGED`
+9. Watch staging workflow matched by merge commit SHA
+10. Present manual production deploy gate; watch once triggered
+11. Comment on both tickets; transition to `done` only if prod workflow truly deploys
+
+Rules:
+- Single signoff; skip QA loop
+- Production deploy is manual
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/open-pr.toml
+++ b/.gemini/commands/open-pr.toml
@@ -1,0 +1,29 @@
+description = "Commit, push, open a PR, request reviewers, and move the ticket to review via tkt."
+
+prompt = """
+Open a PR for ticket {{args}}. Ticketing via `tkt`; Git host via `gh`.
+
+Steps:
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`
+2. Rebase on default branch:
+   ```shell
+   git fetch origin
+   git rebase origin/!{tkt cfg vcs.default_branch}
+   ```
+3. Push: `git push -u origin HEAD`
+4. Create PR:
+   ```shell
+   REPO=$(tkt cfg vcs.repo)
+   gh pr create --repo "$REPO" --title "<type>(<scope>): <description>" --body "..."
+   ```
+5. Request reviewers from `tkt cfg vcs.reviewers --json`
+6. Branch on `type_class`:
+   - `full_sdlc`: `tkt worklog "{{args}}" --from-role in_progress --note "PR opened: $PR_URL"` then `tkt transition "{{args}}" review`
+   - `deliverable`: comment and stay in `in_progress`
+
+Rules:
+- Repo/reviewers/branch format from `tkt cfg`
+- Conventional Commits
+- `tkt worklog` is a no-op when `[timetracking].provider = "none"`
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/plan-ticket.toml
+++ b/.gemini/commands/plan-ticket.toml
@@ -1,0 +1,29 @@
+description = "Analyze a triaged ticket and produce a structured implementation plan via tkt."
+
+prompt = """
+Produce a structured implementation plan for ticket {{args}}. Planning happens BEFORE any code changes.
+
+Steps:
+1. `tkt view "{{args}}" --json` — read summary, acceptance, affected packages
+2. For each affected package, read relevant code (handlers, types, schemas, tests, API specs)
+3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change
+4. Produce a markdown plan with:
+   - Summary (one sentence)
+   - Changes (numbered path — what)
+   - Test Strategy (new / modified / regression)
+   - Risks (including external schema/API deps)
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered by the plan
+6. If >400 lines, comment with `tkt comment "{{args}}" "Scope is large... Recommend splitting..."` and pause for confirmation
+
+Build/test commands from config (never hardcode):
+- `tkt cfg build.build --pkg "<pkg>"`
+- `tkt cfg build.test --pkg "<pkg>"`
+- `tkt cfg build.typecheck`
+
+Rules:
+- Planning happens before any code changes
+- Never hardcode the toolchain
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/respond-to-review.toml
+++ b/.gemini/commands/respond-to-review.toml
@@ -1,0 +1,26 @@
+description = "Read PR review comments, address each, push fixes, and loop until approved via tkt."
+
+prompt = """
+Read PR review comments for {{args}}, address each, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+Steps:
+1. Fetch review comments and decision:
+   ```shell
+   REPO=$(tkt cfg vcs.repo)
+   OWNER=${REPO%/*}
+   NAME=${REPO#*/}
+   gh pr view "$PR" --repo "$REPO" --json reviews,reviewRequests,comments,reviewDecision
+   gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100"
+   ```
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix
+3. Make changes and reply on threads
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`
+7. Loop until approved and no unresolved comments. Max 5 cycles.
+
+Rules:
+- `tkt worklog` is a no-op when `[timetracking].provider = "none"`
+- Never argue with repeated bot nits; justify "won't fix" and resolve
+- All ticketing access goes through `tkt`
+"""

--- a/.gemini/commands/resume-from-revise.toml
+++ b/.gemini/commands/resume-from-revise.toml
@@ -1,0 +1,27 @@
+description = "Resume the SDLC after a human fixes a revise-state ticket via tkt."
+
+prompt = """
+Pick up tickets in `revise` after a failed QA round and a human dev fix. Re-enter the automation loop. Ticketing via `tkt`.
+
+Steps:
+1. Resolve ticket key (arg or infer from branch). Confirm `status_role == revise` via `tkt view "$KEY" --json`
+2. Annotate revise time:
+   ```shell
+   WL=$(tkt worklog "$KEY" --from-role revise --note "Resuming from revise" --json)
+   tkt comment "$KEY" "Resuming from revise. Time in Revise: $(echo "$WL" | jq -r .human)"
+   ```
+3. Transition to `in_progress`
+4. Verify local state: `git status`, build/test via `tkt cfg build.*`
+5. `git push`
+6. Re-run: `ci-fix` → `respond-to-review` → `deploy-preview`
+7. Verify approval; annotate in_progress and review lane times; transition to `qa_ready`
+
+Output:
+- PR URL, preview URL
+- Total time added by the revise cycle
+
+Rules:
+- Stop if local tests fail; don't push broken code
+- All ticketing access goes through `tkt`
+- `tkt worklog` is a no-op when `[timetracking].provider = "none"`
+"""

--- a/.gemini/commands/select-ticket.toml
+++ b/.gemini/commands/select-ticket.toml
@@ -1,0 +1,32 @@
+description = "Discover and select the next ticket to work on via tkt."
+
+prompt = """
+Find the right ticket to work next using `tkt`.
+
+Current user: !{tkt whoami}
+
+Run tiers 1-5 from `.sdlc/config.toml [queries]` in order until one returns selectable tickets:
+1. `tkt list --tier N --json`
+2. For each candidate, filter out tickets with unresolved blockers using `tkt blockers KEY --json`
+3. If any selectable tickets remain, stop and process that tier
+
+If Tier 1 or 2 (assigned to current user):
+- Auto-select the first candidate
+- Emit `SELECTED: <KEY>`
+- Hand off to triage-ticket
+
+If Tier 3, 4, or 5 (unassigned or backlog):
+- Print up to 5 ranked recommendations
+- Wait for a human pick
+- Include columns: Key, Type, type_class, Priority, Summary, Effort (S/M/L), Est. tokens, Est. wall time, Blockers?, Why this one
+
+Estimate guidance:
+- Effort: S <= 100 LOC, M 100-400, L > 400
+- Tokens: S ~50k, M ~150k, L ~400k
+- Wall time: S ~30 min, M ~2 h, L ~half-day
+
+Rules:
+- Never auto-select unassigned work
+- All ticketing access goes through `tkt`
+- `type_class` (`full_sdlc` or `deliverable`) determines downstream routing
+"""

--- a/.gemini/commands/self-review.toml
+++ b/.gemini/commands/self-review.toml
@@ -1,0 +1,31 @@
+description = "Adversarial self-review of changes before PR via tkt config."
+
+prompt = """
+Adversarial self-review of changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+Steps:
+1. Generate diff: `git diff $(git merge-base HEAD origin/!{tkt cfg vcs.default_branch})...HEAD`
+2. Review as adversary across:
+   - Security: injection, auth bypass, secrets, unvalidated input
+   - Types: unjustified loose types, missing null checks
+   - Errors: unhandled rejections, wrong status codes
+   - Tests: new code without tests, meaningless assertions
+   - Style: project lint conventions, debug logging
+   - Breaking: changed shared exports / API contracts
+   - Performance: N+1 queries, unbounded loops
+   - Edge cases: empty arrays, nulls, concurrency
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix
+4. Fix all blockers and warnings
+5. Rebuild/re-test via `tkt cfg build.*`
+6. Loop until zero blockers and zero warnings (max 3 passes)
+
+Output:
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+Rules:
+- Toolchain comes from `tkt cfg`
+- Max 3 passes; escalate to human if still finding blockers
+"""

--- a/.gemini/commands/triage-ticket.toml
+++ b/.gemini/commands/triage-ticket.toml
@@ -1,0 +1,24 @@
+description = "Read a ticket, move it to in_progress, and start work via tkt."
+
+prompt = """
+Read ticket {{args}}, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+Steps:
+1. `tkt view "{{args}}" --json` — extract key, type + type_class, summary, description, acceptance, labels, components, blocked_by
+2. Identify affected packages from ticket content
+3. `tkt transition "{{args}}" in_progress`
+4. `tkt comment "{{args}}" "Starting work. Affected packages: <pkg1>, <pkg2>"`
+
+Output to next skill:
+- Ticket key
+- type + type_class (full_sdlc vs deliverable)
+- Summary
+- Acceptance criteria
+- Affected packages
+- Blockers/unknowns
+
+Rules:
+- Speak in roles, not literal lane names
+- Never transition a blocked ticket
+- All ticketing access goes through `tkt`
+"""

--- a/.github/prompts/automated-sdlc.prompt.md
+++ b/.github/prompts/automated-sdlc.prompt.md
@@ -1,0 +1,32 @@
+---
+mode: agent
+description: 'End-to-end SDLC pipeline from ticket selection to shipped via tkt.'
+tools: ['terminal', 'file']
+---
+
+# Automated SDLC
+
+End-to-end pipeline from "what should I work on?" to "shipped." Orchestrates sub-skills with explicit human gates and lane-time annotation.
+
+## Pipeline
+
+1. **select-ticket** — find next work
+2. **triage-ticket** → `in_progress`
+3. Route by `type_class`:
+   - `full_sdlc` → continue
+   - `deliverable` → **complete-deliverable**, then stop
+4. **plan-ticket** — implementation plan
+5. Implement + test (build/test via `tkt cfg build.*`)
+6. **self-review** — adversarial review loop
+7. **open-pr** → `review`
+8. **ci-fix** — green CI loop
+9. **respond-to-review** — approve loop
+10. **deploy-preview** — confirm preview URL
+11. Promote to `qa_ready` and stop for human QA
+12. **deploy-ready** — merge, staging, prod gate
+
+## Rules
+
+- All ticketing via `tkt`.
+- All repo/toolchain values via `tkt cfg`.
+- Lane times annotated with `tkt worklog` (no-op when time tracking disabled).

--- a/.github/prompts/check-blockers.prompt.md
+++ b/.github/prompts/check-blockers.prompt.md
@@ -1,0 +1,29 @@
+---
+mode: agent
+description: 'Review blocked tickets, classify blockers, and recommend unblock actions via tkt.'
+tools: ['terminal']
+---
+
+# Check Blockers
+
+Scans blocked tickets, summarizes why each is stuck, recommends next steps. All ticketing via `tkt`.
+
+## Steps
+
+1. Query blocked tickets: `tkt list --query blocked --json` (or `blocked_team` for `--team`).
+2. Classify each blocker from recent comments + links (`tkt view "$K" --json`):
+   - internal dep, external dep, spec gap, access gap, stale, undocumented
+3. For internal deps, check blocker status recursively with `tkt blockers` + `tkt view`.
+4. Build a report grouped by recommended action.
+5. List auto-unblock candidates but do **not** transition without confirmation.
+6. Optionally nudge stale blockers with `tkt comment`.
+
+## Output
+
+Markdown report grouped by action type: ready to unblock / needs ping / external / stale.
+
+## Rules
+
+- Default scope: current user's blocked tickets.
+- Never auto-transition.
+- All ticketing via `tkt`.

--- a/.github/prompts/ci-fix.prompt.md
+++ b/.github/prompts/ci-fix.prompt.md
@@ -1,0 +1,32 @@
+---
+mode: agent
+description: 'Monitor CI on a PR, diagnose failures, fix, and loop until green via tkt.'
+tools: ['terminal']
+---
+
+# CI Fix
+
+Monitor CI on a PR. When checks fail, diagnose from logs, fix, push again, loop until green. Git host via `gh`; build + ticketing via `tkt cfg` / `tkt`.
+
+## Steps
+
+1. Wait for CI to settle (no pending checks) using `gh pr checks "$PR" --json bucket`.
+2. Identify failed checks.
+3. Get logs with `gh run view <run-id> --log-failed`.
+4. Diagnose: type error, test failure, service down, bad import, lint, stale branch.
+5. Apply the minimal fix only.
+6. Rebuild/re-test via `tkt cfg build.*`.
+7. Commit and push: `git commit -m "fix(<scope>): resolve CI failure — <brief>" && git push`.
+8. Loop. Max 3 iterations; escalate if still failing.
+
+## Output
+
+- CI status: green / still failing
+- Fixes applied
+- Escalation note if stuck
+
+## Rules
+
+- Toolchain from `tkt cfg`.
+- Rerun flaky failures once; treat second failure as real.
+- All ticketing via `tkt`.

--- a/.github/prompts/complete-deliverable.prompt.md
+++ b/.github/prompts/complete-deliverable.prompt.md
@@ -1,0 +1,27 @@
+---
+mode: agent
+description: 'Short-circuit flow for deliverable ticket types via tkt.'
+tools: ['terminal', 'file']
+---
+
+# Complete Deliverable
+
+For tickets whose `type_class` is `deliverable` (Task, Sub-task, Epic, Chore, Spike). Produces the artifact, comments the link, logs lane time, and transitions to `done`. Ticketing via `tkt`.
+
+## Steps
+
+1. Read ticket `description` + `acceptance`. Classify deliverable: config change, ADR, design doc, spike, demo, POC, runbook, other.
+2. Produce the artifact. Config changes may open a tiny PR with one self-review pass (no QA loop).
+3. Record lane time and transition:
+   ```shell
+   WL=$(tkt worklog "$KEY" --from-role in_progress --note "Deliverable shipped" --json)
+   tkt comment "$KEY" "Deliverable complete: <summary>. Link: <url>. Time: $(echo "$WL" | jq -r .human)"
+   tkt transition "$KEY" done
+   ```
+
+## Rules
+
+- Don't guess ambiguous deliverables; comment and stop.
+- Sub-tasks: complete the sub-task only, not the parent.
+- Blocked deliverables: `tkt transition "$KEY" blocked` with a comment.
+- All ticketing via `tkt`.

--- a/.github/prompts/deploy-preview.prompt.md
+++ b/.github/prompts/deploy-preview.prompt.md
@@ -1,0 +1,31 @@
+---
+mode: agent
+description: 'Confirm preview environment for a PR, extract URL, and post to ticket + PR via tkt.'
+tools: ['terminal']
+---
+
+# Deploy Preview
+
+Confirm an ephemeral preview environment for a PR, extract the service URL, and link it back to the ticket. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Verify preview deployment triggered (`gh pr checks` or `gh workflow run "$PREVIEW_WF"`).
+2. Wait for deployment to finish.
+3. Extract preview URL — **project-specific** (stack output, workflow log, deterministic pattern).
+4. Verify health with `curl -sf <url>/health` (project-specific).
+5. Comment URL on ticket: `tkt comment "$KEY" "Preview environment: <url> ..."`.
+6. Comment URL on PR: `gh pr comment "$PR" --repo "$REPO" --body "## Preview Environment
+🔗 <url>
+✅ Health: passing"`.
+7. Do **not** transition the ticket.
+
+## Output
+
+- Preview URL, health status, ticket + PR updated.
+
+## Rules
+
+- URL extraction is project-specific; replace with your own method.
+- Always pass `$PR` explicitly to `gh pr comment`.
+- All ticketing via `tkt`.

--- a/.github/prompts/deploy-ready.prompt.md
+++ b/.github/prompts/deploy-ready.prompt.md
@@ -1,0 +1,33 @@
+---
+mode: agent
+description: 'Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt.'
+tools: ['terminal']
+---
+
+# Deploy Ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch the staging workflow, gate manual production deploy, and comment status. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times retroactively with `tkt lane-time "$KEY" --role <role>`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Hand off to QE / comment.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual; never auto-deploy to prod.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.github/prompts/hotfix-revert.prompt.md
+++ b/.github/prompts/hotfix-revert.prompt.md
@@ -1,0 +1,38 @@
+---
+mode: agent
+description: 'Revert a bad production change and fast-track a hotfix ticket via tkt.'
+tools: ['terminal']
+---
+
+# Hotfix Revert
+
+Fast lane for production regressions. Reverts a problematic change, creates a highest-priority hotfix ticket, and runs an accelerated PR → staging → prod pipeline. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Identify the merged PR to revert; resolve to `TARGET_SHA` and `TARGET_TICKET`.
+2. Create hotfix ticket:
+   ```shell
+   HOTFIX_KEY=$(tkt create --type Bug --summary "HOTFIX: revert ..." --priority Highest ...)
+   tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
+   tkt transition "$HOTFIX_KEY" in_progress
+   ```
+3. Create revert branch from `origin/$(tkt cfg vcs.default_branch)`; `git revert --no-edit "$TARGET_SHA"`.
+4. Run `self-review` once (mechanical revert).
+5. Open hotfix PR, label hotfix, transition to `review`.
+6. Request one human signoff; do not loop on feedback.
+7. Watch required CI checks.
+8. Merge and poll until `MERGED`.
+9. Watch staging workflow matched by merge commit SHA.
+10. Present manual production deploy gate; watch once triggered.
+11. Comment on both tickets; transition to `done` only if prod workflow truly deploys.
+
+## Output
+
+- Hotfix ticket key, PR URL, prod deploy URL, elapsed time.
+
+## Rules
+
+- Single signoff; skip QA loop.
+- Production deploy is manual.
+- All ticketing via `tkt`.

--- a/.github/prompts/open-pr.prompt.md
+++ b/.github/prompts/open-pr.prompt.md
@@ -1,0 +1,30 @@
+---
+mode: agent
+description: 'Commit, push, open a PR, request reviewers, and move the ticket to review via tkt.'
+tools: ['terminal']
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch: `git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)`.
+3. Push: `git push -u origin HEAD`.
+4. Create PR using `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate time with `tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL"` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Output
+
+- PR URL + number
+- Reviewer status
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.github/prompts/plan-ticket.prompt.md
+++ b/.github/prompts/plan-ticket.prompt.md
@@ -1,0 +1,43 @@
+---
+mode: agent
+description: 'Analyze a triaged ticket and produce a structured implementation plan via tkt.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+2. For each affected package, read relevant code (route handlers, types, schemas, tests, API specs).
+3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+4. Produce a markdown plan with:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy
+   - Risks
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment on the ticket and pause for confirmation.
+
+Build/test commands come from config:
+```shell
+tkt cfg build.build --pkg "<pkg>"
+tkt cfg build.test --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+## Output
+
+Structured markdown plan, ready to drive implementation.
+
+## Rules
+
+- Never hardcode the toolchain.
+- All ticketing access goes through `tkt`.

--- a/.github/prompts/respond-to-review.prompt.md
+++ b/.github/prompts/respond-to-review.prompt.md
@@ -1,0 +1,31 @@
+---
+mode: agent
+description: 'Read PR review comments, address each, push fixes, and loop until approved via tkt.'
+tools: ['terminal']
+---
+
+# Respond to Review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and review decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.github/prompts/resume-from-revise.prompt.md
+++ b/.github/prompts/resume-from-revise.prompt.md
@@ -1,0 +1,33 @@
+---
+mode: agent
+description: 'Resume the SDLC after a human fixes a revise-state ticket via tkt.'
+tools: ['terminal']
+---
+
+# Resume From Revise
+
+Picks up tickets in `revise` after a failed QA round and a human dev fix. Re-enters the automation loop. Ticketing via `tkt`.
+
+## Steps
+
+1. Resolve ticket key (arg or infer from branch). Confirm `status_role == revise`.
+2. Annotate revise time:
+   ```shell
+   WL=$(tkt worklog "$KEY" --from-role revise --note "Resuming from revise" --json)
+   tkt comment "$KEY" "Resuming from revise. Time in Revise: $(echo "$WL" | jq -r .human)"
+   ```
+3. Transition to `in_progress`.
+4. Verify local state: `git status`, build/test via `tkt cfg build.*`.
+5. `git push`.
+6. Re-run: `ci-fix` → `respond-to-review` → `deploy-preview`.
+7. Verify approval; annotate in_progress and review lane times; transition to `qa_ready`.
+
+## Output
+
+- PR URL, preview URL, total time added by the revise cycle.
+
+## Rules
+
+- Stop if local tests fail; don't push broken code.
+- All ticketing via `tkt`.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.github/prompts/select-ticket.prompt.md
+++ b/.github/prompts/select-ticket.prompt.md
@@ -1,0 +1,41 @@
+---
+mode: agent
+description: 'Discover and select the next ticket to work on via tkt.'
+tools: ['terminal']
+---
+
+# Select Ticket
+
+Find the right ticket to work next. All ticketing access goes through `tkt`.
+
+## Prerequisites
+
+- `tkt doctor` passes.
+- `tkt` on PATH.
+
+## Steps
+
+1. Identify current user:
+   ```shell
+   tkt whoami
+   ```
+2. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets:
+   ```shell
+   tkt list --tier N --json
+   ```
+3. Filter out blocked tickets with `tkt blockers KEY --json`.
+4. **Tier 1 or 2** (assigned work): auto-select the first candidate, emit `SELECTED: <KEY>`, and hand off to `triage-ticket`.
+5. **Tier 3–5** (unassigned/backlog): print up to 5 ranked recommendations and wait for a human pick.
+
+## Recommendation output
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+- Effort: S ≤ 100 LOC, M 100–400, L > 400.
+- Tokens: S ≈ 50k, M ≈ 150k, L ≈ 400k.
+- Wall time: S ≈ 30 min, M ≈ 2 h, L ≈ half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- `type_class` tells you if the ticket is `full_sdlc` or `deliverable`.

--- a/.github/prompts/self-review.prompt.md
+++ b/.github/prompts/self-review.prompt.md
@@ -1,0 +1,30 @@
+---
+mode: agent
+description: 'Adversarial self-review of changes before PR via tkt config.'
+tools: ['terminal', 'file']
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.build --pkg "<pkg>"`, `tkt cfg build.test --pkg "<pkg>"`, `tkt cfg build.typecheck`.
+6. Loop until zero blockers and zero warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.github/prompts/triage-ticket.prompt.md
+++ b/.github/prompts/triage-ticket.prompt.md
@@ -1,0 +1,35 @@
+---
+mode: agent
+description: 'Read a ticket, move it to in_progress, and start work via tkt.'
+tools: ['terminal']
+---
+
+# Triage Ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, description, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/.kiro/skills/automated-sdlc/SKILL.md
+++ b/.kiro/skills/automated-sdlc/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: automated-sdlc
+description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+---
+
+# Automated SDLC
+
+End-to-end pipeline from "what should I work on?" to "shipped." Orchestrates
+sub-skills with explicit human gates and per-lane time annotation. **Every
+ticketing/board operation goes through `tkt`**, so the same pipeline runs on Jira,
+GitHub Issues+Projects, Linear, qi, or a markdown board — the backend and board
+shape are declared in `.sdlc/config.toml`.
+
+## Prerequisites
+
+- `tkt doctor` passes (ticketing auth + board model reachable).
+- `gh` authenticated (for the PR/CI/merge phases).
+- Toolchain for local build/test (commands resolved via `tkt cfg build.*`).
+- Docker running if your tests need it.
+- On the default branch, up to date.
+
+## Board lanes (roles)
+
+Skills speak in canonical **roles**; `.sdlc/config.toml` `[board.roles]` maps each
+to the provider's actual lane name. Default flow:
+
+```
+backlog → todo → in_progress → review → qa_ready → qa → deploy_ready → done
+```
+
+Side roles: `revise`, `blocked`, `cancelled`. Print a literal lane name with
+`tkt lane <role>`. A board that lacks a lane (e.g. a markdown board with no
+`qa_ready`) simply doesn't define that role — type routing (below) keeps such
+tickets on the short flow.
+
+## Ownership of transitions
+
+Driven by `[board.ownership]` in config. Default:
+
+| Transition (role→role) | Owner |
+| --- | --- |
+| backlog → todo | Human (refinement) |
+| todo → in_progress | **Agent** (after select + triage) |
+| in_progress → review | **Agent** (on PR open) |
+| review → revise | Reviewer — or `respond-to-review` if changes requested mid-loop |
+| revise → in_progress → review | **Agent** (`resume-from-revise`) |
+| review → qa_ready | **Agent** (QA promotion gate; PR stays open) |
+| qa_ready → qa | **Human (QA)** |
+| qa → revise / qa → deploy_ready | **Human (QA)** |
+| deploy_ready → done | **Human** (until the deploy workflow truly deploys) |
+
+## Lane-time annotation
+
+Every agent-driven transition out of a lane records lane time via **one command**:
+
+```shell
+tkt worklog "$KEY" --from-role <role> --note "<context>" --json
+```
+
+`tkt worklog` finds the most recent entry into that lane (paging the provider's
+full changelog/history), computes elapsed time, writes the canonical time entry
+(e.g. a Jira/Tempo worklog, or a local JSONL row), and returns
+`{human, worklog_id, seconds}`. It is a **no-op** (empty `worklog_id`) when
+`[timetracking].provider = "none"`. Then post the human-readable comment embedding
+both values:
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened" --json)
+tkt comment "$KEY" "PR opened. Time in In Progress: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+Annotate on: in_progress → review, review → qa_ready, deploy_ready → done, any
+revise → in_progress, and any agent-driven transition to `blocked`. (This replaces
+the old hand-rolled `annotate_lane_time` shell/Python helper entirely — the
+changelog pagination + billable logic now live inside the provider adapter.)
+
+Use `--billable` only for client/billable work (provider-dependent; ignored where
+the backend has no billable concept).
+
+## Pipeline
+
+### Phase 0: Select ticket
+
+**Invoke `select-ticket`.** Auto-selects Tier 1/2 (assigned); recommends Tier 3–5.
+Drops candidates with unresolved blockers. If nothing across all tiers → stop with
+a "nothing to work on" report.
+
+### Phase 1: Triage
+
+**Invoke `triage-ticket`** with the key. Transitions `todo → in_progress`. Returns
+the ticket `type` and `type_class`.
+
+### Phase 1.5: Route by type
+
+```shell
+CLASS=$(tkt view "$KEY" --json | jq -r .type_class)
+case "$CLASS" in
+  full_sdlc)   : ;;                               # continue to Phase 2
+  deliverable) echo "→ complete-deliverable"; ;;  # invoke complete-deliverable, then stop
+  *)           # unknown: fall back to lane availability
+    HAS_REVIEW=$(tkt view "$KEY" --json | jq -r '[.transitions[]? == (env.REVIEW_LANE)] | any')
+    ;;
+esac
+```
+
+`full_sdlc` (Story/Bug) → full pipeline. `deliverable` (Task/Sub-task/Chore/Epic/
+Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
+`deliverable` sets are defined in `[issue_types]`.
+
+### Phase 2: Plan
+
+**Invoke `plan-ticket`.** Output: files, test strategy, risks. External dep missing
+→ see "External blocker handling".
+
+### Phase 3: Implement + test
+
+1. Branch: `git checkout -b "$(tkt cfg vcs.branch_fmt --ticket "$KEY" --slug "<slug>")"`
+2. Implement per plan.
+3. After each logical unit, run the configured toolchain:
+
+   ```shell
+   eval "$(tkt cfg build.build --pkg "<pkg>")"
+   eval "$(tkt cfg build.typecheck)"
+   eval "$(tkt cfg build.test --pkg "<pkg>")"
+   ```
+
+4. If tests fail → invoke `debug` → loop back.
+
+### Phase 4: Self-review (adversarial)
+
+**Invoke `self-review`** in a loop until clean.
+
+### Phase 5: Open PR
+
+**Invoke `open-pr`** — pushes, opens the PR, requests reviewers, and (for
+`full_sdlc`) transitions `in_progress → review` with lane-time annotation.
+
+### Phase 6: CI loop
+
+**Invoke `ci-fix`** — wait → diagnose → fix → push → repeat until green.
+
+### Phase 7: Review loop
+
+**Invoke `respond-to-review`** — handle all reviewer feedback. Loop until no
+unaddressed comments and the PR is approved. If a reviewer moves the ticket to
+`revise` mid-loop, `respond-to-review` flips it back to `in_progress` while pushing
+fixes, then back to `review`.
+
+### Phase 8: Preview env confirmation
+
+After CI is green, confirm the preview URL is live. **Invoke `deploy-preview`** to
+comment the URL on the ticket (it does not transition).
+
+### Phase 9: Promote to qa_ready (human QA gate)
+
+PR stays **open**. Transition + annotate:
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role review --note "Approved — promoting to QA" --json)
+tkt transition "$KEY" qa_ready
+tkt comment "$KEY" "Preview: <url>. PR open and approved, awaiting QA. \
+Time in review (incl. loops): $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+**Stop here.** QA owns the next move: `qa_ready → qa` (testing), then `→ deploy_ready`
+(pass, pipeline resumes at Phase 10) or `→ revise` (fail, resume via
+`resume-from-revise`).
+
+### Phase 10: Deploy
+
+**Invoke `deploy-ready`** — picks up `deploy_ready` tickets, merges the open PR,
+watches the deploy workflow, gates manual prod deploy, then handles the final
+`done` transition per your project's deploy contract.
+
+## Side flows
+
+### External blocker handling
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Blocked — <desc>" --json)
+tkt transition "$KEY" blocked
+tkt comment "$KEY" "BLOCKED: <desc>. Waiting on: <who>. Need: <what unblocks>. \
+Time in In Progress before blocking: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+Then stop. Run `check-blockers` periodically to recommend unblock actions.
+
+### Revise (QA failure)
+
+When QA moves a ticket to `revise`, a human dev fixes it, then runs
+`/resume-from-revise <KEY>` — annotates revise time and re-enters Phases 6–9.
+
+### Production regression / revert
+
+Invoke `hotfix-revert` — fast-track: highest-priority hotfix ticket, revert the
+offending commit, single human signoff, skip review/QA loops.
+
+## Decision points
+
+| Condition | Action |
+| --- | --- |
+| Tests fail 3× after debug | Stop, comment, `tkt transition "$KEY" blocked`, request human help |
+| CI flake (infra, not code) | `gh run rerun <id> --failed`; don't count against budget |
+| Reviewer "request changes" | Loop via `respond-to-review` until approved |
+| Merge conflicts | `git fetch && git rebase origin/main` → resolve → re-push |
+| Ticket unclear / spec gap | `tkt transition "$KEY" blocked` with a clarifying comment |
+| Scope > 400 LOC | Stop, recommend splitting via `plan-ticket` |
+| Production regression | Invoke `hotfix-revert` |
+
+## Abort conditions
+
+Stop and notify (comment on the ticket) on: 3+ non-converging review cycles;
+infrastructure CI failure; scope > ~400 lines (split needed); external blocker
+unresolved > 24h.

--- a/.kiro/skills/check-blockers/SKILL.md
+++ b/.kiro/skills/check-blockers/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: check-blockers
+description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
+model: claude-haiku-4-5
+allowed-tools: [Bash, Read]
+---
+
+# Check Blockers
+
+Scans blocked tickets, summarizes why each is stuck, recommends next steps. All
+ticketing via `tkt`.
+
+## When to use
+
+- Standup prep — a "blocked items" rollup
+- Ad-hoc triage of stuck work
+- After a dependency is reported unblocked
+
+## Scope
+
+Default to the current user's blocked tickets. Define the queries in config:
+
+```toml
+[queries]
+blocked      = '... status = blocked AND assignee = currentUser() ...'   # --mine
+blocked_team = '... status = blocked ...'                                 # --team
+```
+
+## Steps
+
+### 1. Query blocked tickets
+
+```shell
+tkt list --query blocked --json        # or blocked_team for --team
+```
+
+### 2. Classify each blocker
+
+Read recent comments + links (`tkt view "$K" --json`) to determine type:
+
+| Signal | Type | Action |
+| --- | --- | --- |
+| unresolved `blocked_by` link → open ticket | internal dep | check blocker status; ping owner |
+| "waiting on <team>" / external system | external dep | verify in their channel; direct ask |
+| "design needed" / "spec missing" | spec gap | schedule a design sync |
+| "credentials" / "access" / "token" | access gap | IT/security request |
+| no update > 7 days | stale | ping blocker owner |
+| no blocker comment | undocumented | add a blocker comment first |
+
+### 3. For internal-dep blockers, check the blocker recursively
+
+```shell
+for B in $(tkt blockers "$K" --json | jq -r '.[].key'); do
+  BSTATE=$(tkt view "$B" --json | jq -r .status_role)
+  echo "$K blocked by $B (status: $BSTATE)"
+done
+```
+
+- blocker is `done`/`deploy_ready` → recommend **unblock now** (move `$K` to `todo`/`in_progress`)
+- blocker is `in_progress`/`review` → ETA-ping its assignee
+- blocker is itself `blocked` → flag chain blocker, recommend escalation
+
+### 4. Build the report
+
+```
+<KEY> | <priority> | <summary>
+  Blocker: <type>
+  Detail: <one line>
+  Recommended next step: <action>
+```
+
+Group by recommended action for batch responses.
+
+### 5. Auto-unblock candidates (confirm before transitioning)
+
+List tickets whose blocker is verifiably resolved. Do **not** transition
+automatically:
+
+```
+Auto-unblock candidates (confirm first):
+  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress
+```
+
+### 6. Optional nudge on stale blockers (after human confirms)
+
+```shell
+tkt comment "$K" "Blocker check: blocked <N> days. Blocker <B> status: <status>. Next: <action>."
+```
+
+## Output
+
+A markdown report grouped by action type (ready to unblock / needs ping / external
+/ stale).
+
+## Scheduling
+
+```
+/schedule weekday 9am /check-blockers --mine
+```

--- a/.kiro/skills/ci-fix/SKILL.md
+++ b/.kiro/skills/ci-fix/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ci-fix
+description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+---
+
+# CI Fix
+
+Monitor CI on a PR. When checks fail, diagnose from logs, fix, push again, loop
+until green. Git host operations use `gh`; toolchain + ticketing come from
+`.sdlc/config.toml` via `tkt cfg` / `tkt`.
+
+## Input
+
+- PR number (`$PR`) and the ticket key (`$KEY`, for the stuck-escalation comment)
+
+## Steps
+
+### 1. Check / wait for CI
+
+```shell
+gh pr checks "$PR"                                  # one-shot read
+
+# Wait until nothing is pending (stable bucket enum; don't text-grep).
+until [ "$(gh pr checks "$PR" --json bucket --jq 'all(.[]; .bucket != "pending")')" = "true" ]; do
+  sleep 15
+done
+gh pr checks "$PR"
+```
+
+All pass after settling → done. **Do not** poll with a text grep — `skipping`
+rows and check names containing `pass` cause false early exits.
+
+### 2. Identify failed checks
+
+```shell
+gh pr checks "$PR" --json name,state,link | jq '.[] | select(.state == "FAILURE")'
+```
+
+### 3. Get failure logs
+
+```shell
+gh run view <run-id> --log-failed | head -200
+```
+
+### 4. Diagnose
+
+| Pattern | Likely cause | Fix |
+| --- | --- | --- |
+| `Type error` | type-check | fix type |
+| `Test failed` | regression | fix code or test |
+| `ECONNREFUSED` | service not up in CI | check CI service step |
+| `Module not found` | bad import / missing ext | fix import path |
+| `Lint error` | style | `eval "$(tkt cfg build.lint)" -- --fix` (if supported) |
+| branch behind | stale | `git rebase origin/$(tkt cfg vcs.default_branch)` |
+
+### 5. Apply the minimal fix
+
+Fix only the CI failure. Do not refactor unrelated code.
+
+### 6. Rebuild locally (config toolchain)
+
+```shell
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+eval "$(tkt cfg build.typecheck)"
+```
+
+### 7. Push
+
+```shell
+git add -A
+git commit -m "fix(<scope>): resolve CI failure — <brief>"
+git push
+```
+
+### 8. Loop
+
+Repeat from step 1. **Max 3 iterations.** If still failing:
+
+```shell
+gh pr comment "$PR" --body "CI failing after 3 fix attempts. Needs human investigation. Last failure: <summary>"
+tkt comment "$KEY" "CI failing after 3 attempts on PR #$PR — needs human investigation."
+```
+
+### 9. Flaky tests
+
+Non-deterministic failure (passes locally, random timeout): `gh run rerun <run-id> --failed`
+**once**. If it fails again, treat as real.
+
+## Output
+
+- CI status: green / still failing
+- Fixes applied (commits)
+- If stuck: the unresolved failure

--- a/.kiro/skills/complete-deliverable/SKILL.md
+++ b/.kiro/skills/complete-deliverable/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: complete-deliverable
+description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+---
+
+# Complete Deliverable
+
+For tickets whose `type_class` is `deliverable` — they produce something other
+than merged feature code (config change, ADR/decision doc, design doc, demo/Loom,
+POC, spike notes, runbook). Their lanes are just `todo → in_progress → done`
+(+ `blocked`, `cancelled`). Ticketing via `tkt`.
+
+## When the orchestrator routes here
+
+`automated-sdlc` checks `tkt view "$KEY" --json | jq -r .type_class` after triage.
+`deliverable` → this skill instead of Plan → Implement → PR → Review.
+
+## Input
+
+- Ticket key (already in `in_progress` from `triage-ticket`)
+
+## Steps
+
+### 1. Determine the deliverable
+
+Read `description` + `acceptance`. Classify into: config change, ADR/decision,
+design doc, spike/research, demo/video, POC, runbook, or other — each resolves to
+an artifact URL. If the expected deliverable is ambiguous, comment a clarifying
+question and stop. Don't guess.
+
+### 2. Do the work
+
+Execute it. A config change may still open a tiny PR (CI + one self-review pass,
+**no QA loop**). Docs/spikes produce a published page or a file in the repo.
+
+### 3. Record lane time and transition to Done
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Deliverable shipped — <summary>" --json)
+tkt comment "$KEY" "Deliverable complete: <summary>.
+Link: <url>
+Time in In Progress: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+tkt transition "$KEY" done
+```
+
+## Edge cases
+
+- **Config change needing a PR** (workflow files, shared tsconfig, infra constants,
+  the skill pack itself): open a small PR, CI runs, skip the QA loop, merge after a
+  single self-review. Then comment + `tkt transition "$KEY" done`. Do not route to
+  `qa_ready`. `open-pr` auto-detects the missing review lane (via `type_class`) and
+  leaves the ticket in `in_progress` until this step.
+- **Sub-task under a parent Story**: complete and mark the sub-task `done`. Do not
+  transition the parent.
+- **Spike with no concrete next step**: comment findings + a recommended follow-up
+  ticket, mark `done`. The follow-up is a separate Story.
+- **Blocked deliverable**: `tkt worklog "$KEY" --from-role in_progress` then
+  `tkt transition "$KEY" blocked` with a blocker comment (see `automated-sdlc` →
+  External blocker handling).
+
+## Output
+
+- Deliverable link
+- Time spent
+- Confirmation the Done transition succeeded

--- a/.kiro/skills/deploy-preview/SKILL.md
+++ b/.kiro/skills/deploy-preview/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: deploy-preview
+description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+---
+
+# Deploy Preview
+
+Confirm an ephemeral preview environment for a PR, extract the service URL, and
+link it back to the ticket. Git host via `gh`; ticketing via `tkt`. The
+URL-extraction step is **project-specific** (depends on your hosting) — the rest
+is portable.
+
+## Input
+
+- PR number (`$PR`), ticket key (`$KEY`)
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+PREVIEW_WF=$(tkt cfg deploy.preview_workflow 2>/dev/null || echo "")
+```
+
+## Steps
+
+### 1. Verify the preview deployment triggered
+
+```shell
+gh pr checks "$PR" --repo "$REPO" | grep -i preview || true
+# If a dedicated workflow exists and didn't auto-run:
+[ -n "$PREVIEW_WF" ] && gh workflow run "$PREVIEW_WF" --repo "$REPO" -f pr_number="$PR"
+```
+
+### 2. Wait for deployment
+
+```shell
+[ -n "$PREVIEW_WF" ] && gh run list --workflow="$PREVIEW_WF" --repo "$REPO" \
+  --branch="$(git branch --show-current)" --limit=1 --json status,databaseId
+```
+
+### 3. Extract the preview URL — PROJECT-SPECIFIC
+
+This depends on where previews live. Replace with your project's method. Examples:
+
+```shell
+# AWS CloudFormation/CDK stack output:
+# aws cloudformation describe-stacks --stack-name <stack-pr-$PR> \
+#   --query "Stacks[0].Outputs[?OutputKey=='ServiceUrl'].OutputValue" --output text --region <region>
+
+# Or: a URL the preview workflow prints / a deterministic pattern:
+# PREVIEW_URL="https://pr-$PR.preview.example.com"
+```
+
+### 4. Verify health (project-specific)
+
+```shell
+curl -sf "<preview-url>/health" || echo "preview health check failed"
+```
+
+### 5. Post the URL to the ticket
+
+```shell
+tkt comment "$KEY" "Preview environment: <preview-url> (PR #$PR). Health: passing."
+```
+
+### 6. Post the URL to the PR
+
+Always pass `$PR` explicitly (don't let `gh` infer from the current branch):
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "## Preview Environment
+🔗 <preview-url>
+✅ Health: passing
+Destroyed when this PR closes/merges."
+```
+
+### 7. Do NOT transition the ticket
+
+`deploy-preview` posts the URL only. Standalone → transitioning is the caller's
+choice. From `automated-sdlc` → Phase 9 owns the `qa_ready` transition after the
+URL is confirmed; transitioning here would jump the gate.
+
+## Output
+
+- Preview URL, health status, ticket + PR updated

--- a/.kiro/skills/deploy-ready/SKILL.md
+++ b/.kiro/skills/deploy-ready/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: deploy-ready
+description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
+disable-model-invocation: true
+---
+
+# Deploy Ready
+
+Resumes the SDLC once a human moves a ticket through `qa_ready → qa → deploy_ready`.
+Ticketing via `tkt`; Git host via `gh`. Repo + workflow names from
+`.sdlc/config.toml`.
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DEFAULT_BRANCH=$(tkt cfg vcs.default_branch)
+STAGING_WF=$(tkt cfg deploy.staging_workflow)
+PROD_WF=$(tkt cfg deploy.production_workflow)
+```
+
+> ⚠️ **Deploy-contract note (project-specific):** whether a green workflow run means
+> "code is live" depends on your pipeline. If your deploy workflow only builds/auths
+> (stub), do **not** auto-transition tickets to `done` — leave them in `deploy_ready`
+> for a human to confirm prod traffic. Set this expectation per project.
+
+## Steps
+
+### 1. Identify deploy_ready tickets
+
+```shell
+tkt list --query deploy_ready --json   # define [queries].deploy_ready in config
+```
+
+If multiple, take highest-priority + oldest. One at a time.
+
+### 2. Annotate QA-lane times (retroactive, per lane)
+
+For each already-exited QA lane, record entry→exit with `tkt lane-time` (which,
+unlike `tkt worklog`, measures a closed interval rather than entry→now):
+
+```shell
+for ROLE in qa_ready qa deploy_ready; do
+  tkt lane-time "$KEY" --role "$ROLE" --json 2>/dev/null || true
+done
+```
+
+Then a summary comment (worklogs are canonical; comment is for skimmers):
+
+```shell
+tkt comment "$KEY" "QA lanes recorded (qa_ready / qa / deploy_ready). Proceeding to merge + staging."
+```
+
+### 3. Find the PR
+
+```shell
+gh pr list --repo "$REPO" --search "$KEY in:title,body" --state open \
+  --json number,headRefName,mergeable,reviewDecision
+```
+
+Abort with a comment if no PR or not approved.
+
+### 4. Merge
+
+`--auto` returns when *enqueued*, not landed. Poll for `MERGED` before reading the
+merge SHA:
+
+```shell
+gh pr merge "$PR" --repo "$REPO" --$(tkt cfg vcs.merge) --auto
+for _ in $(seq 1 60); do
+  STATE=$(gh pr view "$PR" --repo "$REPO" --json state --jq .state)
+  [ "$STATE" = "MERGED" ] && break; sleep 10
+done
+[ "$STATE" != "MERGED" ] && { echo "PR did not merge within 10 min"; exit 1; }
+```
+
+### 5. Watch the staging workflow (match by merge commit)
+
+Don't take the latest run — match the merge `headSha`:
+
+```shell
+MERGE_SHA=$(gh pr view "$PR" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow="$STAGING_WF" --repo "$REPO" --branch="$DEFAULT_BRANCH" \
+    --limit=10 --json databaseId,headSha \
+    | jq -r --arg sha "$MERGE_SHA" '.[] | select(.headSha==$sha) | .databaseId' | head -1)
+  [ -n "$RUN_ID" ] && break; sleep 10
+done
+[ -z "$RUN_ID" ] && { echo "no staging run for $MERGE_SHA"; exit 1; }
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status
+```
+
+On failure: read logs, fix forward if small, else escalate. Annotate the ticket.
+
+### 6. Hand off to QE (if applicable) + comment
+
+```shell
+tkt comment "$KEY" "Staging workflow succeeded for $MERGE_SHA. Handing off to QE for smoke/regression (out-of-band)."
+```
+
+### 7. Present the production deploy gate
+
+Production deploy is **manual**:
+
+```shell
+echo "Staging done. Run manually: gh workflow run $PROD_WF --repo $REPO --ref $DEFAULT_BRANCH [--field version=<tag>]"
+tkt comment "$KEY" "Staging succeeded for $MERGE_SHA. Production deploy ready — manual human trigger required."
+```
+
+### 8. Monitor production deploy (once triggered)
+
+```shell
+gh run watch <prod-run-id> --repo "$REPO" --exit-status
+```
+
+### 9. Identify shipped tickets — transition per the deploy contract
+
+```shell
+git fetch origin "$DEFAULT_BRANCH" --tags
+SHIPPED=$(git log <prev-prod-tag>..origin/"$DEFAULT_BRANCH" --format='%s %b' \
+  | grep -oE '[A-Z]+-[0-9]+' | sort -u)
+```
+
+If your prod workflow truly deploys → transition each to `done`:
+
+```shell
+# for K in $SHIPPED; do tkt transition "$K" done; done
+```
+
+If it's a build/auth stub → comment and leave in `deploy_ready` for human Done:
+
+```shell
+for K in $SHIPPED; do
+  tkt comment "$K" "Production workflow completed. Verify prod traffic, then transition to Done."
+done
+```
+
+### 10. Post-deploy notes (only if notable)
+
+Comment only on friction (CD retry, staging fix, runner outage, time ≫ median):
+
+```shell
+tkt comment "$KEY" "Deploy notes: <what slowed it down> | extra time: <Xh Ym>"
+```
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction

--- a/.kiro/skills/hotfix-revert/SKILL.md
+++ b/.kiro/skills/hotfix-revert/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: hotfix-revert
+description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
+disable-model-invocation: true
+---
+
+# Hotfix Revert
+
+Fast lane for production issues. Reverts a problematic change, opens a hotfix
+ticket at highest priority, runs an accelerated pipeline. Ticketing via `tkt`
+(incl. `tkt create` / `tkt link`); Git host via `gh`.
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DEFAULT_BRANCH=$(tkt cfg vcs.default_branch)
+STAGING_WF=$(tkt cfg deploy.staging_workflow)
+PROD_WF=$(tkt cfg deploy.production_workflow)
+```
+
+## When to use
+
+- A prod deploy caused a regression and the bad commit/PR is known
+- A merged PR must be backed out before the next planned deploy
+
+## Skips vs. standard SDLC
+
+Ticket selection (created here), plan/self-review loops (one pass), QA gate
+(skipped), multi-cycle review (one signoff), QE staging (out-of-band).
+
+## Steps
+
+### 1. Identify the change to revert
+
+Required input: a **merged PR number**. (Commit SHA / ticket key → resolve to a PR
+first with `gh pr list --repo "$REPO" --search "<x>"`.)
+
+```shell
+TARGET_SHA=$(gh pr view <n> --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+TARGET_TICKET=$(gh pr view <n> --repo "$REPO" --json body --jq '.body' | grep -oE '[A-Z]+-[0-9]+' | head -1)
+```
+
+### 2. Create the hotfix ticket
+
+```shell
+HOTFIX_KEY=$(tkt create --type Bug \
+  --summary "HOTFIX: revert <original-summary> (reverts $TARGET_TICKET)" \
+  --priority Highest --assignee "$(tkt whoami)" \
+  --body "Hotfix for $TARGET_TICKET. Reverting $TARGET_SHA. Fast-track: single signoff, skip QA.")
+
+# Link hotfix → original. "Fixes" is the outward description (HOTFIX Fixes TARGET).
+tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
+tkt transition "$HOTFIX_KEY" in_progress
+```
+
+### 3. Create the revert branch
+
+For squash-merged history use `git revert <sha>` (no `-m`; `-m 1` is only for true
+two-parent merge commits):
+
+```shell
+SLUG="revert-${TARGET_SHA:0:8}"
+git fetch origin
+git checkout -b "$(tkt cfg vcs.hotfix_fmt --ticket "$HOTFIX_KEY" --slug "$SLUG")" "origin/$DEFAULT_BRANCH"
+git revert --no-edit "$TARGET_SHA"
+```
+
+Conflicts → resolve minimally, no unrelated changes.
+
+### 4. Single self-review pass
+
+Invoke `self-review` **once** (no loop). The revert is mechanical.
+
+### 5. Open the hotfix PR
+
+```shell
+git push -u origin HEAD
+HOTFIX_URL=$(tkt view "$HOTFIX_KEY" --json | jq -r .url)
+gh pr create --repo "$REPO" --title "hotfix($HOTFIX_KEY): revert $TARGET_TICKET" --label hotfix \
+  --body "## Hotfix
+Reverts $TARGET_SHA (from $TARGET_TICKET). Ticket: $HOTFIX_URL
+Production incident — bypassing standard QA per hotfix policy. Single signoff."
+tkt transition "$HOTFIX_KEY" review
+```
+
+### 6. Request human signoff (skip the bot loop)
+
+```shell
+gh pr edit <pr> --repo "$REPO" --add-reviewer <oncall-handle>
+```
+
+Wait for **one** approval. Don't loop on feedback — if significant changes are
+requested, abort hotfix and escalate.
+
+### 7. Monitor CI (required checks only)
+
+```shell
+gh pr checks <pr> --repo "$REPO" --watch --required
+```
+
+Required check fails → fix forward minimally or abort.
+
+### 8. Merge
+
+```shell
+gh pr merge <pr> --repo "$REPO" --$(tkt cfg vcs.merge) --auto
+for _ in $(seq 1 60); do
+  STATE=$(gh pr view <pr> --repo "$REPO" --json state --jq .state)
+  [ "$STATE" = "MERGED" ] && break; sleep 10
+done
+[ "$STATE" != "MERGED" ] && { echo "hotfix PR did not merge within 10 min"; exit 1; }
+```
+
+### 9. Watch staging (match merge commit)
+
+```shell
+MERGE_SHA=$(gh pr view <pr> --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow="$STAGING_WF" --repo "$REPO" --branch="$DEFAULT_BRANCH" \
+    --limit=10 --json databaseId,headSha \
+    | jq -r --arg sha "$MERGE_SHA" '.[] | select(.headSha==$sha) | .databaseId' | head -1)
+  [ -n "$RUN_ID" ] && break; sleep 10
+done
+[ -z "$RUN_ID" ] && { echo "no staging run for $MERGE_SHA"; exit 1; }
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status
+```
+
+Staging fails → comment on the ticket, escalate, do not proceed to prod.
+
+### 10. Production deploy (single signoff)
+
+```shell
+echo "Staging green. Run: gh workflow run $PROD_WF --repo $REPO --ref $DEFAULT_BRANCH --field version=hotfix-$HOTFIX_KEY"
+# After the human triggers it:
+gh run watch <prod-run-id> --repo "$REPO" --exit-status
+```
+
+### 11. Comment on both tickets — transition per deploy contract
+
+```shell
+WL=$(tkt worklog "$HOTFIX_KEY" --from-role in_progress --note "Hotfix run complete — awaiting verification" --json)
+tkt comment "$HOTFIX_KEY" "Production workflow completed. Verify the revert serves prod traffic, then transition to Done. \
+Agent lane time: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+tkt comment "$TARGET_TICKET" "Reverted by $HOTFIX_KEY due to a production regression. Redo the work with the regression addressed before re-attempting."
+# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done
+```
+
+## Output
+
+- Hotfix ticket key, PR URL, prod deploy URL, total elapsed time

--- a/.kiro/skills/open-pr/SKILL.md
+++ b/.kiro/skills/open-pr/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: open-pr
+description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+---
+
+# Open PR
+
+Commit staged changes, push the branch, open a pull request, and move the ticket
+to its `review` lane. Ticketing via `tkt`; Git host via `gh`. All repo-specific
+values (repo, branch format, reviewers, commit conventions, build commands) come
+from `.sdlc/config.toml`.
+
+## Input
+
+- Feature branch with changes
+- Ticket key (`$KEY`)
+- Implementation summary
+
+## Steps
+
+### 1. Stage and commit
+
+```shell
+git add -A
+git commit -m "<type>(<scope>): <description>"   # Conventional Commits
+```
+
+Scope = primary affected package. Imperative, lowercase, no period, < 72 chars.
+Multiple logical changes → multiple commits.
+
+### 2. Rebase on the default branch
+
+```shell
+git fetch origin
+git rebase origin/main    # or your default branch
+```
+
+Resolve conflicts, then `git rebase --continue`.
+
+### 3. Push
+
+```shell
+git push -u origin HEAD
+```
+
+### 4. Create the PR
+
+Pull repo + reviewer config from `tkt`:
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+gh pr create --repo "$REPO" \
+  --title "<type>(<scope>): <description>" \
+  --body "## Summary
+
+<one paragraph>
+
+## Ticket
+
+$(tkt view "$KEY" --json | jq -r .url)
+
+## Changes
+- <bullets>
+
+## Testing
+- <how tested>
+
+## Checklist
+- [x] Tests added/updated
+- [x] Lint/typecheck pass"
+```
+
+### 5. Request reviewers
+
+```shell
+PR=<pr-number>
+REPO=$(tkt cfg vcs.repo)
+for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
+  gh api -X POST "repos/$REPO/pulls/$PR/requested_reviewers" -f "reviewers[]=$R" 2>/dev/null \
+    || gh pr edit "$PR" --repo "$REPO" --add-reviewer "$R" 2>/dev/null \
+    || echo "Note: reviewer '$R' not addable — skipping"
+done
+```
+
+### 6. Transition the ticket (only if it has a review lane)
+
+`full_sdlc` tickets (Story/Bug) go to the `review` lane immediately on PR open.
+`deliverable` tickets (Task/Spike/…) have no review lane — leave them in
+`in_progress`; `complete-deliverable` handles their final transition. Branch on
+`type_class` (no need to enumerate live transitions):
+
+```shell
+CLASS=$(tkt view "$KEY" --json | jq -r .type_class)
+PR_URL=$(gh pr view "$PR" --repo "$(tkt cfg vcs.repo)" --json url --jq .url)
+
+if [ "$CLASS" = "full_sdlc" ]; then
+  # Annotate time in in_progress, then move to review.
+  WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL" --json)
+  tkt transition "$KEY" review
+  tkt comment "$KEY" "PR opened: $PR_URL. Review requested. Time in In Progress: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+else
+  tkt comment "$KEY" "PR opened: $PR_URL. Review requested. (Deliverable type — staying in In Progress until merge + Done.)"
+fi
+```
+
+`tkt worklog` is a no-op (returns an empty `worklog_id`) when the project's
+`[timetracking].provider = "none"`, so this works unchanged on backends with no
+time tracking — the comment just shows `(no time tracking)`.
+
+## Output
+
+- PR URL + number
+- Whether reviewers were added or skipped

--- a/.kiro/skills/plan-ticket/SKILL.md
+++ b/.kiro/skills/plan-ticket/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: plan-ticket
+description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+---
+
+# Plan Ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens
+BEFORE any code changes. Ticketing access via `tkt`.
+
+## Input
+
+From `triage-ticket`: ticket key, summary, acceptance criteria, affected packages.
+Re-read anytime with `tkt view "$KEY" --json`.
+
+## Steps
+
+### 1. Read existing code
+
+For each affected package, read the relevant entry points (route handlers, types,
+schemas, tests, API specs). Keep this mapping in the project's own conventions
+doc — the skill is repo-agnostic.
+
+### 2. Identify change scope
+
+Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
+or shared-lib change. Note the typical files touched for each.
+
+### 3. Produce the plan
+
+```markdown
+## Implementation Plan — <KEY>
+
+### Summary
+<one sentence>
+
+### Changes
+1. `<path>` — <what to add/change>
+2. ...
+
+### Test Strategy
+- New tests: <describe>
+- Modified tests: <describe>
+- Regression: run the suite for affected packages
+
+### Risks
+- <anything that could go wrong / external schema or API deps>
+
+### Out of Scope
+- <things this ticket does NOT cover>
+
+### Estimated Size
+- ~<N> files, ~<N> lines
+- If >400 lines: recommend splitting into <subtasks>
+```
+
+Build/test commands come from config — don't hardcode the toolchain:
+
+```shell
+tkt cfg build.build --pkg "<pkg>"     # e.g. pnpm turbo build --filter=<pkg>
+tkt cfg build.test  --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+### 4. Validate plan against acceptance criteria
+
+For each criterion in the ticket's `acceptance`, confirm the plan covers it.
+Note any gap.
+
+### 5. Check if the ticket needs splitting
+
+If estimated size > 400 lines:
+
+```shell
+tkt comment "$KEY" "Scope is large (~N lines). Recommend splitting into: 1) <sub>, 2) <sub>"
+```
+
+Pause and ask for confirmation before proceeding with a large ticket.
+
+## Output
+
+The implementation plan as structured markdown, ready to drive implementation.

--- a/.kiro/skills/respond-to-review/SKILL.md
+++ b/.kiro/skills/respond-to-review/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: respond-to-review
+description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+---
+
+# Respond to Review
+
+Read PR review comments (bot + human), address each, push fixes, loop until
+approved. Git host via `gh`; all ticketing via `tkt`. Repo/reviewers from
+`.sdlc/config.toml`.
+
+## Input
+
+- PR number (`$PR`)
+- Ticket key (`$KEY`)
+
+```shell
+REPO=$(tkt cfg vcs.repo); OWNER=${REPO%/*}; NAME=${REPO#*/}
+```
+
+## Ticket state during this skill
+
+A "changes requested" review puts the ticket in the `revise` lane. While
+addressing feedback, move it back to `in_progress`; after pushing fixes and
+re-requesting review, move to `review`. Both are agent-driven → annotate lane time
+with `tkt worklog`:
+
+```shell
+# Exiting revise → in_progress:
+WL=$(tkt worklog "$KEY" --from-role revise --note "Addressing review feedback" --json)
+tkt transition "$KEY" in_progress
+tkt comment "$KEY" "Addressing review feedback. Time in Revise: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+(Skip the revise annotation if the ticket wasn't in `revise` — e.g. first review
+round straight from `review`.)
+
+## Steps
+
+### 1. Fetch review comments (bot + humans)
+
+```shell
+gh pr view "$PR" --repo "$REPO" --json reviews,reviewRequests,comments,reviewDecision
+
+# Inline comments — always paginate.
+gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100" \
+  --jq '.[] | {id, path, line, body, user: .user.login, in_reply_to_id}'
+```
+
+Identify automated-reviewer comments by `user.login` (e.g. `*copilot*[bot]`, or
+whatever your `vcs.reviewers` lists). Track unresolved ones separately.
+
+Resolved-thread state (paginate via `pageInfo.hasNextPage`):
+
+```shell
+CURSOR=null
+while : ; do
+  RESP=$(gh api graphql -f query='
+    query($owner:String!, $repo:String!, $pr:Int!, $after:String) {
+      repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
+        reviewThreads(first:100, after:$after) {
+          pageInfo { hasNextPage endCursor }
+          nodes { id isResolved comments(first:1){ nodes { author{login} body } } }
+        } } } }' \
+    -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CURSOR")
+  echo "$RESP" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
+  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<"$RESP")" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<"$RESP")
+done
+```
+
+### 2. Categorize each comment
+
+Change request → make the change. Question → reply. Suggestion → apply if valid,
+else explain. Nit → apply. Blocker → must fix. Out of scope → acknowledge, create
+a follow-up with `tkt create` if warranted.
+
+### 3. Address change requests
+
+For each: make the change, verify it builds/tests (`tkt cfg build.*`), reply on the
+thread:
+
+```shell
+gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
+  -f body="Fixed in <sha>. <brief explanation>"
+```
+
+### 4. Reply to questions
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "Re: <question> — <answer>"
+```
+
+### 5. Commit and push
+
+```shell
+git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+```
+
+### 6. Re-request review + move back to review lane
+
+```shell
+for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
+  gh api -X POST "repos/$OWNER/$NAME/pulls/$PR/requested_reviewers" -f "reviewers[]=$R" 2>/dev/null || true
+done
+
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — fixes pushed, re-review requested" --json)
+tkt transition "$KEY" review
+tkt comment "$KEY" "Pushed fixes, re-requested review. Time in In Progress (revise cycle): \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+### 7. Loop until clean
+
+Re-fetch after each push. Exit only when **all** hold:
+
+- No automated-reviewer comments on unresolved threads
+- `reviewDecision == APPROVED` (a pending/`REVIEW_REQUIRED` state is NOT enough)
+- No new comments in the last poll
+
+Cap at **5** cycles. If a bot repeats the same nit after 2 attempts, reply with a
+one-line "won't fix" justification and resolve the thread.
+
+### 8. If stuck after 5 cycles
+
+```shell
+gh pr comment "$PR" --repo "$REPO" --body "5 review cycles complete. Remaining items need human judgment — requesting sync review."
+WL=$(tkt worklog "$KEY" --from-role review --note "Review cycling unresolved after 5 attempts" --json)
+tkt comment "$KEY" "Review cycling unresolved after 5 attempts — needs human sync. \
+Time in review so far: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+(`$KEY` is the ticket; `$PR` is the PR number — unrelated. Always pass `$PR`
+explicitly to `gh pr comment`.)
+
+### 9. On loop exit, annotate review lane time
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role review --note "Review loop complete. Cycles: <N>" --json)
+tkt comment "$KEY" "Review loop complete. Cycles: <N>. Time in review (this round): \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items

--- a/.kiro/skills/resume-from-revise/SKILL.md
+++ b/.kiro/skills/resume-from-revise/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: resume-from-revise
+description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+---
+
+# Resume From Revise
+
+Picks up tickets that landed in `revise` after a failed QA round and a human dev
+fix. Re-enters the automation loop. Ticketing via `tkt`; build via `tkt cfg`.
+
+Invoke as `/resume-from-revise <KEY>` or `/resume-from-revise` (infer from branch).
+
+## Steps
+
+### 1. Resolve the ticket
+
+If no arg, infer from branch (`feature/<key-lower>-...` → `<KEY>`).
+
+```shell
+tkt view "$KEY" --json | jq -r .status_role   # must be "revise"
+```
+
+If not `revise`, stop and ask.
+
+### 2. Annotate revise time
+
+```shell
+WL=$(tkt worklog "$KEY" --from-role revise --note "Resuming from revise — human fix complete" --json)
+tkt comment "$KEY" "Resuming from revise — fix complete. Time in Revise: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+### 3. Transition back to in_progress
+
+```shell
+tkt transition "$KEY" in_progress
+```
+
+The agent owns the work again while it pushes/re-reviews.
+
+### 4. Verify local state (config toolchain)
+
+```shell
+git status
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+```
+
+If tests fail: stop and surface. Do not push broken code.
+
+### 5. Push
+
+```shell
+git push
+```
+
+### 6. Re-run automation subset
+
+In sequence: `ci-fix` → `respond-to-review` → `deploy-preview`. Each annotates its
+own added time via `tkt worklog` on exit.
+
+### 7. Promote back to qa_ready
+
+Verify approval first (same canonical criterion as `respond-to-review`):
+
+```shell
+REPO=$(tkt cfg vcs.repo)
+DECISION=$(gh pr view "$PR" --repo "$REPO" --json reviewDecision --jq .reviewDecision)
+[ "$DECISION" != "APPROVED" ] && { echo "PR not approved (decision=${DECISION:-pending})"; exit 1; }
+
+# Annotate the in_progress portion of this revise cycle.
+WL1=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — in_progress portion" --json)
+
+# respond-to-review may already have moved it to review; only transition if not.
+CUR=$(tkt view "$KEY" --json | jq -r .status_role)
+[ "$CUR" != "review" ] && tkt transition "$KEY" review
+WL2=$(tkt worklog "$KEY" --from-role review --note "Revise cycle — re-review portion" --json)
+
+tkt transition "$KEY" qa_ready
+tkt comment "$KEY" "Re-review complete and approved. Back in qa_ready — preview updated: <url>. \
+In Progress (revise): $(echo "$WL1" | jq -r .human) (worklog $(echo "$WL1" | jq -r .worklog_id)) | \
+review (re-review): $(echo "$WL2" | jq -r .human) (worklog $(echo "$WL2" | jq -r .worklog_id))."
+```
+
+QA picks it back up.
+
+## Output
+
+- PR URL, preview URL
+- Total time added by the revise cycle

--- a/.kiro/skills/select-ticket/SKILL.md
+++ b/.kiro/skills/select-ticket/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: select-ticket
+description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
+allowed-tools: [Bash, Read]
+---
+
+# Select Ticket
+
+Entry point for the automated SDLC. Finds the right ticket to work next.
+**All ticketing access goes through `tkt`** (the provider-agnostic CLI) — this
+skill never calls Jira/GitHub/Linear directly. Backend + board shape come from
+`.sdlc/config.toml`.
+
+**Auto-selects at Tier 1 or Tier 2** (top candidate after the query's own sort;
+first hit wins, never blocks on ties). Tiers 3–5 only ever return a ranked
+recommendation list and wait for a human pick — the agent never auto-selects
+unassigned work.
+
+## Prerequisites
+
+- `tkt doctor` passes (auth + board model reachable).
+- `tkt` on PATH (or invoke via its path, e.g. `~/Development/tkt/tkt`).
+
+## Selection tiers (stop at first non-empty)
+
+Tiers map to named queries in `.sdlc/config.toml` `[queries]` (`tier1`…`tier5`).
+The default mapping mirrors the original flow:
+
+```
+Tier 1: To Do + Highest priority + assigned to me   → auto-select
+Tier 2: To Do + any priority     + assigned to me   → auto-select (query sorts by priority)
+Tier 3: To Do + Highest priority + unassigned       → recommend (human picks)
+Tier 4: To Do + any priority     + unassigned       → recommend (human picks)
+Tier 5: Backlog                                       → recommend for promotion
+```
+
+A project that doesn't define a given tier query simply skips it (see Steps).
+
+## Steps
+
+### 1. Identify current user
+
+```shell
+tkt whoami
+```
+
+`currentUser()` inside the tier queries is resolved by the provider, so no email
+variable is needed.
+
+### 2. Run tiers in order until one returns selectable tickets
+
+```shell
+TKT=tkt   # or the repo path, e.g. ~/Development/tkt/tkt
+
+# is_blocked KEY -> prints "1" if the ticket has unresolved blockers.
+is_blocked() { [ "$("$TKT" blockers "$1" --json | jq 'length')" -gt 0 ] && echo 1; }
+
+for N in 1 2 3 4 5; do
+  # A defined-but-empty tier exits 0 with []; an undefined tier exits non-zero.
+  OUT=$("$TKT" list --tier "$N" --json 2>/dev/null) || continue
+  [ "$(echo "$OUT" | jq 'length')" -gt 0 ] || continue
+
+  # Filter blockers per-candidate via `tkt blockers` (authoritative on every
+  # backend — some list paths don't carry link data, e.g. Jira via acli).
+  SELECTABLE='[]'
+  for K in $(echo "$OUT" | jq -r '.[].key'); do
+    [ -n "$(is_blocked "$K")" ] && continue
+    SELECTABLE=$(echo "$OUT" | jq --arg k "$K" --argjson acc "$SELECTABLE" \
+      '$acc + [.[] | select(.key == $k)]')
+  done
+  [ "$(echo "$SELECTABLE" | jq 'length')" -gt 0 ] || continue
+
+  echo "TIER=$N"
+  echo "$SELECTABLE" > /tmp/tkt_candidates.json
+  break
+done
+```
+
+`tkt blockers` returns only **unresolved** blockers (a blocker that's Done is
+dropped), so a non-empty result means genuinely blocked.
+
+### 3. Auto-select (Tier 1 / Tier 2) or recommend (Tier 3+)
+
+- **Tier 1 or 2** → pick the first selectable candidate (assigned work is implicit
+  consent), emit `SELECTED: <KEY>`, hand off to `triage-ticket`.
+
+  ```shell
+  if [ "$TIER" = "1" ] || [ "$TIER" = "2" ]; then
+    KEY=$(jq -r '.[0].key' /tmp/tkt_candidates.json)
+    echo "SELECTED: $KEY"
+  fi
+  ```
+
+- **Tier 3 / 4 / 5** → print up to 5 ranked recommendations and stop. Do not
+  transition. Include **Type** (and `type_class`) so the reader knows whether the
+  ticket runs the full SDLC (`full_sdlc`) or the deliverable short-circuit.
+
+### Recommendation output format
+
+| Key | Type | type_class | Priority | Summary | Effort (S/M/L) | Est. tokens | Est. wall time | Blockers? | Why this one |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+Estimate guidance:
+
+- **Effort**: S ≤ 100 LOC, M 100–400, L > 400 (infer from acceptance criteria).
+- **Tokens**: S ≈ 50k, M ≈ 150k, L ≈ 400k.
+- **Wall time**: S ≈ 30 min, M ≈ 2 h, L ≈ half-day (excl. human review).
+- **Why this one**: one line citing priority, dependency readiness, or alignment.
+
+For Tier 5, label them "promotion candidates — in backlog, not To Do; promote one
+to To Do before work starts."
+
+## Output
+
+- `SELECTED: <KEY>` (auto path) → proceed to `triage-ticket`
+- OR a recommendation table with a clear "waiting for pick" message

--- a/.kiro/skills/self-review/SKILL.md
+++ b/.kiro/skills/self-review/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: self-review
+description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+---
+
+# Self-Review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass,
+BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
+`.sdlc/config.toml` via `tkt cfg`; this skill has no ticketing coupling.
+
+## Steps
+
+### 1. Generate the diff
+
+```shell
+git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
+```
+
+### 2. Review as adversary
+
+Hostile-reviewer mindset. Check every changed file for:
+
+| Category | Look for |
+| --- | --- |
+| **Security** | injection, auth bypass, secrets in code, unvalidated input |
+| **Types** | unjustified loose types, missing null checks, unguarded casts |
+| **Errors** | unhandled rejections, missing error responses, wrong status codes |
+| **Tests** | new code without tests; tests that assert nothing meaningful |
+| **Style** | project lint conventions; debug logging left in |
+| **Breaking** | changed shared exports / existing API contracts |
+| **Performance** | N+1 queries, missing indexes, unbounded loops, large payloads |
+| **Edge cases** | empty arrays, nulls, concurrency, expired tokens |
+
+Project-specific rules (import conventions, error types, logging) belong in the
+project's own conventions doc — read them and apply.
+
+### 3. List findings
+
+Per issue: file+line, severity (**blocker** / **warning** / **nit**), description,
+suggested fix.
+
+### 4. Fix blockers and warnings
+
+Fix all blocker + warning items. Don't skip.
+
+### 5. Rebuild and re-test (config toolchain)
+
+```shell
+eval "$(tkt cfg build.build --pkg "<pkg>")"
+eval "$(tkt cfg build.test --pkg "<pkg>")"
+eval "$(tkt cfg build.typecheck)"
+```
+
+### 6. Loop
+
+Repeat until a pass yields **zero blockers and zero warnings**. Max 3 passes; if
+still finding blockers, stop and flag for human review.
+
+## Output
+
+- Passes completed
+- Issues found/fixed (count by severity)
+- Remaining nits
+- Confidence: high / medium / low

--- a/.kiro/skills/triage-ticket/SKILL.md
+++ b/.kiro/skills/triage-ticket/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: triage-ticket
+description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
+allowed-tools: [Bash, Read, Edit]
+---
+
+# Triage Ticket
+
+Read a ticket, extract actionable requirements, transition to the `in_progress`
+lane, and start time tracking. All access via `tkt`; backend/board from
+`.sdlc/config.toml`.
+
+## Prerequisites
+
+- `tkt doctor` passes.
+
+## Lanes
+
+Skills speak in **roles**, not literal lane names. The default board roles:
+
+```
+backlog → todo → in_progress → review → qa_ready → qa → deploy_ready → done
+```
+
+Side roles: `revise`, `blocked`, `cancelled`. Resolve a role to the provider's
+actual lane string with `tkt lane <role>` when you need to print it.
+
+## Input
+
+- Ticket key (e.g. from `select-ticket`). If none provided, invoke `select-ticket`
+  first rather than asking.
+
+## Steps
+
+### 1. Read the ticket
+
+```shell
+tkt view "$KEY" --json > /tmp/tkt_ticket.json
+```
+
+Extract from the normalized shape:
+
+- `type` + `type_class` — `full_sdlc` (Story/Bug) vs `deliverable` (Task/Epic/…);
+  drives Phase 1.5 routing in `automated-sdlc`.
+- `summary`, `description`, `acceptance`
+- `labels`, `components`, `priority`
+- `blocked_by` (unresolved entries mean you should not have been routed here)
+
+### 2. Identify affected packages
+
+Map ticket content (summary/description/labels/components) to your repo's
+packages. Keep a project-specific keyword→package table in the project's own docs
+or `CLAUDE.md`; this skill stays generic. Example shape:
+
+| Keyword | Package |
+| --- | --- |
+| auth, JWT, token | `@scope/auth` |
+| cart, hold | `@scope/cart-service` |
+
+### 3. Move to In Progress
+
+```shell
+tkt transition "$KEY" in_progress
+```
+
+### 4. Start time tracking
+
+Entry time is recorded implicitly by the provider's history/changelog; `tkt
+worklog ... --from-role in_progress` later computes elapsed time from this entry.
+Nothing to do here beyond the transition.
+
+### 5. Add a work-start comment
+
+```shell
+tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+```
+
+## Output
+
+Provide to the next skill:
+
+- Ticket key
+- `type` + `type_class` (so the orchestrator routes full SDLC vs deliverable)
+- Summary
+- Acceptance criteria (bullet list)
+- Affected packages
+- Any blockers/unknowns identified

--- a/.opencode/commands/deploy-ready.md
+++ b/.opencode/commands/deploy-ready.md
@@ -1,0 +1,17 @@
+---
+description: Pick up deploy_ready tickets, merge PR, watch staging, gate prod deploy via tkt
+---
+
+Deploy the ticket: $ARGUMENTS
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+Repo/workflow names from `tkt cfg`. Production deploy is manual. `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.opencode/commands/open-pr.md
+++ b/.opencode/commands/open-pr.md
@@ -1,0 +1,15 @@
+---
+description: Commit, push, open a PR, request reviewers, and move the ticket to review via tkt
+---
+
+Open a PR for ticket: $ARGUMENTS
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch: `git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)`.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo) --title "..." --body "..."`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate with `tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL"` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+Repo/reviewers from `tkt cfg`. Conventional Commits. `tkt worklog` is a no-op when time tracking is disabled.

--- a/.opencode/commands/plan-ticket.md
+++ b/.opencode/commands/plan-ticket.md
@@ -1,0 +1,28 @@
+---
+description: Produce a structured implementation plan from a triaged ticket
+---
+
+Produce a structured implementation plan for ticket: $ARGUMENTS
+
+Planning happens BEFORE any code changes.
+
+1. Read the ticket with `tkt view "$KEY" --json` and extract key, summary, acceptance criteria, and affected packages.
+2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc.
+3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+4. Produce a markdown plan with these sections:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy (new / modified / regression)
+   - Risks (including external schema/API deps)
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered by the plan. Note any gap.
+6. If estimated size > 400 lines, comment on the ticket recommending sub-tasks, then pause for confirmation before proceeding.
+
+Build/test commands come from config — never hardcode the toolchain:
+
+- `tkt cfg build.build --pkg "<pkg>"`
+- `tkt cfg build.test --pkg "<pkg>"`
+- `tkt cfg build.typecheck`
+
+Output the plan as structured markdown, ready to drive implementation.

--- a/.opencode/commands/respond-to-review.md
+++ b/.opencode/commands/respond-to-review.md
@@ -1,0 +1,17 @@
+---
+description: Read PR review comments, address each, push fixes, and loop until approved via tkt
+---
+
+Respond to PR review feedback for ticket: $ARGUMENTS
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize each comment: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+If stuck after 5 cycles, comment and escalate to human sync.
+
+`tkt worklog` is a no-op when time tracking is disabled.

--- a/.opencode/commands/select-ticket.md
+++ b/.opencode/commands/select-ticket.md
@@ -1,0 +1,19 @@
+---
+description: Discover and select the next ticket to work on via tkt
+---
+
+Discover and select the next ticket to work on: $ARGUMENTS
+
+1. Verify `tkt doctor` passes and `tkt` is on PATH.
+2. Identify current user: `tkt whoami`.
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets:
+   - `tkt list --tier N --json`
+   - Filter out blocked tickets with `tkt blockers KEY --json`.
+4. If Tier 1 or 2 (assigned work): auto-select the first candidate, emit `SELECTED: <KEY>`, and proceed to `triage-ticket`.
+5. If Tier 3/4/5: print up to 5 ranked recommendations and wait for a human pick.
+
+Recommendation table: Key | Type | type_class | Priority | Summary | Effort (S/M/L) | Est. tokens | Est. wall time | Blockers? | Why this one
+
+Estimate guidance: S ≤ 100 LOC / ~50k tokens / ~30 min; M 100–400 LOC / ~150k tokens / ~2 h; L > 400 LOC / ~400k tokens / half-day.
+
+Never auto-select unassigned work. All ticketing access goes through `tkt`.

--- a/.opencode/commands/self-review.md
+++ b/.opencode/commands/self-review.md
@@ -1,0 +1,14 @@
+---
+description: Adversarial self-review of changes before PR via tkt config
+---
+
+Run an adversarial self-review of the current branch's changes: $ARGUMENTS
+
+1. Generate the diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings with file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.build --pkg "<pkg>"`, `tkt cfg build.test --pkg "<pkg>"`, `tkt cfg build.typecheck`.
+6. Loop until zero blockers and warnings. Max 3 passes; escalate if still finding blockers.
+
+Output: passes completed, issues by severity, remaining nits, confidence.

--- a/.opencode/commands/triage-ticket.md
+++ b/.opencode/commands/triage-ticket.md
@@ -1,0 +1,14 @@
+---
+description: Read a ticket, move it to in_progress, and start work via tkt
+---
+
+Triage the ticket and move it to In Progress: $ARGUMENTS
+
+1. Read the ticket with `tkt view "$KEY" --json` and extract key, type + type_class, summary, acceptance, labels, components, and blocked_by.
+2. Identify affected packages from ticket content.
+3. Move the ticket to `in_progress`: `tkt transition "$KEY" in_progress`.
+4. Add a work-start comment: `tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"`.
+
+Output to the next skill: ticket key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+Never transition a blocked ticket. Speak in roles, not literal lane names.

--- a/.windsurf/workflows/deploy-ready.md
+++ b/.windsurf/workflows/deploy-ready.md
@@ -1,0 +1,27 @@
+# /deploy-ready
+
+Pick up tickets in `deploy_ready`, annotate QA lane times, merge the PR, watch staging, gate manual production deploy. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Find deploy_ready tickets: `tkt list --query deploy_ready --json`.
+2. Annotate QA-lane times: `tkt lane-time "$KEY" --role qa_ready`, `qa`, `deploy_ready`.
+3. Find the PR: `gh pr list --repo $(tkt cfg vcs.repo) --search "$KEY in:title,body"`.
+4. Merge: `gh pr merge "$PR" --repo $(tkt cfg vcs.repo) --$(tkt cfg vcs.merge) --auto`. Poll until `MERGED`.
+5. Watch staging workflow matched by merge commit SHA.
+6. Comment and hand off to QE.
+7. Present production deploy gate (manual).
+8. Monitor production deploy once triggered.
+9. Transition to `done` only if prod workflow truly deploys; otherwise leave in `deploy_ready`.
+
+## Output
+
+- Tickets transitioned (or left for human Done)
+- Production run URL
+- Any deploy friction
+
+## Rules
+
+- Repo/workflow names from `tkt cfg`.
+- Production deploy is manual.
+- `tkt lane-time` is a no-op when time tracking is disabled.

--- a/.windsurf/workflows/open-pr.md
+++ b/.windsurf/workflows/open-pr.md
@@ -1,0 +1,24 @@
+# /open-pr
+
+Commit staged changes, push the branch, open a PR, request reviewers, and move the ticket to `review`. Ticketing via `tkt`; Git host via `gh`.
+
+## Steps
+
+1. Stage and commit: `git add -A && git commit -m "<type>(<scope>): <description>"`.
+2. Rebase on default branch: `git fetch origin && git rebase origin/$(tkt cfg vcs.default_branch)`.
+3. Push: `git push -u origin HEAD`.
+4. Create PR with `gh pr create --repo $(tkt cfg vcs.repo)`.
+5. Request reviewers from `tkt cfg vcs.reviewers --json`.
+6. If `type_class == full_sdlc`: annotate with `tkt worklog` then `tkt transition "$KEY" review`.
+7. If `deliverable`: comment and stay in `in_progress`.
+
+## Output
+
+- PR URL + number
+- Reviewer status
+
+## Rules
+
+- Repo/reviewers from `tkt cfg`.
+- Conventional Commits.
+- `tkt worklog` is a no-op when time tracking is disabled.

--- a/.windsurf/workflows/plan-ticket.md
+++ b/.windsurf/workflows/plan-ticket.md
@@ -1,0 +1,37 @@
+# /plan-ticket
+
+Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
+3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+4. Produce a markdown plan:
+   - Summary (one sentence)
+   - Changes (numbered `path — what`)
+   - Test Strategy (new / modified / regression)
+   - Risks (including external schema/API deps)
+   - Out of Scope
+   - Estimated Size (~N files, ~N lines)
+5. Validate each acceptance criterion is covered.
+6. If >400 lines, comment on the ticket and pause for confirmation.
+
+Build/test commands come from config:
+```shell
+tkt cfg build.build --pkg "<pkg>"
+tkt cfg build.test --pkg "<pkg>"
+tkt cfg build.typecheck
+```
+
+## Output
+
+Structured markdown plan, ready to drive implementation.
+
+## Rules
+
+- Never hardcode the toolchain.
+- All ticketing access goes through `tkt`.

--- a/.windsurf/workflows/respond-to-review.md
+++ b/.windsurf/workflows/respond-to-review.md
@@ -1,0 +1,25 @@
+# /respond-to-review
+
+Read PR review comments, address each with code changes or replies, push fixes, loop until approved. Git host via `gh`; ticketing via `tkt`.
+
+## Steps
+
+1. Fetch review comments and decision with `gh pr view` and `gh api`.
+2. Categorize: change request → fix; question → reply; suggestion → apply if valid; nit → apply; blocker → must fix.
+3. Make changes and reply on threads.
+4. Commit and push: `git add -A && git commit -m "fix(<scope>): address review feedback" && git push`.
+5. Re-request reviewers from `tkt cfg vcs.reviewers --json`.
+6. Move ticket `revise → in_progress → review`, annotating lane time with `tkt worklog`.
+7. Loop until `reviewDecision == APPROVED` and no unresolved comments. Max 5 cycles.
+
+## Output
+
+- Review status: approved / changes requested / stuck
+- Comments addressed (count)
+- Outstanding items
+
+## Rules
+
+- `tkt worklog` is a no-op when time tracking is disabled.
+- Never argue with repeated bot nits; justify "won't fix" and resolve.
+- All ticketing access goes through `tkt`.

--- a/.windsurf/workflows/select-ticket.md
+++ b/.windsurf/workflows/select-ticket.md
@@ -1,0 +1,26 @@
+# /select-ticket
+
+Discover and select the next ticket to work on via `tkt`.
+
+## Steps
+
+1. Verify `tkt doctor` passes and `tkt` is on PATH.
+2. Identify current user:
+   ```shell
+   tkt whoami
+   ```
+3. Run tiers 1–5 from `.sdlc/config.toml [queries]` until one returns selectable tickets.
+4. Filter out blocked tickets with `tkt blockers KEY --json`.
+5. **Tier 1/2** (assigned): auto-select, emit `SELECTED: <KEY>`, proceed to `triage-ticket`.
+6. **Tier 3/4/5** (unassigned/backlog): print up to 5 ranked recommendations and wait for human pick.
+
+## Recommendation format
+
+| Key | Type | type_class | Priority | Summary | Effort | Est. tokens | Est. wall time | Blockers? | Why this one |
+
+Estimate guidance: S ≤ 100 LOC / ~50k tokens / ~30 min; M 100–400 LOC / ~150k tokens / ~2 h; L > 400 LOC / ~400k tokens / half-day.
+
+## Rules
+
+- Never auto-select unassigned work.
+- All ticketing access goes through `tkt`.

--- a/.windsurf/workflows/self-review.md
+++ b/.windsurf/workflows/self-review.md
@@ -1,0 +1,24 @@
+# /self-review
+
+Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
+
+## Steps
+
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
+3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
+4. Fix all blockers and warnings.
+5. Rebuild/re-test via `tkt cfg build.*`.
+6. Loop until zero blockers and warnings. Max 3 passes.
+
+## Output
+
+- Passes completed
+- Issues found/fixed by severity
+- Remaining nits
+- Confidence: high / medium / low
+
+## Rules
+
+- Toolchain comes from `tkt cfg`.
+- Max 3 passes; escalate if still finding blockers.

--- a/.windsurf/workflows/triage-ticket.md
+++ b/.windsurf/workflows/triage-ticket.md
@@ -1,0 +1,29 @@
+# /triage-ticket
+
+Read a ticket, extract requirements, transition to `in_progress`, and start tracking. All access via `tkt`.
+
+## Steps
+
+1. Read the ticket:
+   ```shell
+   tkt view "$KEY" --json
+   ```
+   Extract: key, type + type_class, summary, acceptance, labels, components, blocked_by.
+2. Identify affected packages from ticket content.
+3. Move to In Progress:
+   ```shell
+   tkt transition "$KEY" in_progress
+   ```
+4. Add a work-start comment:
+   ```shell
+   tkt comment "$KEY" "Starting work. Affected packages: <pkg1>, <pkg2>"
+   ```
+
+## Output
+
+Provide to the next skill: key, type + type_class, summary, acceptance criteria, affected packages, blockers/unknowns.
+
+## Rules
+
+- Speak in roles, not literal lane names.
+- Never transition a blocked ticket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md — tkt Project Guide
+
+This repo is **`tkt`**, a provider-agnostic ticketing CLI plus a portable SDLC
+skill pack. The pack's skills speak semantic verbs (`tkt view`, `tkt transition`,
+...) and never touch a concrete backend. `tkt` reads `.sdlc/config.toml`,
+dispatches to the configured provider adapter, and normalizes every backend into
+one JSON ticket shape.
+
+Use this file as the root fallback when your harness does not have a dedicated
+per-tool folder (Cursor rules, Windsurf rules, OpenCode instructions, etc. are in
+separate harness-specific files).
+
+## Core portability rules
+
+1. **No backend specifics in workflow logic.**
+   - Use `tkt view`, `tkt transition`, `tkt comment`, `tkt blockers`,
+     `tkt worklog`, `tkt lane-time`, `tkt list`, `tkt create`, `tkt link`.
+   - Never call `acli`, `gh issue`, Jira REST, Linear GraphQL, or any other
+     backend API directly for ticketing.
+
+2. **No repo/toolchain hardcoding.**
+   - Read values through `tkt cfg`:
+     - `tkt cfg vcs.repo`
+     - `tkt cfg vcs.default_branch`
+     - `tkt cfg vcs.merge`
+     - `tkt cfg vcs.reviewers --json`
+     - `tkt cfg vcs.branch_fmt --ticket K --slug s`
+     - `tkt cfg build.build --pkg X`
+     - `tkt cfg build.test --pkg X`
+     - `tkt cfg build.typecheck`
+     - `tkt cfg deploy.staging_workflow`
+     - `tkt cfg deploy.production_workflow`
+   - Never hardcode repo names, branch names, workflow names, or build commands.
+
+3. **Speak in roles, not lane names.**
+   - Canonical roles: `backlog`, `todo`, `in_progress`, `review`, `qa_ready`,
+     `qa`, `deploy_ready`, `done`, plus side roles `revise`, `blocked`,
+     `cancelled`.
+   - Use `tkt transition KEY review` to move.
+   - Use `tkt lane review` only when you need the provider's literal lane string.
+
+4. **Respect `type_class` routing.**
+   - `full_sdlc` (Story/Bug): runs select → triage → plan → implement →
+     self-review → open-pr → respond-to-review → deploy-ready.
+   - `deliverable` (Task/Epic/Spike/Chore): short-circuits via
+     `complete-deliverable` straight to `done`.
+
+5. **`tkt worklog` / `tkt lane-time` are safe no-ops.**
+   - When `[timetracking].provider = "none"`, these return empty worklogs.
+   - Comments should still read naturally (e.g. "Time in In Progress: (no time
+     tracking)").
+
+## Verb contract (quick reference)
+
+| Command | Purpose |
+|---------|---------|
+| `tkt whoami` | current user id |
+| `tkt list --tier N` / `--query NAME` | run named query from config |
+| `tkt view KEY --json` | normalized ticket |
+| `tkt transition KEY ROLE` | move ticket to role's lane |
+| `tkt comment KEY BODY` | post activity comment |
+| `tkt blockers KEY --json` | unresolved blockers only |
+| `tkt worklog KEY --from-role ROLE [--note T]` | log time since entry → now |
+| `tkt lane-time KEY --role ROLE` | log time for closed lane interval |
+| `tkt create --type T --summary S ...` | create a ticket (adapter-opt-in) |
+| `tkt link KEY --to OTHER --type T` | link tickets (adapter-opt-in) |
+| `tkt lane ROLE` | resolve role → provider lane name |
+| `tkt cfg DOTTED.KEY ...` | read config + template substitution |
+| `tkt doctor` | validate auth + reachability + board model |
+
+## SDLC skill pack
+
+Canonical source: `skills/<name>/SKILL.md`. Harness-specific translations live in
+per-tool folders (`.opencode/commands/`, `.cursor/commands/`, `.cursor/skills/`,
+`.continue/prompts/`, `.windsurf/workflows/`, `.clinerules/workflows/`,
+`.augment/commands/`, `.agents/workflows/`, `.agents/skills/`, `.kiro/skills/`,
+`.github/prompts/`, `.gemini/commands/`).
+
+| Skill | Purpose |
+|-------|---------|
+| `select-ticket` | pick next ticket (tiered queries + blocker filter) |
+| `triage-ticket` | read ticket + move to `in_progress` |
+| `plan-ticket` | structured implementation plan before coding |
+| `open-pr` | commit/push/PR/reviewers + `→ review` with lane-time |
+| `self-review` | adversarial pre-PR review loop |
+| `respond-to-review` | address review comments, `revise ↔ review` loop |
+| `deploy-ready` | merge, watch staging, gate prod, QA lane-times |
+| `automated-sdlc` | orchestrator across all of the above |
+| `check-blockers` | classify blocked tickets, recommend unblocks |
+| `ci-fix` | watch CI, diagnose, fix, loop until green |
+| `complete-deliverable` | short-circuit `→ done` for deliverable types |
+| `deploy-preview` | confirm preview env, post URL to ticket + PR |
+| `hotfix-revert` | fast-track prod revert |
+| `resume-from-revise` | re-enter the loop after a human revise fix |
+
+## Meta
+
+- `skills/sync-skills/SKILL.md` documents how to translate the canonical skills
+  into each harness format.
+- `agents/ticket-researcher.md` is the read-only lookup subagent.
+- This repo is pure stdlib Python 3.11+; no build step.
+
+## When in doubt
+
+- Run `tkt doctor` to validate a project's config.
+- Run `tkt view KEY --json` to see the normalized shape.
+- Run `tkt cfg <dotted.key> --help` is not supported; consult
+  `.sdlc/config.toml` or `examples/config.<provider>.toml`.

--- a/skills/sync-skills/SKILL.md
+++ b/skills/sync-skills/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: sync-skills
+description: 'When a skill is created or updated in skills/, generate the translated versions for all other agent/IDE platforms.'
+---
+
+# Sync Skills
+
+When a new skill is created (or an existing skill is significantly updated) in
+`skills/<name>/SKILL.md`, generate equivalent files for all supported agent
+platforms.
+
+## Source of Truth
+
+`skills/<name>/SKILL.md` is always the canonical version. All other locations are
+derived from it.
+
+## Target Locations
+
+### Tier A — Per-skill invocable workflows (sync every skill)
+
+These tools support discrete, invocable workflows. Every skill (except meta/internal
+ones — see "When NOT to Sync") gets a copy here.
+
+| # | Location | Format | Used By |
+|---|----------|--------|---------|
+| 1 | `.agents/skills/<name>/SKILL.md` | Agent Skills (YAML + MD) | Antigravity, JetBrains Junie |
+| 2 | `.kiro/skills/<name>/SKILL.md` | Agent Skills (YAML + MD) | AWS Kiro |
+| 3 | `.github/prompts/<name>.prompt.md` | Copilot Prompt (YAML + MD) | GitHub Copilot |
+| 4 | `.gemini/commands/<name>.toml` | TOML | Gemini CLI |
+
+### Tier B — Selective per-skill workflows (sync the high-value ~7 only)
+
+These tools support invocable workflows but the spec favors a curated set. Sync the
+core SDLC pipeline skills: `select-ticket`, `triage-ticket`, `plan-ticket`,
+`open-pr`, `self-review`, `respond-to-review`, `deploy-ready`.
+
+| Location | Format | Used By |
+|----------|--------|---------|
+| `.cursor/skills/<name>/SKILL.md` | Skill MD + YAML | Cursor |
+| `.cursor/commands/<name>.md` | Plain command MD | Cursor |
+| `.windsurf/workflows/<name>.md` | Workflow MD | Windsurf |
+| `.clinerules/workflows/<name>.md` | Workflow MD | Cline |
+| `.continue/prompts/<name>.prompt` | Prompt MD + YAML | Continue |
+| `.augment/commands/<name>.md` | Command MD | Augment |
+| `.agents/workflows/<name>.md` | Workflow MD (`// turbo` markers) | Antigravity |
+| `.opencode/commands/<name>.md` | Command MD (`description` frontmatter; `$ARGUMENTS`; `!` backtick shell injection) | OpenCode |
+
+### Tier C — Rules-style targets (NOT per-skill; only when global conventions change)
+
+These tools consume project-wide rule files. **When a skill changes, do NOT sync to
+these locations.** Only update them if tkt conventions or project-wide guardrail
+policy change.
+
+| Location | Format | Used By |
+|----------|--------|---------|
+| `AGENTS.md` (root) | MD | Codex, Codex Cloud, Devin, T3Code, Zed, Amp, v0/Vercel, Cursor, Windsurf, Aider, Gemini CLI, Jules, Factory, Warp, Junie, Kilo, Augment, Ona, Phoenix, UiPath, Semgrep, Lovable, OpenCode |
+| `.cursor/rules/*.mdc` | Cursor MDC | Cursor |
+| `.windsurf/rules/*.md` | YAML + MD (`trigger:`) | Windsurf |
+| `.clinerules/*.md` | YAML + MD (`paths:`) | Cline |
+| `.continue/rules/*.md` | YAML + MD (`globs:`) | Continue.dev |
+| `.augment/rules/*.md` | YAML + MD (`type:`) | Augment Code |
+| `.agents/rules/*.md` | YAML + MD (`trigger:`) | Antigravity |
+
+Root `AGENTS.md` is the universal fallback. Sub-`AGENTS.md` cascading is honored by
+Codex, Kilo, Amp, Factory, and Windsurf; other tools fall back gracefully to root.
+OpenCode reads root `AGENTS.md` natively.
+
+### Tier D — Programmatic surfaces (NOT per-skill; configure once)
+
+These are per-tool programmatic config, not skill translations. Update only when
+guardrail policy or MCP servers change.
+
+| Location | Purpose |
+|----------|---------|
+| `.claude/settings.json` | Claude Code hooks, permissions, statusLine |
+| `.cursor/hooks.json` + `.cursor/scripts/` | Cursor guardrail hooks |
+| `.cursor/mcp.json` | Cursor MCP |
+| `.windsurf/hooks.json` + `.windsurf/scripts/` | Windsurf guardrail hooks |
+| `.windsurf/mcp_config.json` | Windsurf MCP |
+| `.continue/agents/*.yaml` | Continue agent personas |
+| `.augment/settings.json` | Augment MCP |
+| `.codex/config.toml` | Codex CLI approval policy |
+| `.openhands/microagents/repo.md` | OpenHands runtime bootstrap |
+
+## Format Templates
+
+### 1. Agent Skills Standard (`.agents/skills/` and `.kiro/skills/`)
+
+Identical to the source format:
+
+```markdown
+---
+name: <skill-name>
+description: <one-line description from source>
+---
+
+# <Title>
+
+<body — same markdown content as source skill>
+```
+
+### 2. GitHub Copilot Prompt (`.github/prompts/<name>.prompt.md`)
+
+Condensed version with Copilot-specific frontmatter:
+
+```markdown
+---
+mode: agent
+description: '<one-line description>'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# <Title>
+
+<condensed instructions — keep under ~60 lines>
+```
+
+Preserve the provider-agnostic rule: all ticketing goes through `tkt`, all
+repo/toolchain values come from `.sdlc/config.toml` via `tkt cfg`.
+
+### 3. Gemini CLI Command (`.gemini/commands/<name>.toml`)
+
+```toml
+description = "<one-line description>"
+
+prompt = """
+<instruction text>
+
+## Steps
+
+1. <step 1>
+2. <step 2>
+...
+"""
+```
+
+Use `{{args}}` for user-provided input. Use `!{<cmd>}` for shell expansions
+providing context (e.g. `!{git status --short}`). Use `@{path}` for file
+inclusions. No YAML, no markdown frontmatter — pure TOML.
+
+### 4. Cursor Skill (`.cursor/skills/<name>/SKILL.md`)
+
+```markdown
+---
+name: <skill-name>
+description: <one-line description>
+disable-model-invocation: true  # invoke as slash command, not auto
+---
+
+# <Title>
+
+<condensed instructions, ~40-60 lines>
+```
+
+### 5. Windsurf / Cline / Augment Workflow
+
+Plain markdown, ≤12KB. Slash-invokable as `/<name>`. No frontmatter required for
+Cline/Augment. Windsurf accepts optional frontmatter.
+
+### 6. Continue Prompt (`.continue/prompts/<name>.prompt`)
+
+```markdown
+---
+name: <skill-name>
+description: <one-line description>
+invokable: true
+---
+
+# <Title>
+
+<condensed instructions>
+```
+
+### 7. Antigravity Workflow (`.agents/workflows/<name>.md`)
+
+```markdown
+---
+name: <skill-name>
+description: <one-line description>
+trigger: manual
+---
+
+# <Title>
+
+<condensed instructions. Mark safe-to-auto commands with `// turbo` comment lines.>
+```
+
+### 8. OpenCode Command (`.opencode/commands/<name>.md`)
+
+```markdown
+---
+description: <one-line description>
+---
+
+<condensed instructions. Use `$ARGUMENTS` (all args) or `$1`, `$2` for positional
+input, and a bang-prefixed backtick command (`!<cmd>`) to inject live shell output,
+e.g. `!git status --short`.>
+```
+
+Markdown body is the prompt template. Optional frontmatter keys: `agent`, `model`,
+`subtask`. Guardrails are enforced separately by project config — not per-command.
+
+## Steps to Sync
+
+### 1. Identify the source skill
+
+Read `skills/<name>/SKILL.md` — extract `name`, `description`, and body.
+
+### 2. Tier A: byte-identical copies (always)
+
+Copy to:
+- `.agents/skills/<name>/SKILL.md`
+- `.kiro/skills/<name>/SKILL.md`
+
+### 3. Tier A: condensed translations (always)
+
+Translate to:
+- `.github/prompts/<name>.prompt.md` (~40-60 lines, `mode: agent` + `tools` array)
+- `.gemini/commands/<name>.toml` (TOML format, `{{args}}` for input)
+
+### 4. Tier B: selective workflows (only for high-value skills)
+
+If the skill is one of `select-ticket`, `triage-ticket`, `plan-ticket`, `open-pr`,
+`self-review`, `respond-to-review`, `deploy-ready`, also create:
+- `.cursor/skills/<name>/SKILL.md` + `.cursor/commands/<name>.md`
+- `.windsurf/workflows/<name>.md`
+- `.clinerules/workflows/<name>.md`
+- `.continue/prompts/<name>.prompt`
+- `.augment/commands/<name>.md`
+- `.agents/workflows/<name>.md` (with `// turbo` markers)
+- `.opencode/commands/<name>.md`
+
+### 5. Verify
+
+```shell
+NAME=<skill-name>
+for p in skills/$NAME/SKILL.md .agents/skills/$NAME/SKILL.md .kiro/skills/$NAME/SKILL.md .github/prompts/$NAME.prompt.md .gemini/commands/$NAME.toml; do
+  test -f "$p" && echo "✓ $p" || echo "✗ $p MISSING"
+done
+```
+
+For high-value skills additionally verify:
+```shell
+for p in .cursor/skills/$NAME/SKILL.md .cursor/commands/$NAME.md .windsurf/workflows/$NAME.md .clinerules/workflows/$NAME.md .continue/prompts/$NAME.prompt .augment/commands/$NAME.md .agents/workflows/$NAME.md .opencode/commands/$NAME.md; do
+  test -f "$p" && echo "✓ $p" || echo "✗ $p MISSING"
+done
+```
+
+## Current Skill Inventory
+
+`tkt` skills are the canonical source. Tier A targets get every non-meta skill.
+
+| Skill | Source | Agents | Kiro | Copilot | Gemini | Tier B? |
+|-------|--------|--------|------|---------|--------|---------|
+| automated-sdlc | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| check-blockers | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| ci-fix | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| complete-deliverable | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| deploy-preview | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| deploy-ready | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| hotfix-revert | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| open-pr | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| plan-ticket | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| respond-to-review | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| resume-from-revise | ✓ | ✓ | ✓ | ✓ | ✓ | |
+| select-ticket | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| self-review | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| triage-ticket | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+`sync-skills` itself is meta — only in `skills/`.
+
+**Tier B coverage**: the seven ✓ skills above should also exist in `.cursor/skills/`,
+`.cursor/commands/`, `.windsurf/workflows/`, `.clinerules/workflows/`,
+`.continue/prompts/`, `.augment/commands/`, `.agents/workflows/`, and
+`.opencode/commands/`.
+
+## When NOT to Sync
+
+- **Meta/internal skills** (like this one) — only in `skills/`.
+- **Skills that use harness-specific features** — adapt or skip for other platforms.
+- **Trivial updates** (typo fixes) — sync only if the fix is in commands or steps that
+  other platforms also show.
+- **Per-skill changes** — never propagate to Tier C (rules-style targets) or Tier D
+  (programmatic surfaces). Those only change when global conventions or guardrail
+  policy change.
+
+## Portability Rules for All Translations
+
+1. **No backend specifics.** Skills must call `tkt view`, `tkt transition`, etc.,
+   never `acli`, `gh issue`, Jira REST, or Linear GraphQL directly.
+2. **No repo/toolchain hardcoding.** Read values through `tkt cfg`
+   (e.g. `tkt cfg vcs.repo`, `tkt cfg build.test --pkg X`).
+3. **Speak in roles, not lane names.** Use `in_progress`, `review`, `done`, etc.;
+   resolve literal lane names with `tkt lane <role>` when needed.
+4. **Keep `type_class` branching.** `full_sdlc` vs `deliverable` drives whether a
+   ticket stops at `complete-deliverable` or runs the full PR/review/deploy loop.
+5. **Respect `tkt worklog` / `tkt lane-time` no-ops.** Backends with
+   `[timetracking].provider = "none"` return empty worklogs; comments should still
+   read naturally.
+
+## Platforms Explicitly Skipped (and Why)
+
+| Platform | Why skipped |
+|----------|-------------|
+| **Roo Code** | Service sunset 2026-05-15. Successor: **Kilo Code** (covered via root `AGENTS.md`). |
+| **T3Code** | Wraps OpenAI Codex CLI — covered via `AGENTS.md` + `.codex/`. |
+| **Sweep** | Adoption declining; uses `sweep.yaml` if revisited. |
+| **Replit Agent / v0 / bolt.new** | SaaS-only; honor `AGENTS.md` manually if needed. |
+| **Qodo** | PR-review only; would use `.pr_agent.toml` if adopted. |
+| **Aide / Codestory** | No documented project-rules file as of June 2026. |
+| **Sourcegraph Cody** | Maintenance mode; strategic agent is Amp (covered by `AGENTS.md`). |
+| **Tabnine / Tabby** | No team adoption; project-rules surfaces exist but server-side only. |
+| **Lovable / GitHub Spark** | Covered by `AGENTS.md` (Lovable) or Copilot config (Spark). |


### PR DESCRIPTION
## Summary

Generate harness-native translations for the tkt SDLC skill pack so users of OpenCode, Cursor, Continue, Windsurf, Cline, Augment, Antigravity, AWS Kiro, GitHub Copilot, and Gemini CLI get the same provider-agnostic workflows.

## Ticket

/Users/raymonddoran/Development/odnf/.sdlc/board/TKT-4.md

## Changes
- OpenCode commands (`.opencode/commands/`)
- Cursor commands + skills (`.cursor/`)
- Continue prompts (`.continue/prompts/`)
- Windsurf workflows (`.windsurf/workflows/`)
- Cline workflows (`.clinerules/workflows/`)
- Augment commands (`.augment/commands/`)
- Antigravity skills + workflows (`.agents/`)
- AWS Kiro skills (`.kiro/skills/`)
- GitHub Copilot prompts (`.github/prompts/`)
- Gemini CLI commands (`.gemini/commands/`)
- Root `AGENTS.md` fallback
- `skills/sync-skills/SKILL.md` meta skill documenting the porting matrix

Tier A coverage: all 14 non-meta skills.
Tier B coverage: 7 core SDLC skills (select, triage, plan, open-pr, self-review, respond-to-review, deploy-ready).

## Testing
- Verified all 114 generated files exist.
- Verified all 14 Gemini TOML files parse with Python `tomllib`.
- Verified no backend-specific direct calls leaked into translations.
- Verified OpenCode command frontmatter, Cursor command headers, and Cursor skill `disable-model-invocation` flags.

## Checklist
- [x] Tests added/updated
- [x] Lint/typecheck pass