### PR TITLE
feat(init): seed [build] from project package manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ separate harness-specific files).
 | `tkt lane ROLE` | resolve role → provider lane name |
 | `tkt cfg DOTTED.KEY [--pkg/--ticket/--slug]` | read config + template substitution |
 | `tkt cfg priorities` | backend-aware priority list, highest-first |
-| `tkt init --provider P [--dir D] [--link-skills] [--sample] [--force]` | scaffold `.sdlc/` |
+| `tkt init --provider P [--dir D] [--link-skills] [--sample] [--force] [--no-detect-build]` | scaffold `.sdlc/` (seeds `[build]` from the project's package manager) |
 | `tkt sync-pack [--dir D] [--all-harnesses] [--check]` | install the pack into a consumer repo as committed copies |
 | `tkt doctor` | validate auth + reachability + board model + pack sync |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ Two layers, connected only by the verb contract and the normalized schema:
     writes outside recorded paths, and is idempotent.
   - `errors.py` — typed errors → exit codes (see `AGENTS.md` for the table). Errors
     always go to stderr with a non-zero exit so skills branch on codes.
+  - `toolchain.py` — best-effort detection of a project's build/test/typecheck/lint
+    commands (package.json scripts, Cargo.toml, go.mod, pyproject.toml, Makefile)
+    plus the `[build]`-table rewrite `init` applies to the copied example config.
+    Advisory only: a key the project doesn't declare keeps the example's value.
   - `scaffold.py` — implements `tkt init`.
 - **`adapters/`** — one file per backend, each subclassing `adapters/base.Adapter`.
   - `base.py` is the contract: required `@abstractmethod` verbs (whoami, list, view,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ tkt doctor                        # validate auth + board model
 `tkt init` flags: `--provider` (required non-interactively; prompts on a TTY),
 `--dir` (target, default cwd), `--force` (overwrite existing config),
 `--link-skills` (symlink the pack into `.claude/`), `--sample` (markdown starter
-ticket). It refuses to clobber an existing `.sdlc/config.toml` without `--force`.
+ticket), `--no-detect-build` (skip toolchain detection). It refuses to clobber an
+existing `.sdlc/config.toml` without `--force`.
+
+`init` seeds `[build]` from whatever the project already declares, so skills run
+the project's real commands without hand-editing: `package.json` scripts (runner
+picked from `packageManager`/lockfile — pnpm, yarn, bun, npm), `Cargo.toml`,
+`go.mod`, `pyproject.toml` (pytest/mypy/pyright/ruff/flake8, prefixed with
+`uv run`/`poetry run` when a lockfile says so), or `Makefile` targets. Keys the
+project doesn't declare keep the example's value.
 
 Manual equivalent, if you prefer:
 
@@ -91,7 +99,7 @@ Every adapter implements these. Read verbs accept `--json` (either side of the v
 | `tkt edit KEY [--summary S] [--body B] [--priority P] [--assignee A] [--add-label L] [--remove-label L] [--due D] [--scheduled D] [--completed D] [--agent-status S]` | edit content/fields in place (only flags passed change; status excluded — use `transition`). Dates are ISO `YYYY-MM-DD`; pass `""` to clear. `--agent-status` is the agent execution state (`idle`/`processing`/`waiting`/`done`/`blocked`, `""` to clear) a board can surface; markdown backend only. | normalized ticket / `--json` |
 | `tkt apply --new --file F` / `tkt apply KEY --file F` | create / update a ticket from a full markdown doc (frontmatter + body; `-` = stdin). Owns the doc except `status` (use `transition`) and backend-managed sections (Comments), preserved verbatim. | new/updated key / `--json` ticket |
 | `tkt apply --template` | print the create-document template the editor opens with | markdown doc |
-| `tkt init --provider P [--dir D] [--force] [--link-skills] [--sample]` | scaffold `.sdlc/config.toml` (+ optionally link the pack) | next-steps summary |
+| `tkt init --provider P [--dir D] [--force] [--link-skills] [--sample] [--no-detect-build]` | scaffold `.sdlc/config.toml` (+ optionally link the pack) | next-steps summary |
 | `tkt lane ROLE` | resolve ROLE → provider lane name | string (config-only, no backend) |
 | `tkt cfg DOTTED.KEY [--pkg X] [--ticket K] [--slug S]` | read a config value; substitutes `{pkg}`/`{key}`/`{key-lower}`/`{slug}` | string / `--json` |
 | `tkt doctor` | validate auth + reachability + board model | checks; exit 1 if any fail |
@@ -282,6 +290,7 @@ core/
   registry.py  provider name -> adapter (lazy import)
   schema.py    Ticket / Worklog / Check dataclasses + to_dict()
   query.py     shared JQL-subset evaluator (markdown + linear + openkanban)
+  toolchain.py detect build/test/typecheck/lint commands for `tkt init`
   ticketdoc.py canonical full-ticket markdown doc parser (for `tkt apply`)
   scaffold.py  `tkt init` scaffolder
   errors.py    typed errors -> exit codes

--- a/core/cli.py
+++ b/core/cli.py
@@ -154,6 +154,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="symlink skills/ + agents/ into .claude/")
     sp.add_argument("--sample", action="store_true",
                     help="markdown: also write a starter ticket")
+    sp.add_argument("--no-detect-build", action="store_false", dest="detect_build",
+                    help="keep the example's [build] commands instead of seeding "
+                         "them from the project's package manager")
 
     sp = add("sync-pack")
     sp.add_argument("--all-harnesses", action="store_true", dest="all_harnesses",
@@ -245,7 +248,8 @@ def main(argv: list[str]) -> int:
         if args.verb == "init":
             from .scaffold import init as scaffold_init
             return scaffold_init(args.provider, args.dir, args.force,
-                                 args.link_skills, args.sample, interactive=True)
+                                 args.link_skills, args.sample, interactive=True,
+                                 detect_build=args.detect_build)
 
         # `sync-pack` installs pack files into a consumer tree; it needs no
         # config and may run before `tkt init`.

--- a/core/scaffold.py
+++ b/core/scaffold.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 from pathlib import Path
 
+from . import toolchain
 from .errors import ConfigError, UsageError
 
 PACK_ROOT = Path(__file__).resolve().parent.parent
@@ -37,7 +38,8 @@ Created by `tkt init --sample`. Edit or delete this file.
 
 
 def init(provider: str | None, target_dir: str, force: bool,
-         link_skills: bool, sample: bool, interactive: bool) -> int:
+         link_skills: bool, sample: bool, interactive: bool,
+         detect_build: bool = True) -> int:
     providers = available_providers()
 
     if not provider:
@@ -68,6 +70,9 @@ def init(provider: str | None, target_dir: str, force: bool,
     shutil.copyfile(src, cfg)
     print(f"wrote {cfg}  (from examples/config.{provider}.toml)")
 
+    if detect_build:
+        _seed_build(cfg, target)
+
     if sample and provider == "markdown":
         board = sdlc / "board"
         board.mkdir(parents=True, exist_ok=True)
@@ -96,6 +101,23 @@ def init(provider: str | None, target_dir: str, force: bool,
         print("  4. Activate skills: `tkt sync-pack` (committed copies — best for "
               "cloud/CI harnesses like Copilot) or `tkt init --link-skills` (symlinks)")
     return 0
+
+
+def _seed_build(cfg: Path, target: Path) -> None:
+    """Replace the example's placeholder [build] commands with detected ones."""
+    found, label = toolchain.detect(target)
+    if not found:
+        print("  no build/test commands detected — [build] left at example "
+              "defaults (edit by hand)")
+        return
+    cfg.write_text(toolchain.apply_to_config(cfg.read_text(), found))
+    print(f"  detected {label} toolchain; [build] set to:")
+    for key in toolchain.KEYS:
+        if key in found:
+            print(f"    {key:<9} = {found[key]}")
+    missing = [k for k in toolchain.KEYS if k not in found]
+    if missing:
+        print(f"  not declared by the project (left as-is): {', '.join(missing)}")
 
 
 def _link_pack(target: Path) -> None:

--- a/core/toolchain.py
+++ b/core/toolchain.py
@@ -1,0 +1,210 @@
+"""Best-effort detection of a project's build/test/typecheck/lint commands.
+
+Used by `tkt init` to seed `[build]` in the scaffolded config from whatever the
+project already declares (package.json scripts, Cargo.toml, Makefile targets, ...)
+instead of the example's placeholder `make build` / `true`.
+
+Detection is advisory: a key is only reported when the project actually declares
+something for it, so the example's value survives for everything else. Runs before
+any config exists, so it never calls Config.load().
+"""
+import json
+import re
+import tomllib
+from pathlib import Path
+
+KEYS = ("build", "test", "typecheck", "lint")
+
+# script name -> config key. First match (in this order) per key wins.
+_NODE_SCRIPTS: dict[str, tuple[str, ...]] = {
+    "build": ("build",),
+    "test": ("test",),
+    "typecheck": ("typecheck", "type-check", "types", "tsc", "check-types"),
+    "lint": ("lint",),
+}
+
+_MAKE_TARGETS: dict[str, tuple[str, ...]] = {
+    "build": ("build",),
+    "test": ("test", "check"),
+    "typecheck": ("typecheck", "type-check", "types"),
+    "lint": ("lint",),
+}
+
+
+def detect(root: Path) -> tuple[dict[str, str], str]:
+    """Return ({key: command}, ecosystem-label). Empty dict when nothing detected."""
+    for probe in (_detect_node, _detect_rust, _detect_go, _detect_python, _detect_make):
+        found, label = probe(root)
+        if found:
+            return found, label
+    return {}, ""
+
+
+# --- node ------------------------------------------------------------------
+
+def _node_runner(root: Path, pkg: dict) -> str:
+    declared = pkg.get("packageManager")
+    if isinstance(declared, str) and declared:
+        name = declared.split("@", 1)[0].strip()
+        if name in ("pnpm", "yarn", "bun", "npm"):
+            return name
+    for lockfile, runner in (("pnpm-lock.yaml", "pnpm"), ("yarn.lock", "yarn"),
+                             ("bun.lockb", "bun"), ("bun.lock", "bun"),
+                             ("package-lock.json", "npm")):
+        if (root / lockfile).exists():
+            return runner
+    return "npm"
+
+
+def _detect_node(root: Path) -> tuple[dict[str, str], str]:
+    manifest = root / "package.json"
+    if not manifest.exists():
+        return {}, ""
+    try:
+        pkg = json.loads(manifest.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}, ""
+    scripts = pkg.get("scripts")
+    if not isinstance(scripts, dict):
+        return {}, ""
+
+    runner = _node_runner(root, pkg)
+    found = {}
+    for key, candidates in _NODE_SCRIPTS.items():
+        for name in candidates:
+            if isinstance(scripts.get(name), str):
+                found[key] = f"{runner} run {name}"
+                break
+    return found, f"node ({runner})" if found else ""
+
+
+# --- rust / go -------------------------------------------------------------
+
+def _detect_rust(root: Path) -> tuple[dict[str, str], str]:
+    if not (root / "Cargo.toml").exists():
+        return {}, ""
+    found = {"build": "cargo build", "test": "cargo test", "typecheck": "cargo check"}
+    if (root / "clippy.toml").exists() or (root / ".clippy.toml").exists():
+        found["lint"] = "cargo clippy -- -D warnings"
+    return found, "rust (cargo)"
+
+
+def _detect_go(root: Path) -> tuple[dict[str, str], str]:
+    if not (root / "go.mod").exists():
+        return {}, ""
+    return {"build": "go build ./...", "test": "go test ./...",
+            "typecheck": "go vet ./..."}, "go"
+
+
+# --- python ----------------------------------------------------------------
+
+def _python_runner(root: Path) -> str:
+    if (root / "uv.lock").exists():
+        return "uv run "
+    if (root / "poetry.lock").exists():
+        return "poetry run "
+    return ""
+
+
+def _detect_python(root: Path) -> tuple[dict[str, str], str]:
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():
+        return {}, ""
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}, ""
+
+    # pyproject has no standard script table, so infer from the tools it configures
+    # plus whatever the dependency lists name.
+    tools = set(data.get("tool", {}))
+    blob = json.dumps(data.get("project", {})) + json.dumps(data.get("dependency-groups", {}))
+    names = tools | set(re.findall(r"[A-Za-z0-9_-]+", blob.lower()))
+
+    run = _python_runner(root)
+    found = {}
+    if "pytest" in names:
+        found["test"] = f"{run}pytest"
+    if "mypy" in names:
+        found["typecheck"] = f"{run}mypy ."
+    elif "pyright" in names:
+        found["typecheck"] = f"{run}pyright"
+    if "ruff" in names:
+        found["lint"] = f"{run}ruff check ."
+    elif "flake8" in names:
+        found["lint"] = f"{run}flake8"
+    return found, "python" if found else ""
+
+
+# --- make ------------------------------------------------------------------
+
+def _make_targets(root: Path) -> set[str]:
+    for name in ("Makefile", "makefile", "GNUmakefile"):
+        path = root / name
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text()
+        except OSError:
+            return set()
+        return set(re.findall(r"^([A-Za-z0-9_.-]+)\s*:(?!=)", text, re.MULTILINE))
+    return set()
+
+
+def _detect_make(root: Path) -> tuple[dict[str, str], str]:
+    targets = _make_targets(root)
+    if not targets:
+        return {}, ""
+    found = {}
+    for key, candidates in _MAKE_TARGETS.items():
+        for name in candidates:
+            if name in targets:
+                found[key] = f"make {name}"
+                break
+    return found, "make" if found else ""
+
+
+# --- config rewrite --------------------------------------------------------
+
+_KEY_RE = re.compile(r"^(?P<key>[A-Za-z0-9_]+)(?P<pad>\s*)=")
+
+
+def apply_to_config(text: str, found: dict[str, str]) -> str:
+    """Rewrite `key = "..."` lines inside the config's [build] table.
+
+    Only keys present in `found` are touched; alignment padding and every other
+    table are left byte-identical. A [build] table with no line for a detected
+    key gains one at the end of the table.
+    """
+    if not found:
+        return text
+
+    lines = text.splitlines(keepends=True)
+    start = next((i for i, line in enumerate(lines)
+                  if line.strip() == "[build]"), None)
+    if start is None:
+        block = "\n[build]\n" + "".join(
+            f'{k:<9} = "{v}"\n' for k, v in found.items() if k in KEYS)
+        return text if not block.strip() else text.rstrip("\n") + "\n" + block
+
+    end = next((i for i in range(start + 1, len(lines))
+                if lines[i].lstrip().startswith("[")), len(lines))
+
+    seen = set()
+    for i in range(start + 1, end):
+        m = _KEY_RE.match(lines[i].strip())
+        if not m or m.group("key") not in found:
+            continue
+        key = m.group("key")
+        seen.add(key)
+        pad = _KEY_RE.match(lines[i].lstrip()).group("pad")
+        lines[i] = f'{key}{pad}= "{found[key]}"\n'
+
+    extra = [f'{k:<9} = "{v}"\n' for k, v in found.items()
+             if k in KEYS and k not in seen]
+    if extra:
+        tail = end
+        while tail > start + 1 and not lines[tail - 1].strip():
+            tail -= 1
+        lines[tail:tail] = extra
+    return "".join(lines)


### PR DESCRIPTION
## What

`tkt init` copied the example config's placeholder `[build]` commands (`make build`, `true`) verbatim, so every scaffolded project had to hand-edit them before any skill could run the real toolchain. It now seeds `[build]` from whatever the project already declares.

Detection order (first match wins):

| Source | Commands |
|---|---|
| `package.json` scripts | runner from `packageManager` or lockfile (pnpm/yarn/bun/npm) |
| `Cargo.toml` | `cargo build` / `test` / `check`, clippy when configured |
| `go.mod` | `go build ./...` / `go test ./...` / `go vet ./...` |
| `pyproject.toml` | pytest/mypy/pyright/ruff/flake8, prefixed `uv run` / `poetry run` when a lockfile says so |
| `Makefile` | matching targets |

**Detection is advisory.** A key the project doesn't declare (a node repo with no `lint` script) keeps the example's value rather than gaining a fabricated command — reported on stdout as `not declared by the project (left as-is): lint`. `--no-detect-build` opts out entirely.

## Design

New `core/toolchain.py` holds both halves: `detect(root)` returns `({key: cmd}, label)`, and `apply_to_config()` rewrites only the `key = "..."` lines inside the `[build]` table, preserving alignment padding and leaving every other table byte-identical. No new deps — `tomllib` + `json` + `re`.

Skills are unaffected; they keep reading `tkt cfg build.*`, which now returns something real on a fresh scaffold.

## Testing

This repo has no test suite, so per `CLAUDE.md` the verb was exercised live against four fixtures:

| Fixture | Result |
|---|---|
| node, `packageManager: pnpm@9.1.0` | `pnpm run build` / `pnpm run test` / `pnpm run type-check`; `lint` kept |
| `pyproject.toml` + `uv.lock` | `uv run pytest` / `uv run mypy .` / `uv run ruff check .`; `build` kept |
| `Makefile` | `make build` / `make test` |
| bare dir | nothing detected, defaults kept |

Also confirmed the rewritten config still parses (`tkt cfg build.test` → `pnpm run test`), that the rewrite handles the jira example's differently-shaped `[build]` block, and that `--no-detect-build` leaves the example untouched.
