### PR TITLE
feat(cfg): expose configured priorities verb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.pyc
+
+# Local SDLC/agent state (dogfooding tkt against the shared ODNF board)
+.sdlc/
+.omo/

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -90,6 +90,16 @@ class Adapter(ABC):
     def doctor(self) -> list[Check]:
         """Validate auth + reachability + board model. Read-only."""
 
+    # ---- config-backed, optionally backend-mapped --------------------------
+
+    def priorities(self) -> list[str]:
+        """The ordered priority list (highest-first) this backend understands.
+
+        Defaults to the project's configured list (Config.priorities()); a
+        backend with its own priority scheme (e.g. Jira) overrides this to
+        reconcile the configured names with what the backend actually accepts."""
+        return self.config.priorities()
+
     # ---- optional verbs ----------------------------------------------------
     # Not every backend supports these; default to a clear error so adapters
     # can opt in without breaking instantiation (unlike the @abstractmethods).

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -211,6 +211,20 @@ class JiraAdapter(Adapter):
                 return line.split("Email:", 1)[1].strip()
         return "(acli authenticated; identity unknown)"
 
+    def priorities(self) -> list[str]:
+        """Jira's own priority scheme. In REST mode we return Jira's live
+        priority names (the values its API actually accepts, highest-first);
+        in acli-only mode we can't enumerate them, so fall back to the
+        configured/default list."""
+        if not self.have_rest:
+            return self.config.priorities()
+        try:
+            data = self._jira("GET", "/rest/api/3/priority")
+        except ProviderError:
+            return self.config.priorities()
+        names = [p.get("name", "") for p in (data or []) if p.get("name")]
+        return names or self.config.priorities()
+
     def _full_jql(self, jql: str) -> str:
         if self.project and "project" not in jql.lower():
             return f"project = {self.project} AND {jql}"

--- a/core/cli.py
+++ b/core/cli.py
@@ -198,6 +198,12 @@ def main(argv: list[str]) -> int:
             return 0
 
         if args.verb == "cfg":
+            # `priorities` is backend-aware (jira maps to its own scheme), so it
+            # resolves through the adapter rather than a raw config lookup.
+            if args.key == "priorities":
+                vals = get_adapter(config).priorities()
+                print(json.dumps(vals) if args.json else "\n".join(vals))
+                return 0
             val = config.get(args.key)
             if isinstance(val, str):
                 print(_subst(val, args.pkg, args.ticket, args.slug))

--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from .errors import ConfigError, NotFoundError
 
+# Backend-agnostic priority ordering, highest-first. Used when a project does
+# not define its own `priorities = [...]` in .sdlc/config.toml.
+DEFAULT_PRIORITIES = ["Highest", "High", "Medium", "Low", "Lowest"]
+
 
 class Config:
     def __init__(self, data: dict[str, Any], path: Path):
@@ -79,6 +83,17 @@ class Config:
                 f"{', '.join(sorted(self.queries)) or '(none)'}"
             )
         return self.queries[name]
+
+    # ---- priorities --------------------------------------------------------
+
+    def priorities(self) -> list[str]:
+        """The configured ordered priority list (highest-first), or the default
+        when `priorities` is absent or not a non-empty list. Adapters may map
+        this to a backend's own scheme; see Adapter.priorities()."""
+        val = self._d.get("priorities")
+        if isinstance(val, list) and val:
+            return [str(p) for p in val]
+        return list(DEFAULT_PRIORITIES)
 
     # ---- arbitrary lookups (for skills reading build/vcs settings) ---------
 

--- a/examples/config.github.toml
+++ b/examples/config.github.toml
@@ -2,6 +2,10 @@
 # Copy to .sdlc/config.toml and adjust. Two board models are supported via
 # [github].board — see the two query blocks below.
 
+# Optional: ordered priority set (highest-first) exposed via `tkt cfg priorities`.
+# Defaults to ["Highest", "High", "Medium", "Low", "Lowest"] when omitted.
+# priorities = ["Highest", "High", "Medium", "Low", "Lowest"]
+
 [ticketing]
 provider = "github"
 project  = ""          # unused for github (repo identifies the issues)

--- a/examples/config.jira.toml
+++ b/examples/config.jira.toml
@@ -1,6 +1,11 @@
 # Example tkt config for the DTB / edge-dev-platform Jira board.
 # Copy to .sdlc/config.toml at your repo root and adjust.
 
+# `tkt cfg priorities` returns Jira's live priority scheme in REST mode; this
+# list is the fallback used in acli-only mode (and when the REST call fails).
+# Defaults to ["Highest", "High", "Medium", "Low", "Lowest"] when omitted.
+# priorities = ["Highest", "High", "Medium", "Low", "Lowest"]
+
 [ticketing]
 provider = "jira"
 project  = "DTB"

--- a/examples/config.linear.toml
+++ b/examples/config.linear.toml
@@ -1,6 +1,10 @@
 # Example tkt config for Linear. Copy to .sdlc/config.toml and adjust.
 # Auth: set LINEAR_API_KEY (a personal API key) in your environment.
 
+# Optional: ordered priority set (highest-first) exposed via `tkt cfg priorities`.
+# Defaults to ["Highest", "High", "Medium", "Low", "Lowest"] when omitted.
+# priorities = ["Urgent", "High", "Medium", "Low", "No priority"]
+
 [ticketing]
 provider = "linear"
 auth_env = ["LINEAR_API_KEY"]

--- a/examples/config.markdown.toml
+++ b/examples/config.markdown.toml
@@ -1,6 +1,10 @@
 # Example tkt config for a dependency-free local markdown board.
 # Copy to .sdlc/config.toml. Tickets live as <KEY>.md files under board_dir.
 
+# Optional: ordered priority set (highest-first) exposed via `tkt cfg priorities`.
+# Defaults to ["Highest", "High", "Medium", "Low", "Lowest"] when omitted.
+# priorities = ["Highest", "High", "Medium", "Low", "Lowest"]
+
 [ticketing]
 provider = "markdown"
 project  = "TKT"

--- a/examples/config.openkanban.toml
+++ b/examples/config.openkanban.toml
@@ -2,6 +2,10 @@
 # Copy to .sdlc/config.toml. tkt reads/writes openkanban's JSON store directly
 # (openkanban has no ticket CLI). Register a project first: `openkanban new <name>`.
 
+# Optional: ordered priority set (highest-first) exposed via `tkt cfg priorities`.
+# Defaults to ["Highest", "High", "Medium", "Low", "Lowest"] when omitted.
+# priorities = ["Highest", "High", "Medium", "Low", "Lowest"]
+
 [ticketing]
 provider = "openkanban"
 


### PR DESCRIPTION
## Summary

Adds a backend-agnostic, ordered priority enumeration surfaced via `tkt cfg priorities`, so clients (e.g. tktban TKB-8) can render priority as a select box instead of free text. Backends with their own priority scheme map the list themselves.

## Ticket

TKT-6 (/Users/raymonddoran/Development/odnf/.sdlc/board/TKT-6.md)

## Changes
- `core/config.py` — `DEFAULT_PRIORITIES` (Highest..Lowest) + `Config.priorities()` returning the configured `priorities = [...]` list or the default.
- `adapters/base.py` — non-abstract `Adapter.priorities()` returning the config list as-is (markdown/github/linear/openkanban inherit).
- `adapters/jira.py` — override mapping to Jira's live REST priority scheme, falling back to config in acli-only mode / on REST error.
- `core/cli.py` — `cfg` verb routes the `priorities` key through the adapter; `--json` emits a JSON list, plain emits newline-separated.
- `examples/config.*.toml` — document the optional `priorities` key.
- `.gitignore` — ignore local `.sdlc/` and `.omo/` dogfooding state.

## Testing
- `tkt cfg priorities --json` (markdown, no key) → default list.
- Configured `priorities = ["P0","P1","P2"]` → returns it; empty list → default fallback.
- jira path code-reviewed (no live Jira); fallback guarantees no hard failure in acli-only mode.

## Checklist
- [x] Validated live against markdown backend
- [x] No regressions in `doctor` / existing `cfg` keys