### PR TITLE
feat(cli): batch lane-time verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Every adapter implements these. Read verbs accept `--json` (either side of the v
 | `tkt blockers KEY` | unresolved blockers only | list / `--json` |
 | `tkt worklog KEY --from-role ROLE [--note T] [--billable]` | log time since entry into ROLE's lane → now | worklog / `--json`; no-op if `[timetracking].provider="none"` |
 | `tkt lane-time KEY --role ROLE` | log time for an already-exited lane (entry→exit) | worklog / `--json` |
+| `tkt lane-time --keys K1:ROLE[,K2:ROLE,...] [--read-only]` | batch lane-time (one call, N keys) | JSON array of worklogs |
 | `tkt create --type T --summary S [--priority P] [--assignee A] [--body B] [--project P]` | create a ticket | new key / `--json` ticket |
 | `tkt link KEY --to OTHER --type T` | link KEY → OTHER (`T` = outward description: `blocks`, `is blocked by`, `Fixes`, …) | confirmation |
 | `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L]` | edit content/fields in place (only flags passed change; status excluded — use `transition`) | normalized ticket / `--json` |

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -60,6 +60,30 @@ class Adapter(ABC):
         in that mode the timetracking provider is ignored so the duration is
         available even when no time is being tracked."""
 
+    def lane_time_batch(
+        self,
+        keys_roles: list[tuple[str, str]],
+        read_only: bool = False,
+    ) -> list[Worklog]:
+        """Batch form of `lane_time`. Default implementation loops over single
+        calls; adapters for local/remote backends should override for efficiency.
+
+        Per-key failures (e.g. no history in the requested lane) degrade to a
+        Worklog with seconds=0 and human="" rather than aborting the whole batch.
+        Other failures propagate."""
+        out = []
+        for key, role in keys_roles:
+            try:
+                out.append(self.lane_time(key, role, read_only=read_only))
+            except ProviderError as e:
+                msg = str(e).lower()
+                if "no entry" in msg or "no transition" in msg:
+                    out.append(Worklog(key=key, role=role,
+                                     lane=self.config.role_to_lane(role)))
+                else:
+                    raise
+        return out
+
     @abstractmethod
     def doctor(self) -> list[Check]:
         """Validate auth + reachability + board model. Read-only."""

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -366,10 +366,8 @@ class JiraAdapter(Adapter):
         return Worklog(key=key, role=from_role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note=note)
 
-    def lane_time(self, key, role, read_only=False):
+    def _lane_time_for(self, key, role, read_only=False):
         lane = self.config.role_to_lane(role)
-        # read_only computes for display regardless of time tracking; the
-        # recording path stays a no-op when the provider tracks no time.
         if not read_only and not self._provider_tracks_time():
             return Worklog(key=key, role=role, lane=lane)
         entries = sorted(self._changelog_entries(key), key=lambda e: e[0])
@@ -393,6 +391,9 @@ class JiraAdapter(Adapter):
         self._mark_non_billable(wl_id, secs, body)
         return Worklog(key=key, role=role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note="retroactive")
+
+    def lane_time(self, key, role, read_only=False):
+        return self._lane_time_for(key, role, read_only=read_only)
 
     def doctor(self):
         checks = []

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -416,6 +416,38 @@ class MarkdownAdapter(Adapter):
         return Worklog(key=key, role=role, lane=lane, seconds=secs,
                        human=human_duration(secs), worklog_id=wl_id, note="retroactive")
 
+    def lane_time_batch(self, keys_roles, read_only=False):
+        out = []
+        for key, role in keys_roles:
+            lane = self.config.role_to_lane(role)
+            if not read_only and self.config.timetracking.get("provider", "none") == "none":
+                out.append(Worklog(key=key, role=role, lane=lane))
+                continue
+            history = sorted(self._read_history(key), key=lambda h: h["ts"])
+            last_in = None
+            for h in history:
+                if h["to"] == lane:
+                    last_in = _parse_iso(h["ts"])
+            if last_in is None:
+                out.append(Worklog(key=key, role=role, lane=lane))
+                continue
+            exit_dt = _now()
+            for h in history:
+                ts = _parse_iso(h["ts"])
+                if h["from"] == lane and ts > last_in:
+                    exit_dt = ts
+                    break
+            secs = max(int((exit_dt - last_in).total_seconds()), 60)
+            if read_only:
+                out.append(Worklog(key=key, role=role, lane=lane, seconds=secs,
+                                   human=human_duration(secs)))
+            else:
+                wl_id = self._append_worklog(key, role, lane, secs, "retroactive")
+                out.append(Worklog(key=key, role=role, lane=lane, seconds=secs,
+                                   human=human_duration(secs), worklog_id=wl_id,
+                                   note="retroactive"))
+        return out
+
     def doctor(self):
         checks = [
             Check("board_dir exists", self.board_dir.is_dir(), str(self.board_dir)),

--- a/core/cli.py
+++ b/core/cli.py
@@ -91,8 +91,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--billable", action="store_true")
 
     sp = add("lane-time")
-    sp.add_argument("key")
-    sp.add_argument("--role", required=True)
+    sp.add_argument("key", nargs="?")
+    sp.add_argument("--role", default=None)
+    sp.add_argument("--keys", default=None,
+                    help="comma-separated key:role pairs for batch mode "
+                         "(e.g. K1:todo,K2:in_progress); role defaults to --role")
     sp.add_argument("--read-only", action="store_true", dest="read_only",
                     help="compute and print the duration without recording a worklog")
 
@@ -149,6 +152,24 @@ def _subst(value: str, pkg: str, ticket: str, slug: str) -> str:
             .replace("{key-lower}", ticket.lower())
             .replace("{key}", ticket)
             .replace("{slug}", slug))
+
+
+def _parse_lane_time_keys(keys_arg: str, default_role: str | None) -> list[tuple[str, str]]:
+    pairs = []
+    for token in keys_arg.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if ":" in token:
+            key, role = token.split(":", 1)
+            pairs.append((key.strip(), role.strip()))
+        elif default_role:
+            pairs.append((token, default_role))
+        else:
+            raise UsageError(f"batch entry '{token}' has no role; use KEY:ROLE or pass --role")
+    if not pairs:
+        raise UsageError("--keys produced no key:role pairs")
+    return pairs
 
 
 def main(argv: list[str]) -> int:
@@ -230,14 +251,27 @@ def main(argv: list[str]) -> int:
                 print(f"{wl.key}  {wl.role}: {wl.human}  worklog={where}")
 
         elif args.verb == "lane-time":
-            wl = adapter.lane_time(args.key, args.role, read_only=args.read_only)
-            if args.json:
-                print(json.dumps(wl.to_dict(), indent=2))
-            elif args.read_only:
-                print(f"{wl.key}  {wl.role}: {wl.human}")
+            if args.keys:
+                pairs = _parse_lane_time_keys(args.keys, args.role)
+            elif args.key:
+                if not args.role:
+                    raise UsageError("--role is required when a single KEY is given")
+                pairs = [(args.key, args.role)]
             else:
-                where = wl.worklog_id or "(no time tracking)"
-                print(f"{wl.key}  {wl.role}: {wl.human}  worklog={where}")
+                raise UsageError("provide either KEY or --keys")
+            results = adapter.lane_time_batch(pairs, read_only=args.read_only)
+            if args.json:
+                if args.keys:
+                    print(json.dumps([wl.to_dict() for wl in results], indent=2))
+                else:
+                    print(json.dumps(results[0].to_dict(), indent=2))
+            else:
+                for wl in results:
+                    if args.read_only:
+                        print(f"{wl.key}  {wl.role}: {wl.human}")
+                    else:
+                        where = wl.worklog_id or "(no time tracking)"
+                        print(f"{wl.key}  {wl.role}: {wl.human}  worklog={where}")
 
         elif args.verb == "create":
             t = adapter.create(


### PR DESCRIPTION
Implements batch lane-time for TKT-3.

-  default; markdown + jira overrides degrade per-key missing-history entries instead of failing the whole batch.
-  for batch; single  preserved.
- JSON output stays scalar for single-key, array for batch (backward compat).
- README verb table updated.

Relates TKT-3.