### PR TITLE
feat(cli): add apply verb to ingest ticket markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ Every adapter implements these. Read verbs accept `--json` (either side of the v
 | `tkt create --type T --summary S [--priority P] [--assignee A] [--body B] [--project P]` | create a ticket | new key / `--json` ticket |
 | `tkt link KEY --to OTHER --type T` | link KEY → OTHER (`T` = outward description: `blocks`, `is blocked by`, `Fixes`, …) | confirmation |
 | `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L]` | edit content/fields in place (only flags passed change; status excluded — use `transition`) | normalized ticket / `--json` |
+| `tkt apply --new --file F` / `tkt apply KEY --file F` | create / update a ticket from a full markdown doc (frontmatter + body; `-` = stdin). Owns the doc except `status` (use `transition`) and backend-managed sections (Comments), preserved verbatim. | new/updated key / `--json` ticket |
+| `tkt apply --template` | print the create-document template the editor opens with | markdown doc |
 | `tkt init --provider P [--dir D] [--force] [--link-skills] [--sample]` | scaffold `.sdlc/config.toml` (+ optionally link the pack) | next-steps summary |
 | `tkt lane ROLE` | resolve ROLE → provider lane name | string (config-only, no backend) |
 | `tkt cfg DOTTED.KEY [--pkg X] [--ticket K] [--slug S]` | read a config value; substitutes `{pkg}`/`{key}`/`{key-lower}`/`{slug}` | string / `--json` |
 | `tkt doctor` | validate auth + reachability + board model | checks; exit 1 if any fail |
 
-`create`/`link`/`edit` are optional verbs — adapters opt in (markdown supports all
-three; jira supports create/link); a backend without them returns a clear "not
-supported" error rather than failing to load.
+`create`/`link`/`edit`/`apply` are optional verbs — adapters opt in (markdown
+supports all four; jira supports create/link/apply); a backend without them
+returns a clear "not supported" error rather than failing to load.
 
 Errors always go to stderr with a non-zero exit (2 config, 3 provider, 4 not-found,
 64 usage) — skills can branch on exit code and never get a silent failure.
@@ -257,6 +259,7 @@ core/
   registry.py  provider name -> adapter (lazy import)
   schema.py    Ticket / Worklog / Check dataclasses + to_dict()
   query.py     shared JQL-subset evaluator (markdown + linear + openkanban)
+  ticketdoc.py canonical full-ticket markdown doc parser (for `tkt apply`)
   scaffold.py  `tkt init` scaffolder
   errors.py    typed errors -> exit codes
 adapters/

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -116,6 +116,19 @@ class Adapter(ABC):
         """Create a new ticket; return it normalized (with its new key)."""
         raise ProviderError(f"create not supported by provider '{self.config.provider}'")
 
+    def apply(self, doc: str, key: str | None = None) -> Ticket:
+        """Create (key=None) or update a ticket from a full canonical ticket
+        document (frontmatter + body; see core.ticketdoc). Owns the frontmatter
+        (except `status`, which only `transition` changes) and the body, while
+        preserving backend-managed sections (Comments) verbatim. Returns the
+        ticket normalized. Validation failures raise before any write."""
+        raise ProviderError(f"apply not supported by provider '{self.config.provider}'")
+
+    def apply_template(self) -> str:
+        """The canonical create-document template the editor opens for
+        `apply --new`."""
+        raise ProviderError(f"apply not supported by provider '{self.config.provider}'")
+
     def link(self, key: str, to: str, link_type: str) -> None:
         """Link `key` to `to` with a provider link type (e.g. 'is blocked by',
         'blocks', 'relates to', 'Fixes', 'duplicates')."""

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -52,6 +52,19 @@ def _adf_to_text(node) -> str:
     return "".join(out)
 
 
+def _text_to_adf(text: str) -> dict:
+    """Wrap plaintext as a minimal ADF document — one paragraph per line."""
+    content = []
+    for line in text.split("\n"):
+        para: dict = {"type": "paragraph", "content": []}
+        if line:
+            para["content"] = [{"type": "text", "text": line}]
+        content.append(para)
+    if not content:
+        content = [{"type": "paragraph", "content": []}]
+    return {"type": "doc", "version": 1, "content": content}
+
+
 class JiraAdapter(Adapter):
     def __init__(self, config):
         super().__init__(config)
@@ -287,6 +300,52 @@ class JiraAdapter(Adapter):
                 print(f"tkt: priority '{priority}' not set on {key} — acli can't set "
                       f"priority and no REST token is configured. Set it manually.",
                       flush=True)
+        return self.view(key)
+
+    def apply_template(self):
+        from core import ticketdoc
+        return ticketdoc.template()
+
+    def apply(self, doc, key=None):
+        from core import ticketdoc
+        fm_in, body_in = ticketdoc.split_frontmatter(doc)
+        summary = ticketdoc.summary_of(body_in)
+        if not summary:
+            raise ProviderError("apply: document needs a '# summary' heading")
+        # Jira stores the summary as a field and comments out-of-band, so the
+        # description is the body minus the summary line and managed sections.
+        desc = ticketdoc.body_without_summary(body_in)
+        for name in ticketdoc.MANAGED_SECTIONS:
+            desc = ticketdoc.strip_section(desc, name)
+        desc = desc.strip()
+
+        if key is None:
+            issue_type = str(fm_in.get("type", "")).strip()
+            if not issue_type:
+                raise ProviderError("apply --new: frontmatter must set 'type'")
+            created = self.create(issue_type, summary,
+                                  priority=str(fm_in.get("priority", "")),
+                                  assignee=str(fm_in.get("assignee", "")),
+                                  body=desc)
+            labels = list(fm_in.get("labels", []) or [])
+            if labels and self.have_rest:
+                self._jira("PUT", f"/rest/api/3/issue/{created.key}",
+                           {"fields": {"labels": labels}})
+                return self.view(created.key)
+            return created
+
+        # update — patch fields via REST (acli can't set description/priority).
+        if not self.have_rest:
+            raise ProviderError(
+                "apply update needs a REST token (set CONFLUENCE_SITE/EMAIL/"
+                "API_TOKEN); acli cannot patch issue fields")
+        fields: dict = {"summary": summary, "description": _text_to_adf(desc)}
+        if "priority" in fm_in:
+            fields["priority"] = {"name": str(fm_in["priority"])}
+        if "labels" in fm_in:
+            fields["labels"] = list(fm_in.get("labels") or [])
+        # assignee needs an accountId lookup; left unchanged here on purpose.
+        self._jira("PUT", f"/rest/api/3/issue/{key}", {"fields": fields})
         return self.view(key)
 
     def link(self, key, to, link_type):

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -41,6 +41,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from core import ticketdoc
 from core.errors import NotFoundError, ProviderError
 from core.query import JqlSubset
 from core.schema import Check, Ticket, Worklog, human_duration
@@ -284,6 +285,60 @@ class MarkdownAdapter(Adapter):
             doc += f"\n{body}\n"
         self._write_raw(key, fm, doc)
         self._append_history(key, "", todo_lane)
+        return self.view(key)
+
+    def apply_template(self):
+        return ticketdoc.template()
+
+    def apply(self, doc, key=None):
+        fm_in, body_in = ticketdoc.split_frontmatter(doc)
+        summary = ticketdoc.summary_of(body_in)
+        if not summary:
+            raise ProviderError("apply: document needs a '# summary' heading")
+
+        if key is None:
+            # create
+            issue_type = str(fm_in.get("type", "")).strip()
+            if not issue_type:
+                raise ProviderError("apply --new: frontmatter must set 'type'")
+            self.board_dir.mkdir(parents=True, exist_ok=True)
+            new_key = self._next_key(self.config.project)
+            todo_lane = (self.config.roles.get("todo")
+                         or self.config.roles.get("backlog", "To Do"))
+            fm = {
+                "type": issue_type,
+                "status": todo_lane,
+                "priority": str(fm_in.get("priority", "")),
+                "assignee": str(fm_in.get("assignee", "")) or self.me,
+                "blocked_by": list(fm_in.get("blocked_by", []) or []),
+                "blocks": list(fm_in.get("blocks", []) or []),
+            }
+            labels = list(fm_in.get("labels", []) or [])
+            if labels:
+                fm["labels"] = labels
+            self._write_raw(new_key, fm, body_in)
+            self._append_history(new_key, "", todo_lane)
+            return self.view(new_key)
+
+        # update — NotFoundError here means no partial write happened.
+        cur_fm, cur_body = self._read_raw(key)
+        fm = dict(cur_fm)
+        # `status` stays under transition's control; everything else the doc
+        # carries is owned by apply.
+        for field in ("type", "priority", "assignee", "labels",
+                      "blocked_by", "blocks", "components"):
+            if field in fm_in:
+                fm[field] = fm_in[field]
+        # The buffer body wins, but backend-managed sections (Comments) are
+        # restored verbatim from the stored ticket so the editor can't corrupt
+        # the timestamped log.
+        body = body_in
+        for name in ticketdoc.MANAGED_SECTIONS:
+            canon = ticketdoc.extract_section(cur_body, name)
+            body = ticketdoc.strip_section(body, name)
+            if canon:
+                body = body.rstrip() + "\n\n" + canon + "\n"
+        self._write_raw(key, fm, body)
         return self.view(key)
 
     def link(self, key, to, link_type):

--- a/core/cli.py
+++ b/core/cli.py
@@ -107,6 +107,15 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--body", default="")
     sp.add_argument("--project", default="")
 
+    sp = add("apply")
+    sp.add_argument("key", nargs="?", default=None,
+                    help="ticket to update; omit and pass --new to create")
+    sp.add_argument("--new", action="store_true", help="create a new ticket")
+    sp.add_argument("--file", default=None,
+                    help="full ticket markdown to apply; '-' reads stdin")
+    sp.add_argument("--template", action="store_true",
+                    help="print the create-document template and exit")
+
     sp = add("link")
     sp.add_argument("key")
     sp.add_argument("--to", required=True, dest="to")
@@ -288,6 +297,29 @@ def main(argv: list[str]) -> int:
                 print(json.dumps(t.to_dict(), indent=2))
             else:
                 print(t.key)
+
+        elif args.verb == "apply":
+            if args.template:
+                print(adapter.apply_template())
+            else:
+                if args.new and args.key:
+                    raise UsageError("apply: pass a KEY to update OR --new to create, not both")
+                if not args.new and not args.key:
+                    raise UsageError("apply: need a KEY (update) or --new (create), or --template")
+                if not args.file:
+                    raise UsageError("apply: --file PATH required ('-' for stdin)")
+                if args.file == "-":
+                    doc = sys.stdin.read()
+                else:
+                    try:
+                        doc = open(args.file, encoding="utf-8").read()
+                    except OSError as e:
+                        raise UsageError(f"apply: cannot read {args.file}: {e}") from e
+                t = adapter.apply(doc, key=None if args.new else args.key)
+                if args.json:
+                    print(json.dumps(t.to_dict(), indent=2))
+                else:
+                    print(t.key)
 
         elif args.verb == "link":
             adapter.link(args.key, args.to, args.link_type)

--- a/core/ticketdoc.py
+++ b/core/ticketdoc.py
@@ -1,0 +1,156 @@
+"""Canonical full-ticket markdown document — the editor-buffer format that
+`tkt apply` ingests and that TKB-10's $EDITOR flow round-trips. Backend-agnostic:
+adapters map the parsed result onto their own storage (markdown writes it almost
+verbatim; jira splits summary/description and maps frontmatter to fields).
+
+Shape (frontmatter optional; body is GitHub-flavored markdown):
+
+    ---
+    type: Story
+    priority: Medium
+    assignee: raymond
+    labels: [a, b]
+    blocked_by: []
+    blocks: []
+    ---
+    # One-line summary
+
+    Free-form description.
+
+    ## Acceptance
+    - criterion one
+
+    ## Comments          # backend-managed; `apply` never rewrites it
+    - 2026-06-02T10:00:00Z raymond: started work
+
+`apply` owns the frontmatter (except `status`, which only `transition` changes so
+lane history stays correct) and the whole body EXCEPT backend-managed sections
+(`MANAGED_SECTIONS`), which are preserved verbatim from the stored ticket.
+"""
+from __future__ import annotations
+
+# Body section headings `apply` must not overwrite — the backend manages them
+# (e.g. the timestamped comment log appended by `tkt comment`). Compared
+# case-insensitively against each `## ` heading.
+MANAGED_SECTIONS = ("comments",)
+
+
+def parse_scalar(raw: str):
+    """The tiny frontmatter value grammar: `[a, b]` list literals, else a bare
+    (optionally quoted) scalar. Mirrors the markdown adapter's reader."""
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if not inner:
+            return []
+        return [x.strip().strip("'\"") for x in inner.split(",") if x.strip()]
+    return raw.strip("'\"")
+
+
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter, body). Body is everything after the closing `---`,
+    or the whole text when there is no frontmatter block."""
+    fm: dict[str, object] = {}
+    body = text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            block = text[3:end].strip("\n")
+            body = text[end + 4:].lstrip("\n")
+            for line in block.splitlines():
+                if ":" not in line:
+                    continue
+                k, _, v = line.partition(":")
+                fm[k.strip()] = parse_scalar(v)
+    return fm, body
+
+
+def render_frontmatter(fm: dict) -> str:
+    """The `---` block, in the same shape the markdown adapter writes."""
+    lines = ["---"]
+    for k, v in fm.items():
+        if isinstance(v, list):
+            lines.append(f"{k}: [{', '.join(str(x) for x in v)}]")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def summary_of(body: str) -> str:
+    """The first `# ` heading's text (the ticket summary), or ""."""
+    for line in body.splitlines():
+        s = line.strip()
+        if s.startswith("# "):
+            return s[2:].strip()
+    return ""
+
+
+def body_without_summary(body: str) -> str:
+    """Body with the first `# summary` heading line removed, for backends that
+    store the summary as a separate field (e.g. jira)."""
+    out, dropped = [], False
+    for line in body.splitlines():
+        if not dropped and line.strip().startswith("# "):
+            dropped = True
+            continue
+        out.append(line)
+    return "\n".join(out).strip()
+
+
+def _section_bounds(body: str, name_lower: str) -> tuple[int, int] | None:
+    """(start, end) line indices for the `## <name>` section — end exclusive,
+    bounded by the next `## ` heading or EOF — or None if absent."""
+    lines = body.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        s = line.strip()
+        if start is None:
+            if s.startswith("## ") and s[3:].strip().lower().startswith(name_lower):
+                start = i
+        elif s.startswith("## "):
+            return (start, i)
+    if start is None:
+        return None
+    return (start, len(lines))
+
+
+def extract_section(body: str, name_lower: str) -> str | None:
+    """The full `## <name>` section text (heading included), or None."""
+    bounds = _section_bounds(body, name_lower)
+    if bounds is None:
+        return None
+    lines = body.splitlines()
+    return "\n".join(lines[bounds[0]:bounds[1]]).strip()
+
+
+def strip_section(body: str, name_lower: str) -> str:
+    """`body` with the `## <name>` section removed (no-op if absent)."""
+    bounds = _section_bounds(body, name_lower)
+    if bounds is None:
+        return body
+    lines = body.splitlines()
+    return "\n".join(lines[:bounds[0]] + lines[bounds[1]:]).strip()
+
+
+TEMPLATE = """\
+---
+type: Story
+priority: Medium
+assignee:
+labels: []
+blocked_by: []
+blocks: []
+---
+# One-line summary
+
+Describe the work here.
+
+## Acceptance
+- first acceptance criterion
+"""
+
+
+def template() -> str:
+    """The create-document the editor should open with for `apply --new`."""
+    return TEMPLATE


### PR DESCRIPTION
## Summary

Adds `tkt apply` — create or update a ticket from a full canonical ticket-markdown document (frontmatter + body). This lets TKB-10's `$EDITOR` flow treat the editor buffer as the source of truth without re-parsing markdown per backend. The doc format is defined once in `core/ticketdoc.py` and mapped onto each backend's storage.

## Ticket

TKT-7 (/Users/raymonddoran/Development/odnf/.sdlc/board/TKT-7.md)

## Behavior
- `tkt apply --new --file -` creates a ticket from stdin/file, returns its key.
- `tkt apply KEY --file -` updates an existing ticket.
- `tkt apply --template` emits the create-document template.
- **Ownership:** apply owns the frontmatter *except* `status` (status changes only via `transition`, so lane history stays correct) and owns the body, but **preserves backend-managed sections (Comments) verbatim** from the stored ticket — the editor buffer cannot corrupt the timestamped log.
- Validation errors (missing summary/type, unreadable file, conflicting flags) exit nonzero **before any write** — no partial state.

## Changes
- `core/ticketdoc.py` (new) — backend-agnostic doc format: `split_frontmatter`, `render_frontmatter`, `summary_of`, `extract_section`/`strip_section`/`body_without_summary`, `template()`, `MANAGED_SECTIONS`.
- `adapters/base.py` — optional `apply`/`apply_template` defaulting to a clear not-supported error.
- `adapters/markdown.py` — primary impl (create + update with Comments preservation).
- `adapters/jira.py` — maps doc → summary + description (ADF) + priority/labels; create via acli, update via REST PUT (requires REST token).
- `core/cli.py` — `apply [key] [--new] [--file] [--template]` parsing + dispatch.
- `README.md` — verb contract + core module list.

## Testing
Validated live against a markdown board:
- template → create → view (summary/type/priority/assignee/acceptance correct)
- round-trip update: description/acceptance/priority/labels updated from buffer; **status preserved** (buffer's forged `Done` ignored); **Comments preserved canonical** (forged comment dropped)
- all error paths: usage (exit 64), provider (3), not-found (4); confirmed no partial writes
- real-board regression: doctor + existing verbs unaffected

jira path is code-reviewed only (no live instance); update is guarded behind a REST token and is non-destructive (assignee left unchanged — accountId mapping out of scope).

## Checklist
- [x] Validated live on markdown backend (create, update, round-trip, errors)
- [x] No regressions in existing verbs / doctor
- [x] Docs updated