### PR TITLE
fix(adapters): defer type annotation evaluation

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -2,6 +2,8 @@
 each verb. Skills depend ONLY on these signatures and the schema shapes they
 return — never on a concrete provider.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 from core.config import Config

--- a/adapters/github.py
+++ b/adapters/github.py
@@ -21,6 +21,8 @@ Config ([github] block):
 Time tracking: GitHub has none — worklog/lane-time are always no-ops here. Set
 [timetracking].provider = "none" (doctor warns otherwise).
 """
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -8,6 +8,8 @@ Auth (env names declared in config [ticketing].auth_env, defaults shown):
     CONFLUENCE_API_TOKEN
     TEMPO_API_TOKEN       optional; required to mark worklogs non-billable
 """
+from __future__ import annotations
+
 import base64
 import json
 import os

--- a/adapters/linear.py
+++ b/adapters/linear.py
@@ -19,6 +19,8 @@ Board roles map to Linear workflow-state NAMES:
 Time tracking: Linear has none — worklog/lane-time are no-ops; set
 [timetracking].provider = "none".
 """
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -35,6 +35,8 @@ list literals. No nested structures. Status transitions and time tracking are
 recorded in JSONL sidecars under state_dir, never the markdown (markdown stays
 the human-canonical source; sidecars are derived/machine-local).
 """
+from __future__ import annotations
+
 import json
 from datetime import datetime, timezone
 from pathlib import Path

--- a/adapters/openkanban.py
+++ b/adapters/openkanban.py
@@ -28,6 +28,8 @@ Config [openkanban]:
   config_dir    optional — overrides the resolved config dir
   me            optional — for whoami (openkanban has no users)
 """
+from __future__ import annotations
+
 import json
 import os
 import uuid


### PR DESCRIPTION
## Problem
Every adapter defines a `list()` verb method, which shadows the builtin `list` inside the class namespace. Method annotations such as `-> list[dict]` (and `list[Ticket]`, `list[Worklog]`, `list[Check]`) are evaluated at **class-definition time**, so `list` resolved to the verb method and raised:

```
TypeError: 'function' object is not subscriptable
  File "adapters/base.py", line 37, in Adapter
    def blockers(self, key: str) -> list[dict]:
```

This crashes `import adapters.*` (hence any verb that loads an adapter) on **every Python < 3.14**. It's masked on 3.14 by PEP 649 deferred annotations, so it doesn't reproduce in a dev shell whose `python3` is 3.14 — but it breaks all supported runtimes.

Surfaced by new CI in the `tktban` consumer (matrix 3.11/3.12/3.13).

## Fix
Add `from __future__ import annotations` to all six adapter modules (`base`, `github`, `jira`, `linear`, `markdown`, `openkanban`) so annotations are stored as strings and never evaluated eagerly. No behaviour change.

## Verification
- Clean-env (`env -i`) import of all six adapters: OK on 3.12 and 3.13.
- Clean-env markdown verbs (`transition`) round-trip: OK on 3.12 and 3.13.
- Reproduced the original crash before the fix; gone after.