### PR TITLE
feat(schema): add optional ticket date fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Every adapter implements these. Read verbs accept `--json` (either side of the v
 | `tkt lane-time --keys K1:ROLE[,K2:ROLE,...] [--read-only]` | batch lane-time (one call, N keys) | JSON array of worklogs |
 | `tkt create --type T --summary S [--priority P] [--assignee A] [--body B] [--project P]` | create a ticket | new key / `--json` ticket |
 | `tkt link KEY --to OTHER --type T` | link KEY → OTHER (`T` = outward description: `blocks`, `is blocked by`, `Fixes`, …) | confirmation |
-| `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L]` | edit content/fields in place (only flags passed change; status excluded — use `transition`) | normalized ticket / `--json` |
+| `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L] [--due D] [--scheduled D] [--completed D]` | edit content/fields in place (only flags passed change; status excluded — use `transition`). Dates are ISO `YYYY-MM-DD`; pass `""` to clear. | normalized ticket / `--json` |
 | `tkt apply --new --file F` / `tkt apply KEY --file F` | create / update a ticket from a full markdown doc (frontmatter + body; `-` = stdin). Owns the doc except `status` (use `transition`) and backend-managed sections (Comments), preserved verbatim. | new/updated key / `--json` ticket |
 | `tkt apply --template` | print the create-document template the editor opens with | markdown doc |
 | `tkt init --provider P [--dir D] [--force] [--link-skills] [--sample]` | scaffold `.sdlc/config.toml` (+ optionally link the pack) | next-steps summary |
@@ -107,6 +107,7 @@ name, and `tkt transition KEY review` to move.
   "summary": "...", "description": "...", "acceptance": ["..."],
   "status": "In Progress", "status_role": "in_progress",
   "assignee": "raymond", "priority": "Highest",
+  "due": null, "scheduled": null, "completed": null,
   "labels": ["..."], "components": ["..."],
   "blocked_by": [{"key": "TKT-2", "resolved": false}],
   "blocks": [], "transitions": ["..."], "url": "..."

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -143,11 +143,14 @@ class Adapter(ABC):
         assignee: str | None = None,
         add_labels: list[str] | None = None,
         remove_labels: list[str] | None = None,
+        due: str | None = None,
+        scheduled: str | None = None,
+        completed: str | None = None,
     ) -> Ticket:
         """Edit a ticket's content/fields in place; return it normalized.
 
         Only the arguments that are not None are changed (an empty string is a
-        valid value, e.g. clearing the assignee). Status is intentionally NOT
-        editable here — lane moves go through `transition` so history/worklog
-        stay correct."""
+        valid value, e.g. clearing the assignee or a date). Status is
+        intentionally NOT editable here — lane moves go through `transition` so
+        history/worklog stay correct."""
         raise ProviderError(f"edit not supported by provider '{self.config.provider}'")

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -185,6 +185,12 @@ class JiraAdapter(Adapter):
             assignee=((f.get("assignee") or {}).get("displayName")
                       or (f.get("assignee") or {}).get("emailAddress") or ""),
             priority=(f.get("priority") or {}).get("name", ""),
+            # Native Jira dates: duedate is YYYY-MM-DD; resolutiondate is a
+            # datetime we trim to its date. Jira has no native "scheduled"
+            # field, so it stays unset here.
+            due=(f.get("duedate") or None),
+            scheduled=None,
+            completed=((f.get("resolutiondate") or "")[:10] or None),
             url=f"https://{self._site_for_url()}/browse/{key}",
             acceptance=self._extract_acceptance(desc),
             labels=list(f.get("labels", []) or []),

--- a/adapters/markdown.py
+++ b/adapters/markdown.py
@@ -186,6 +186,10 @@ class MarkdownAdapter(Adapter):
         if isinstance(blocks, str):
             blocks = [blocks]
 
+        def _date(name: str) -> str | None:
+            v = fm.get(name)
+            return str(v) if v not in (None, "", []) else None
+
         return Ticket(
             key=key,
             type=issue_type,
@@ -196,6 +200,9 @@ class MarkdownAdapter(Adapter):
             type_class=self.config.type_class(issue_type),
             assignee=str(fm.get("assignee", "")),
             priority=str(fm.get("priority", "")),
+            due=_date("due"),
+            scheduled=_date("scheduled"),
+            completed=_date("completed"),
             url=str(self._ticket_path(key)),
             acceptance=acceptance,
             labels=list(fm.get("labels", []) or []),
@@ -316,6 +323,9 @@ class MarkdownAdapter(Adapter):
             labels = list(fm_in.get("labels", []) or [])
             if labels:
                 fm["labels"] = labels
+            for name in ("due", "scheduled", "completed"):
+                if name in fm_in and fm_in[name] not in (None, ""):
+                    fm[name] = fm_in[name]
             self._write_raw(new_key, fm, body_in)
             self._append_history(new_key, "", todo_lane)
             return self.view(new_key)
@@ -326,7 +336,8 @@ class MarkdownAdapter(Adapter):
         # `status` stays under transition's control; everything else the doc
         # carries is owned by apply.
         for field in ("type", "priority", "assignee", "labels",
-                      "blocked_by", "blocks", "components"):
+                      "blocked_by", "blocks", "components",
+                      "due", "scheduled", "completed"):
             if field in fm_in:
                 fm[field] = fm_in[field]
         # The buffer body wins, but backend-managed sections (Comments) are
@@ -394,13 +405,24 @@ class MarkdownAdapter(Adapter):
         return summary, "\n".join(desc_lines).strip(), "\n".join(rest_lines).strip()
 
     def edit(self, key, summary=None, body=None, priority=None, assignee=None,
-             add_labels=None, remove_labels=None):
+             add_labels=None, remove_labels=None,
+             due=None, scheduled=None, completed=None):
         fm, doc = self._read_raw(key)
 
         if priority is not None:
             fm["priority"] = priority
         if assignee is not None:
             fm["assignee"] = assignee
+
+        # Dates: None = leave as-is, "" = clear (drop the key), else set.
+        for name, val in (("due", due), ("scheduled", scheduled),
+                          ("completed", completed)):
+            if val is None:
+                continue
+            if val == "":
+                fm.pop(name, None)
+            else:
+                fm[name] = val
 
         if add_labels or remove_labels:
             cur = fm.get("labels", []) or []

--- a/core/cli.py
+++ b/core/cli.py
@@ -3,6 +3,7 @@ on read verbs emits the normalized shape for skills to parse."""
 import argparse
 import json
 import sys
+from datetime import datetime
 
 from .config import Config
 from .errors import TktError, UsageError
@@ -17,6 +18,10 @@ def _print_ticket_human(t: Ticket) -> None:
     print(f"  summary:  {t.summary}")
     if t.labels:
         print(f"  labels:   {', '.join(t.labels)}")
+    dates = [f"{n}={v}" for n, v in
+             (("due", t.due), ("scheduled", t.scheduled), ("completed", t.completed)) if v]
+    if dates:
+        print(f"  dates:    {', '.join(dates)}")
     unresolved = t.unresolved_blockers()
     if unresolved:
         print(f"  BLOCKED BY: {', '.join(b['key'] for b in unresolved)}")
@@ -131,6 +136,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--assignee", default=None)
     sp.add_argument("--add-label", action="append", default=[], dest="add_label")
     sp.add_argument("--remove-label", action="append", default=[], dest="remove_label")
+    # Dates: omit = unchanged, pass "" to clear, else YYYY-MM-DD.
+    sp.add_argument("--due", default=None)
+    sp.add_argument("--scheduled", default=None)
+    sp.add_argument("--completed", default=None)
 
     sp = add("lane")
     sp.add_argument("role")
@@ -153,6 +162,17 @@ def build_parser() -> argparse.ArgumentParser:
     add("doctor")
 
     return p
+
+
+def _validate_date(flag: str, value: str | None) -> str | None:
+    """None = leave unchanged, "" = clear, else require ISO YYYY-MM-DD."""
+    if value is None or value == "":
+        return value
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise UsageError(f"{flag}: invalid date '{value}', expected YYYY-MM-DD")
+    return value
 
 
 def _subst(value: str, pkg: str, ticket: str, slug: str) -> str:
@@ -330,6 +350,9 @@ def main(argv: list[str]) -> int:
                 args.key, summary=args.summary, body=args.body,
                 priority=args.priority, assignee=args.assignee,
                 add_labels=args.add_label, remove_labels=args.remove_label,
+                due=_validate_date("--due", args.due),
+                scheduled=_validate_date("--scheduled", args.scheduled),
+                completed=_validate_date("--completed", args.completed),
             )
             if args.json:
                 print(json.dumps(t.to_dict(), indent=2))

--- a/core/schema.py
+++ b/core/schema.py
@@ -18,6 +18,10 @@ class Ticket:
     type_class: str = ""             # "full_sdlc" | "deliverable" | "unknown"
     assignee: str = ""
     priority: str = ""
+    # Optional dates, ISO YYYY-MM-DD; None when unset (rendered as null in JSON).
+    due: str | None = None
+    scheduled: str | None = None
+    completed: str | None = None
     url: str = ""
     acceptance: list[str] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)


### PR DESCRIPTION
## Summary

Adds optional `due` / `scheduled` / `completed` dates (ISO `YYYY-MM-DD`) to the ticket schema so clients (tktban TKB-12) can render and edit dates as first-class fields instead of parsing markdown.

## Ticket

TKT-8 (/Users/raymonddoran/Development/odnf/.sdlc/board/TKT-8.md)

## Changes
- `core/schema.py` — `Ticket` gains `due`/`scheduled`/`completed` (`None` default → `null` in `tkt view --json` when unset).
- `core/cli.py` — `edit` gains `--due/--scheduled/--completed`; `""` clears, omitted leaves unchanged; invalid format rejected (exit 64) before any write. `view` human output shows set dates.
- `adapters/base.py` — `edit` contract extended with the three date params.
- `adapters/markdown.py` — reads dates from frontmatter, sets/clears them in `edit`, and round-trips them through `apply` (create + update).
- `adapters/jira.py` — maps native dates: `duedate`→`due`, `resolutiondate[:10]`→`completed`; Jira has no native "scheduled" field (stays unset).
- `README.md` — verb row + normalized-shape example.

Other adapters (github/linear/openkanban) need no change — they build `Ticket` without dates, so the fields default to `null`.

## Testing
Validated live on a markdown board:
- unset → `null` in `--json`; set all three → present; human `view` shows them
- clear one with `""` leaves the others; frontmatter storage confirmed
- invalid dates (`07/01/2026`, `2026-13-99`) → exit 64, no write
- `apply` round-trips dates from frontmatter
- jira `_to_ticket` mapping unit-checked offline (duedate/resolutiondate set + unset cases)
- real-board regression: doctor + existing verbs unaffected

## Checklist
- [x] Validated live on markdown (set/clear/json/human/errors)
- [x] jira mapping unit-checked offline (no live instance)
- [x] No regressions; docs updated