### PR TITLE
docs: refresh AGENTS.md and dedupe CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ skill pack. The pack's skills speak semantic verbs (`tkt view`, `tkt transition`
 dispatches to the configured provider adapter, and normalizes every backend into
 one JSON ticket shape.
 
+This file is the harness-facing contract: how to drive `tkt` and how to edit the
+skills without breaking portability. For this repo's internals (`core/`,
+`adapters/`, how to add a provider), see `CLAUDE.md`.
+
 Use this file as the root fallback when your harness does not have a dedicated
 per-tool folder (Cursor rules, Windsurf rules, OpenCode instructions, etc. are in
 separate harness-specific files).
@@ -13,10 +17,8 @@ separate harness-specific files).
 ## Core portability rules
 
 1. **No backend specifics in workflow logic.**
-   - Use `tkt view`, `tkt transition`, `tkt comment`, `tkt blockers`,
-     `tkt worklog`, `tkt lane-time`, `tkt list`, `tkt create`, `tkt link`.
-   - Never call `acli`, `gh issue`, Jira REST, Linear GraphQL, or any other
-     backend API directly for ticketing.
+   - Use the semantic verbs below — never call `acli`, `gh issue`, Jira REST,
+     Linear GraphQL, or any other backend API directly for ticketing.
 
 2. **No repo/toolchain hardcoding.**
    - Read values through `tkt cfg`:
@@ -50,23 +52,57 @@ separate harness-specific files).
    - Comments should still read naturally (e.g. "Time in In Progress: (no time
      tracking)").
 
+6. **Optional verbs are opt-in per adapter.**
+   - `create`, `apply`, `edit`, and `link` raise a "not supported"
+     `ProviderError` on backends that don't implement them. Branch on the exit
+     code (3) rather than assuming availability.
+
 ## Verb contract (quick reference)
 
 | Command | Purpose |
 |---------|---------|
 | `tkt whoami` | current user id |
-| `tkt list --tier N` / `--query NAME` | run named query from config |
+| `tkt list --tier N` \| `--query NAME` | run named query from config (one is required) |
 | `tkt view KEY --json` | normalized ticket |
 | `tkt transition KEY ROLE` | move ticket to role's lane |
 | `tkt comment KEY BODY` | post activity comment |
 | `tkt blockers KEY --json` | unresolved blockers only |
-| `tkt worklog KEY --from-role ROLE [--note T]` | log time since entry → now |
-| `tkt lane-time KEY --role ROLE` | log time for closed lane interval |
-| `tkt create --type T --summary S ...` | create a ticket (adapter-opt-in) |
+| `tkt worklog KEY --from-role ROLE [--note T] [--billable]` | log time since entry → now |
+| `tkt lane-time [KEY] --role ROLE [--keys K1:role,K2:role] [--read-only]` | log time for a closed lane interval; batch via `--keys` |
+| `tkt create --type T --summary S [--priority P] [--assignee A] [--body B] [--project P]` | create a ticket (adapter-opt-in) |
+| `tkt apply [KEY] --file PATH` \| `--new --file PATH` \| `--template` | create/update from a full ticket markdown doc (`-` reads stdin) |
+| `tkt edit KEY [--summary/--body/--priority/--assignee/--add-label/--remove-label/--due/--scheduled/--completed/--agent-status]` | field-level update |
 | `tkt link KEY --to OTHER --type T` | link tickets (adapter-opt-in) |
 | `tkt lane ROLE` | resolve role → provider lane name |
-| `tkt cfg DOTTED.KEY ...` | read config + template substitution |
-| `tkt doctor` | validate auth + reachability + board model |
+| `tkt cfg DOTTED.KEY [--pkg/--ticket/--slug]` | read config + template substitution |
+| `tkt cfg priorities` | backend-aware priority list, highest-first |
+| `tkt init --provider P [--dir D] [--link-skills] [--sample] [--force]` | scaffold `.sdlc/` |
+| `tkt sync-pack [--dir D] [--all-harnesses] [--check]` | install the pack into a consumer repo as committed copies |
+| `tkt doctor` | validate auth + reachability + board model + pack sync |
+
+`--json` works on either side of the verb.
+
+### Edit semantics
+
+`tkt edit` distinguishes "not supplied" from "clear":
+
+- Omit a flag → field unchanged.
+- Pass `""` → field cleared (e.g. `--assignee ""`).
+- `--due` / `--scheduled` / `--completed` take `YYYY-MM-DD`.
+- `--agent-status` takes one of `idle`, `processing`, `waiting`, `done`,
+  `blocked` (or `""` to clear). Invalid values are rejected up front so a typo
+  can't write a state the board's badge mapping won't recognize.
+
+### Exit codes
+
+Branch on these — errors always go to stderr with a non-zero exit:
+
+| Code | Meaning |
+|------|---------|
+| 2 | config error |
+| 3 | provider error (includes "verb not supported by this adapter") |
+| 4 | not found |
+| 64 | usage error |
 
 ## SDLC skill pack
 
@@ -92,17 +128,48 @@ per-tool folders (`.opencode/commands/`, `.cursor/commands/`, `.cursor/skills/`,
 | `deploy-preview` | confirm preview env, post URL to ticket + PR |
 | `hotfix-revert` | fast-track prod revert |
 | `resume-from-revise` | re-enter the loop after a human revise fix |
+| `sync-skills` | translate the canonical skills into each harness format |
+
+### Editing skills
+
+- **No backend specifics in skill text.** Speak in roles, and read all
+  toolchain/VCS/deploy settings through `tkt cfg`. Never hardcode Jira/pnpm/
+  GitHub/repo names.
+- VCS (PR/CI/merge via `gh`) and infra (preview/deploy) are still GitHub/
+  cloud-shaped, but repo/branch/reviewer/workflow values come from config;
+  genuinely infra-specific steps are marked `PROJECT-SPECIFIC` in the skill text.
+- Editing a skill's frontmatter `description` changes the `sync-pack` managed
+  block in consumer repos — it is generated from the first sentence.
+
+## Distributing the pack
+
+`tkt sync-pack` installs the pack into a consumer repo as **committed copies**,
+not symlinks: cloud harnesses and CI only see tracked files, so the symlinks
+`tkt init --link-skills` writes are invisible to them. It only writes paths it
+records in `.sdlc/pack-manifest.json`, never deletes, and is idempotent (a second
+run with an unchanged pack leaves `git status` clean).
+
+In a consumer repo it also maintains a generated block inside that repo's
+`AGENTS.md`, delimited by markers — content outside the markers is preserved
+verbatim. `tkt sync-pack --check` reports missing/locally-modified/out-of-date
+pack files and exits 1; `tkt doctor` folds the same check in.
+
+This file — the pack repo's own `AGENTS.md` — has no managed block and is
+hand-maintained.
 
 ## Meta
 
-- `skills/sync-skills/SKILL.md` documents how to translate the canonical skills
-  into each harness format.
 - `agents/ticket-researcher.md` is the read-only lookup subagent.
+- `docs/install.md` — installing `tkt` and the pack.
+- `docs/markdown-ticketing.md` — the markdown provider's on-disk format.
+- `docs/extraction-history.md` — how this pack was extracted from its origin repo.
+- `scripts/` — `company-import.sh` (bulk import) and `smoke-sync-pack.sh`
+  (sync-pack smoke test).
 - This repo is pure stdlib Python 3.11+; no build step.
 
 ## When in doubt
 
 - Run `tkt doctor` to validate a project's config.
 - Run `tkt view KEY --json` to see the normalized shape.
-- Run `tkt cfg <dotted.key> --help` is not supported; consult
-  `.sdlc/config.toml` or `examples/config.<provider>.toml`.
+- Config keys are not self-documenting: consult `.sdlc/config.toml` or
+  `examples/config.<provider>.toml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Read `AGENTS.md` first.** It is the harness-facing contract: the verb reference,
+role vocabulary, exit codes, portability rules, and the skill pack inventory. This
+file covers only what `AGENTS.md` deliberately leaves out — the internals of this
+repo and how to change them.
+
 ## What this is
 
 `tkt` is a provider-agnostic ticketing/board CLI plus a portable SDLC skill pack.
-The pack's skills speak **semantic verbs** (`tkt view`, `tkt transition`, ...) and
-never touch a concrete backend; `tkt` reads `.sdlc/config.toml`, dispatches to the
-configured provider adapter, and normalizes every backend into one JSON ticket shape.
-This decouples **process logic** (what step comes next, in the skills) from
-**provider calls** (how to talk to Jira/GitHub/etc., in the adapters). See `PLAN.md`
-for the coupling inventory that motivated the split, and `README.md` for the full
-verb contract and per-provider notes.
+It decouples **process logic** (what step comes next, in the skills) from
+**provider calls** (how to talk to Jira/GitHub/etc., in the adapters). `README.md`
+has the full verb contract and per-provider notes.
 
 Pure stdlib, Python 3.11+ (uses `tomllib`). No third-party deps, no build step.
 
@@ -22,12 +23,14 @@ Pure stdlib, Python 3.11+ (uses `tomllib`). No third-party deps, no build step.
 ./tkt doctor                  # validate a project's auth + reachability + board model
 ./tkt view KEY --json         # normalized ticket shape skills parse
 ./tkt init --provider markdown --link-skills --sample   # scaffold a project's .sdlc/
+./tkt sync-pack --check --dir ../consumer   # is a consumer repo's pack copy current?
 ```
 
 There is **no test suite, linter config, or Makefile** in this repo. "Validation"
 of an adapter means running `tkt doctor` / the read verbs live against a real backend
 (see each provider's "Validation status" in `README.md`). When adding code, exercise
 it by running the actual verbs against a configured backend rather than expecting CI.
+`scripts/smoke-sync-pack.sh` is the one exception — it smoke-tests `sync-pack`.
 
 `tkt` locates its own `core/`/`adapters/` relative to the script (`tkt:12`), so it
 runs from any cwd and a PATH symlink is fine.
@@ -38,56 +41,67 @@ Two layers, connected only by the verb contract and the normalized schema:
 
 - **`core/`** — provider-independent plumbing.
   - `cli.py` — argparse verb parsing, dispatch, and output formatting. `--json` works
-    on either side of the verb. `init`/`lane`/`cfg` are handled **before** loading an
-    adapter (`init` runs before any config exists; `lane`/`cfg` are pure config reads).
+    on either side of the verb. `init`/`sync-pack`/`lane`/`cfg` are handled **before**
+    loading an adapter (`init` and `sync-pack` run before any config exists; `lane`/`cfg`
+    are pure config reads). Exception: `cfg priorities` is backend-aware, so it does
+    load an adapter. Input validation for dates and `--agent-status` lives here so a
+    typo fails before it reaches a backend.
   - `config.py` — loads `.sdlc/config.toml`. Discovery order: `--config` → `$TKT_CONFIG`
     → nearest `.sdlc/config.toml` walking up from cwd. Owns role↔lane mapping, issue-type
-    routing (`full_sdlc` vs `deliverable`), named queries, and dotted-path `get()`.
+    routing (`full_sdlc` vs `deliverable`), named queries, the backend-agnostic priority
+    ordering, and dotted-path `get()`.
   - `registry.py` — `provider name → (module, class)`, **lazy-imported** so one adapter's
     missing optional dep can't break the others.
   - `schema.py` — `Ticket` / `Worklog` / `Check` dataclasses + `to_dict()` (the JSON shape).
   - `query.py` — shared tiny **JQL-subset** evaluator, used by adapters with no native
     query language (markdown, linear, openkanban). (Note: `README.md`'s architecture
     block lists this under `adapters/`; it actually lives in `core/`.)
-  - `errors.py` — typed errors → exit codes: **2** config, **3** provider, **4** not-found,
-    **64** usage. Errors always go to stderr with a non-zero exit so skills branch on codes.
+  - `ticketdoc.py` — the canonical full-ticket markdown document (frontmatter + body)
+    that `tkt apply` ingests and the `$EDITOR` flow round-trips. Backend-agnostic:
+    adapters map the parsed result onto their own storage.
+  - `pack.py` — implements `tkt sync-pack` and its `doctor` check. Copies pack files
+    into a consumer tree, tracks them in `.sdlc/pack-manifest.json`, and maintains a
+    marker-delimited managed block in the consumer's `AGENTS.md`. Never deletes, never
+    writes outside recorded paths, and is idempotent.
+  - `errors.py` — typed errors → exit codes (see `AGENTS.md` for the table). Errors
+    always go to stderr with a non-zero exit so skills branch on codes.
   - `scaffold.py` — implements `tkt init`.
 - **`adapters/`** — one file per backend, each subclassing `adapters/base.Adapter`.
   - `base.py` is the contract: required `@abstractmethod` verbs (whoami, list, view,
     transition, comment, blockers, worklog, lane_time, doctor) plus **optional** verbs
-    (`create`, `link`) that default to a clear "not supported" `ProviderError` so a
-    backend opts in without breaking instantiation.
+    (`create`, `apply`, `edit`, `link`) that default to a clear "not supported"
+    `ProviderError` so a backend opts in without breaking instantiation.
   - Implementations: `jira.py` (acli + Jira REST + Tempo), `github.py` (Issues + Projects v2
     or `Status:` labels, all via `gh`), `linear.py` (GraphQL), `openkanban.py` (local JSON
     store), `markdown.py` (one `<KEY>.md` per ticket + JSONL state sidecars).
 
 ### Roles, not lane names
 
-Skills reference canonical **roles** (`in_progress`, `review`, `qa_ready`, `done`,
-`blocked`, ...). `[board.roles]` in config maps each role to the provider's literal lane
-string. This is the core abstraction that lets one skill drive an 8-lane Jira board and a
-3-column markdown board unchanged. In skills, use `tkt transition KEY review` to move and
-`$(tkt lane review)` when you need the literal lane name.
+Skills reference canonical **roles**; `[board.roles]` in config maps each role to the
+provider's literal lane string. This is the core abstraction that lets one skill drive
+an 8-lane Jira board and a 3-column markdown board unchanged. Role vocabulary and usage
+are in `AGENTS.md`.
+
+### Ticket schema notes
+
+Beyond the obvious fields, `Ticket` carries `status` (provider lane, verbatim) alongside
+`status_role` (canonical role), `type_class` (`full_sdlc` | `deliverable` | `unknown`),
+the date fields `due` / `scheduled` / `completed`, and `agent_status` (board agent state:
+`idle` | `processing` | `waiting` | `done` | `blocked`, or empty). Adapters that can't
+store a field leave it at its default rather than faking it.
 
 ## Adding a provider
 
 1. Implement `adapters/base.Adapter` in `adapters/<name>.py` (all abstract verbs;
-   `create`/`link` only if the backend supports them).
+   `create`/`apply`/`edit`/`link` only if the backend supports them).
 2. Register it in `core/registry.py`'s `_PROVIDERS`.
 3. Add `examples/config.<name>.toml`.
 
 No skill changes are ever required — that's the point of the split.
 
-## Skill pack (`skills/`, `agents/`)
+## Editing the skill pack
 
-The `skills/*/SKILL.md` files are the provider-agnostic SDLC pipeline (select → triage →
-plan → open-pr → ci-fix → self-review → respond-to-review → deploy, orchestrated by
-`automated-sdlc`). They depend only on `tkt` + `.sdlc/config.toml`. Two rules when editing
-them:
-
-- **No backend specifics in skill text.** Speak in roles, and read all toolchain/VCS/deploy
-  settings through `tkt cfg` (e.g. `tkt cfg build.test --pkg X`,
-  `tkt cfg vcs.branch_fmt --ticket K --slug s`). Never hardcode Jira/pnpm/GitHub/repo names.
-- VCS (PR/CI/merge via `gh`) and infra (preview/deploy) are still GitHub/cloud-shaped, but
-  repo/branch/reviewer/workflow values come from config; genuinely infra-specific steps are
-  marked `PROJECT-SPECIFIC` in the skill text.
+The rules live in `AGENTS.md` ("Editing skills"). The short version: no backend
+specifics in skill text, read every toolchain/VCS/deploy value through `tkt cfg`, and
+remember that a skill's frontmatter `description` feeds the generated `AGENTS.md` block
+that `sync-pack` writes into consumer repos.


### PR DESCRIPTION
## Summary
`AGENTS.md` and `CLAUDE.md` had drifted from the code and restated a lot
of the same material. This splits them by concern and corrects both
against the current source: `AGENTS.md` is the harness-facing contract
(verbs, roles, exit codes, portability rules, skill pack) and
`CLAUDE.md` covers repo internals (module map, ticket schema, adding a
provider), pointing at `AGENTS.md` for the rest.

## Changes
- Dropped the `PLAN.md` reference; the file was deleted in aeab617
- Documented the `apply`, `edit` and `sync-pack` verbs with their real
  flags, plus the adapter-backed `cfg priorities`
- Added `core/pack.py` and `core/ticketdoc.py` to the module map
- Documented `agent_status`, the `due`/`scheduled`/`completed` date
  fields, and the omit-vs-empty-string semantics of `tkt edit`
- Noted that `doctor` folds in the pack check, added `sync-skills` to
  the skill table, and added `docs/` + `scripts/` pointers
- Moved the exit-code table into `AGENTS.md`, where skills branch on it
- Recorded that `sync-pack`'s managed block applies to consumer repos;
  this repo's own `AGENTS.md` has no markers and stays hand-maintained

## Test Plan
Docs-only; no runtime surface to exercise. Every factual claim was
checked against source rather than memory:
- `adapters/base.py` has 9 `@abstractmethod` verbs (a grep count of 10
  was a comment mentioning "@abstractmethods"); optional verbs are
  `create`/`apply`/`edit`/`link`
- `list` requires exactly one of `--tier`/`--query`; `cfg priorities`
  loads an adapter while `lane`/`cfg`/`init`/`sync-pack` do not
- `AGENT_STATES` is idle/processing/waiting/done/blocked
- The `tkt:12` line reference still resolves; `examples/` covers all
  five providers