### PR TITLE
feat: port downstream SDLC pack updates upstream

### DIFF
--- a/.agents/skills/automated-sdlc/SKILL.md
+++ b/.agents/skills/automated-sdlc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: automated-sdlc
 description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+model_tier: standard
 ---
 
 # Automated SDLC
@@ -10,6 +11,32 @@ sub-skills with explicit human gates and per-lane time annotation. **Every
 ticketing/board operation goes through `tkt`**, so the same pipeline runs on Jira,
 GitHub Issues+Projects, Linear, qi, or a markdown board — the backend and board
 shape are declared in `.sdlc/config.toml`.
+
+## Model routing
+
+Each sub-skill declares a `model_tier` (`cheap` | `standard` | `deep`) in its
+frontmatter. Resolve the tier to a concrete model from project config before
+invoking a phase:
+
+```shell
+tkt cfg models.deep         # exit 4 = no [models] table -> skip routing entirely
+```
+
+| Tier | Phases |
+|------|--------|
+| cheap | `select-ticket`, `check-blockers`, `triage-ticket` |
+| deep | `plan-ticket` |
+| standard | everything else |
+
+**Escalate on failure, never start high.** A cheap-tier phase that returns a wrong
+or ambiguous result gets retried once at standard. If `self-review` cycles 3+ times
+without converging, re-plan at deep and resume the review at standard. Escalation
+is per-invocation — subsequent phases resume at their assigned tier.
+
+**Never block on routing.** If the harness cannot select a model, or `[models]` is
+unset, proceed on the session default. No phase requires a specific model to
+produce correct output — routing is a cost optimization. Full policy and the
+per-harness support matrix: [docs/model-routing.md](../../docs/model-routing.md).
 
 ## Prerequisites
 
@@ -108,15 +135,20 @@ esac
 Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 `deliverable` sets are defined in `[issue_types]`.
 
-### Phase 2: Plan
+### Phase 2: Plan (→ `sdlc-planner`)
 
-**Invoke `plan-ticket`.** Output: files, test strategy, risks. External dep missing
-→ see "External blocker handling".
+**Delegate to `sdlc-planner`** with the ticket JSON (`tkt view "$KEY" --json`) as
+context. It returns files to touch, ordered steps, risks, test strategy, and
+parallelism hints. External dep missing → see "External blocker handling".
 
-### Phase 3: Implement + test
+**Fallback:** invoke `plan-ticket` inline. Same output, same context — acceptable
+here because planning is not adversarial.
+
+### Phase 3: Implement + test (→ `sdlc-executor`)
 
 1. Branch: `git checkout -b "$(tkt cfg vcs.branch_fmt --ticket "$KEY" --slug "<slug>")"`
-2. Implement per plan.
+2. Implement per plan. **Delegate to `sdlc-executor`**, which is scoped to the repo
+   worktree and cannot transition tickets or push. Fallback: implement inline.
 3. After each logical unit, run the configured toolchain:
 
    ```shell
@@ -129,7 +161,24 @@ Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 
 ### Phase 4: Self-review (adversarial)
 
-**Invoke `self-review`** in a loop until clean.
+**Invoke `self-review`** in a loop until clean. Its review pass delegates to
+`sdlc-reviewer` (read-only, findings only) and its check pass to `sdlc-verifier`
+(PASS/FAIL with command output as evidence) — both fresh contexts that did not
+write the code.
+
+### Phase 4.5: Adversarial QA (optional, → `qa-engineer`)
+
+Run when the change carries real failure risk — new endpoints, auth, money, data
+migrations, concurrency — or when Phase 4 flagged a test gap. Skip for docs-only
+and trivial changes; say which and why.
+
+**Delegate to `qa-engineer`**, which routes to the QA skills: `qa-strategy` (test
+plan from acceptance criteria), `qa-author` (adversarial tests, red-before-green),
+`qa-critique` (existing-suite assessment). See
+[docs/qa-suite-design.md](../../docs/qa-suite-design.md).
+
+A P0 finding sends the ticket back to Phase 3. **Fallback:** invoke `qa-author`
+inline against the modules Phase 4 flagged.
 
 ### Phase 5: Open PR
 

--- a/.agents/skills/check-blockers/SKILL.md
+++ b/.agents/skills/check-blockers/SKILL.md
@@ -3,6 +3,7 @@ name: check-blockers
 description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
 model: claude-haiku-4-5
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Check Blockers
@@ -78,7 +79,7 @@ automatically:
 
 ```
 Auto-unblock candidates (confirm first):
-  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress
+  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress (and `tkt edit <KEY> --agent-status processing`)
 ```
 
 ### 6. Optional nudge on stale blockers (after human confirms)

--- a/.agents/skills/ci-fix/SKILL.md
+++ b/.agents/skills/ci-fix/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-fix
 description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+model_tier: standard
 ---
 
 # CI Fix
@@ -85,10 +86,27 @@ tkt comment "$KEY" "CI failing after 3 attempts on PR #$PR — needs human inves
 ### 9. Flaky tests
 
 Non-deterministic failure (passes locally, random timeout): `gh run rerun <run-id> --failed`
-**once**. If it fails again, treat as real.
+**once**. If it fails again on the same assertion but with a different value or
+timing, it is a flake, not a regression.
+
+Hand the root cause to **`qa-flake-triage`** rather than patching around it:
+
+```
+⚠️ FLAKE DETECTED: <test name> in <file>
+  - Failed with: <assertion/error>
+  - Passed on rerun: yes/no
+  → Recommend: invoke `qa-flake-triage` for root-cause classification and fix.
+```
+
+`ci-fix` must **not**: add `sleep()` or raise timeouts, skip or disable the test,
+or rerun more than once. Each of those turns a real race condition into a silent
+one. If the flake still blocks CI after one rerun, flag it and stop — the QA suite
+classifies the cause (race, shared state, clock sensitivity, test ordering) and
+proposes a real fix.
 
 ## Output
 
 - CI status: green / still failing
 - Fixes applied (commits)
+- Flake findings (handed to `qa-flake-triage`)
 - If stuck: the unresolved failure

--- a/.agents/skills/complete-deliverable/SKILL.md
+++ b/.agents/skills/complete-deliverable/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: complete-deliverable
 description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Complete Deliverable
@@ -41,6 +42,7 @@ tkt comment "$KEY" "Deliverable complete: <summary>.
 Link: <url>
 Time in In Progress: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 tkt transition "$KEY" done
+tkt edit "$KEY" --agent-status done
 ```
 
 ## Edge cases
@@ -55,8 +57,8 @@ tkt transition "$KEY" done
 - **Spike with no concrete next step**: comment findings + a recommended follow-up
   ticket, mark `done`. The follow-up is a separate Story.
 - **Blocked deliverable**: `tkt worklog "$KEY" --from-role in_progress` then
-  `tkt transition "$KEY" blocked` with a blocker comment (see `automated-sdlc` →
-  External blocker handling).
+  `tkt transition "$KEY" blocked` followed by `tkt edit "$KEY" --agent-status blocked`
+  with a blocker comment (see `automated-sdlc` → External blocker handling).
 
 ## Output
 

--- a/.agents/skills/deploy-preview/SKILL.md
+++ b/.agents/skills/deploy-preview/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deploy-preview
 description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+model_tier: standard
 ---
 
 # Deploy Preview

--- a/.agents/skills/deploy-ready/SKILL.md
+++ b/.agents/skills/deploy-ready/SKILL.md
@@ -2,6 +2,7 @@
 name: deploy-ready
 description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Deploy Ready
@@ -123,7 +124,7 @@ SHIPPED=$(git log <prev-prod-tag>..origin/"$DEFAULT_BRANCH" --format='%s %b' \
 If your prod workflow truly deploys → transition each to `done`:
 
 ```shell
-# for K in $SHIPPED; do tkt transition "$K" done; done
+# for K in $SHIPPED; do tkt transition "$K" done; tkt edit "$K" --agent-status done; done
 ```
 
 If it's a build/auth stub → comment and leave in `deploy_ready` for human Done:

--- a/.agents/skills/hotfix-revert/SKILL.md
+++ b/.agents/skills/hotfix-revert/SKILL.md
@@ -2,6 +2,7 @@
 name: hotfix-revert
 description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Hotfix Revert
@@ -50,6 +51,7 @@ HOTFIX_KEY=$(tkt create --type Bug \
 # Link hotfix → original. "Fixes" is the outward description (HOTFIX Fixes TARGET).
 tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
 tkt transition "$HOTFIX_KEY" in_progress
+tkt edit "$HOTFIX_KEY" --agent-status processing
 ```
 
 ### 3. Create the revert branch
@@ -80,6 +82,7 @@ gh pr create --repo "$REPO" --title "hotfix($HOTFIX_KEY): revert $TARGET_TICKET"
 Reverts $TARGET_SHA (from $TARGET_TICKET). Ticket: $HOTFIX_URL
 Production incident — bypassing standard QA per hotfix policy. Single signoff."
 tkt transition "$HOTFIX_KEY" review
+tkt edit "$HOTFIX_KEY" --agent-status waiting
 ```
 
 ### 6. Request human signoff (skip the bot loop)
@@ -142,7 +145,7 @@ WL=$(tkt worklog "$HOTFIX_KEY" --from-role in_progress --note "Hotfix run comple
 tkt comment "$HOTFIX_KEY" "Production workflow completed. Verify the revert serves prod traffic, then transition to Done. \
 Agent lane time: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 tkt comment "$TARGET_TICKET" "Reverted by $HOTFIX_KEY due to a production regression. Redo the work with the regression addressed before re-attempting."
-# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done
+# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done; tkt edit "$HOTFIX_KEY" --agent-status done
 ```
 
 ## Output

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: open-pr
 description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+model_tier: standard
 ---
 
 # Open PR
@@ -97,6 +98,7 @@ if [ "$CLASS" = "full_sdlc" ]; then
   # Annotate time in in_progress, then move to review.
   WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL" --json)
   tkt transition "$KEY" review
+  tkt edit "$KEY" --agent-status waiting
   tkt comment "$KEY" "PR opened: $PR_URL. Review requested. Time in In Progress: \
 $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 else

--- a/.agents/skills/plan-ticket/SKILL.md
+++ b/.agents/skills/plan-ticket/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-ticket
 description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+model_tier: deep
 ---
 
 # Plan Ticket

--- a/.agents/skills/qa-author/SKILL.md
+++ b/.agents/skills/qa-author/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: qa-author
+description: 'Write adversarial tests focused on failure modes, edge cases, and the Break-It Checklist. Produces test files — not essays. Enforces red-before-green rule.'
+model_tier: standard
+---
+
+# QA Author — Write Adversarial Tests
+
+Write tests that find where code breaks. Prioritize failure modes over happy
+paths. The developer already tested the happy path — we exist to find what they
+missed.
+
+## Input
+
+- File path or diff of the implementation under test
+- Optionally: a `TEST-PLAN.md` from `qa-strategy` (if available, implement its
+  test cases rather than re-deriving them)
+
+## Steps
+
+### 1. Read the implementation
+
+Read the file(s) being tested. Identify:
+- Public API surface (exports, endpoints, handlers)
+- Internal branching logic
+- External dependencies (DB, APIs, file system)
+- Error handling paths
+
+### 2. Read existing tests
+
+Find and read existing test files for the same module. Identify what's already
+covered to avoid duplication.
+
+### 3. Detect stack and load reference
+
+Check the file extension and import patterns, then load the appropriate reference
+for framework-specific testing patterns:
+
+| Pattern | Reference |
+| --- | --- |
+| `.ts` + `@nestjs/*` imports | `references/nestjs.md` |
+| `.tsx` + `react` imports | `references/react.md` |
+| `.go` files | `references/go.md` |
+| `.ts` + `aws-cdk-lib` imports | `references/cdk.md` |
+| `.ts` + `hx-` attributes in templates | `references/htmx-lambda.md` |
+
+If no reference matches, use the project's existing test conventions (infer from
+neighboring test files).
+
+### 4. Walk the Break-It Checklist
+
+For the implementation under test, enumerate failure scenarios:
+
+**Boundary Analysis**
+- 0, 1, n, n+1 for every numeric input
+- Empty array, empty string, empty object, null, undefined
+- Single-element collections
+- At configured limits, at integer overflow, at payload size limits
+- Negative numbers, negative indexes
+
+**Null / Undefined / Missing**
+- null vs undefined vs empty string
+- Missing key vs key-present-with-null-value
+- Optional chaining paths that produce undefined mid-chain
+- JSON.parse of responses that omit fields
+
+**Authorization**
+- User A reading/writing user B's resources
+- Horizontal and vertical privilege escalation
+- Resource enumeration via sequential IDs
+- Token expiry mid-operation
+
+**Concurrency**
+- Two writes, same row, same millisecond
+- Read-then-write races (TOCTOU)
+- Connection pool exhaustion
+
+**Idempotency & Retries**
+- Client sends request twice
+- Network timeout → retry → original succeeded
+- Partial retry after partial success
+
+**Partial Failure**
+- DB write succeeds, external API doesn't — state consistency
+- Multi-step transaction: step N fails — what's left behind
+
+**Time**
+- Timezone handling (UTC vs local)
+- DST transitions
+- Token/session expiry at exact boundary
+
+**Pagination & Ordering**
+- Unstable sort with ties
+- Cursor drift during writes
+- Page size = 0, page = -1, page beyond total
+
+**Encoding & Input**
+- Unicode (emoji, combining characters, zero-width joiners)
+- 10k-character inputs
+- Script injection in user-writable fields
+- Path traversal in filenames
+
+**Error Propagation**
+- Error messages don't leak internals
+- Correct HTTP status codes
+- Error response matches documented schema
+
+### 5. Write tests
+
+Write test files following the project's conventions:
+- Group: unit → integration → e2e
+- Each test has a descriptive name stating the scenario and expected outcome
+- Assertions are specific — never `toBeDefined()` alone
+- Tests are isolated — no shared mutable state between tests
+
+### 6. Verify red-before-green (mandatory)
+
+**A new test MUST fail first against the unfixed/unmocked code path it exercises.**
+
+For each test written:
+1. Identify what makes it fail (the bug or missing behavior it catches)
+2. Document how to verify the red state
+3. If a test passes immediately, investigate:
+   - The bug doesn't exist → remove the test
+   - The test doesn't exercise the failure path → fix the test
+   - The assertion is too weak → strengthen it
+
+## Forbidden Cheats
+
+These are explicitly forbidden. Violation means the test is worthless:
+
+| Cheat | Why forbidden |
+| --- | --- |
+| `.skip()` or delete a failing test | Deleting evidence is not fixing |
+| Weaken assertion to match wrong output | You encoded the bug as a spec |
+| `sleep(5000)` to paper over a flake | Hidden race condition behind a prayer |
+| Mock the unit under test | You're testing your mock, not your code |
+| `expect(result).toBeDefined()` alone | Proves nothing except it didn't throw |
+| Catch-all try/catch that swallows errors | Makes the test unfailable |
+| Test that passes regardless of implementation | Tautological — delete it |
+
+## Output
+
+Test files in the project's testing convention. No essays — working test code.
+
+Each file includes a header comment:
+
+```
+// QA Author — adversarial tests
+// Break-It dimensions covered: [list]
+// See TEST-PLAN.md TC-X.Y for requirements mapping (if applicable)
+```
+
+## Guardrails
+
+- **Write only test files.** Only create/modify files matching `**/*.test.*`,
+  `**/*.spec.*`, `**/__tests__/**`, or `**/test/**`.
+- **Never modify implementation code.** If the implementation is buggy, write a
+  test that proves it — don't fix the bug.
+- **Never transition tickets.** No `tkt transition`, `tkt comment`,
+  or `tkt create`.
+- **Never commit or push.** Write files only. The user/executor reviews and commits.
+- **No git mutations.** Never `git commit`, `git push`, `git add`.

--- a/.agents/skills/qa-bug-report/SKILL.md
+++ b/.agents/skills/qa-bug-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: qa-bug-report
+description: 'Produce a structured bug report with minimal reproduction steps from a failing scenario. Optionally creates a ticket via tkt create.'
+model_tier: cheap
+---
+
+# QA Bug Report — Structured Reproduction
+
+Produce a structured, actionable bug report from a failing scenario. Distills
+test output, error logs, or user reports into minimal reproduction steps with
+clear expected/actual behavior.
+
+## Input
+
+- A failing scenario: test output, error log, user report, or observed behavior
+- Optionally: the code path involved
+
+## Steps
+
+### 1. Identify the failure
+
+From the input, extract:
+- What operation was attempted
+- What went wrong (error message, wrong output, crash, hang)
+- Under what conditions (specific inputs, timing, environment)
+
+### 2. Determine minimal reproduction steps
+
+Strip away everything that isn't required to trigger the failure:
+- What's the minimum setup?
+- What's the fewest steps to reproduce?
+- Can it be triggered from a test? From a curl command? From the UI?
+
+### 3. Classify severity
+
+| Severity | Criteria |
+| --- | --- |
+| **Critical** | Data loss, security breach, complete service outage |
+| **High** | Core feature broken, no workaround, affects many users |
+| **Medium** | Feature degraded, workaround exists, affects some users |
+| **Low** | Cosmetic, rare edge case, minimal user impact |
+
+### 4. Classify reproducibility
+
+| Reproducibility | Meaning |
+| --- | --- |
+| **Always** | Reproduces 100% of the time with given steps |
+| **Often** | Reproduces >50% of attempts |
+| **Intermittent** | Reproduces <50% — timing/state dependent |
+| **Rare** | Hard to reproduce — specific conditions required |
+
+### 5. Identify suspected root cause
+
+From reading the code path and error:
+- What function/module is likely at fault?
+- Is this a logic error, data issue, race condition, or configuration problem?
+- What would a fix likely involve?
+
+### 6. Format the report
+
+## Output
+
+```markdown
+## Bug Report
+
+**Summary:** <one-line description of the bug>
+**Severity:** Critical / High / Medium / Low
+**Component:** <package/module/service>
+**Reproducibility:** Always / Often / Intermittent / Rare
+
+### Steps to Reproduce
+1. <precondition or setup>
+2. <action>
+3. <action>
+4. Observe: <what goes wrong>
+
+### Expected Behavior
+<what should happen>
+
+### Actual Behavior
+<what actually happens, including error messages>
+
+### Environment
+- Branch: <branch name>
+- Commit: <short sha>
+- OS/Runtime: <if relevant>
+- Relevant config: <if relevant>
+
+### Evidence
+```
+<error log, stack trace, or test output — trimmed to relevant portion>
+```
+
+### Root Cause (suspected)
+<brief analysis of what's likely wrong>
+
+### Suggested Fix
+<what the fix would involve, if known>
+
+### Regression?
+- [ ] Yes — worked in <commit/version>, broken since <commit/version>
+- [ ] No — appears to be a pre-existing issue
+- [ ] Unknown — needs bisection
+```
+
+### 7. Optional: Create ticket
+
+If the user confirms, create a ticket:
+
+```shell
+tkt create \
+  --type Bug \
+  --summary "<one-line summary>" \
+  --description "<full report body>" \
+  --priority "<severity-mapped-priority>"
+```
+
+Do NOT create the ticket automatically — always ask first.
+
+## Guardrails
+
+- **Read-only by default.** Only create tickets when explicitly confirmed by user.
+- **No code modifications.** Document the bug, don't fix it.
+- **No ticket transitions.** Never `tkt transition` on existing tickets.
+- **No git mutations.** Never commit or push.
+- **Minimal, precise reports.** Every field must be specific and actionable.
+  "Something is broken" is not a bug report.
+- **No speculation without marking it.** If the root cause is uncertain, say
+  "suspected" — don't present guesses as facts.

--- a/.agents/skills/qa-critique/SKILL.md
+++ b/.agents/skills/qa-critique/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: qa-critique
+description: 'Evaluate existing test suite quality: coverage gaps, assertion strength, false confidence detection, Break-It Checklist compliance. Produces a scored assessment.'
+model_tier: deep
+---
+
+# QA Critique — Test Suite Quality Assessment
+
+Evaluate an existing test suite for adequacy. Finds coverage gaps, weak
+assertions, false confidence, and missing adversarial scenarios. Produces a
+scored assessment with prioritized recommendations.
+
+This skill does NOT write tests — it identifies what's missing so `qa-author`
+can fill the gaps.
+
+## Input
+
+- Test file paths (or a diff containing test changes)
+- Optionally: the implementation files they test
+
+## Steps
+
+### 1. Read the test files
+
+Read all test files in scope. Understand:
+- What modules/functions are under test
+- What scenarios are exercised
+- What assertions are made
+- How tests are structured (setup/teardown, isolation)
+
+### 2. Read the implementation under test
+
+Read the implementation code. Identify:
+- All branches and code paths
+- External dependencies and failure modes
+- Authorization checks (or their absence)
+- Error handling paths
+- Edge cases in business logic
+
+### 3. Evaluate coverage gaps
+
+For each public function / endpoint / handler in the implementation:
+- Is it tested at all?
+- Which branches have no test?
+- Which error paths are unexercised?
+
+### 4. Evaluate assertion quality
+
+For each assertion in the test suite:
+
+| Quality level | Example | Verdict |
+| --- | --- | --- |
+| **Strong** | `expect(result.amount).toBe(150.00)` | Good |
+| **Adequate** | `expect(result).toMatchObject({...})` | Acceptable |
+| **Weak** | `expect(result).toBeDefined()` | Flag |
+| **Meaningless** | `expect(true).toBe(true)` | Critical flag |
+| **Tautological** | Tests that pass regardless of implementation | Critical flag |
+
+### 5. Detect false confidence
+
+Tests that give a feeling of safety without providing it:
+
+- **Mock-heavy tests:** If the mock covers 80% of the code path, you're testing
+  the remaining 20% plus your mock setup. The integration gap is where bugs hide.
+- **Overly specific mocks:** Mock returns exactly what the code expects — proves
+  only that the code works when given perfect inputs.
+- **Assertion on mock calls only:** Verifying a function was called doesn't verify
+  the *result* is correct.
+- **Try/catch swallowing:** Test catches errors without asserting on them.
+
+### 6. Walk the Break-It Checklist
+
+Check which dimensions from the checklist are exercised:
+
+| Dimension | Exercised? | Missing scenarios |
+| --- | --- | --- |
+| Boundary (0, 1, n, n+1, max, negative, empty) | | |
+| Null / Undefined / Missing | | |
+| Authorization (horizontal, vertical, expiry) | | |
+| Concurrency (races, TOCTOU, pool exhaustion) | | |
+| Idempotency (double-submit, retry) | | |
+| Partial failure (DB + API mismatch) | | |
+| Time (timezone, DST, expiry boundary) | | |
+| Pagination (unstable sort, cursor drift) | | |
+| Encoding (unicode, injection, path traversal) | | |
+| Performance (N+1, unbounded, missing index) | | |
+| Error propagation (safe messages, correct codes) | | |
+
+### 7. Evaluate test isolation
+
+- Shared mutable state between tests?
+- Test ordering dependencies?
+- Global setup that hides individual test requirements?
+- Tests that only pass when run in a specific order?
+
+### 8. Evaluate maintenance burden
+
+- Overly brittle tests that break on refactors (testing implementation details)?
+- Snapshot tests without targeted assertions?
+- Deep mock hierarchies that mirror implementation structure?
+
+### 9. Score and produce report
+
+Score on a 1–10 scale:
+
+| Score | Meaning |
+| --- | --- |
+| 9–10 | Adversarial-quality suite, covers failure modes |
+| 7–8 | Good coverage, some gaps in edge cases |
+| 5–6 | Happy-path coverage, missing adversarial scenarios |
+| 3–4 | Sparse, weak assertions, significant gaps |
+| 1–2 | Cosmetic tests only, false confidence |
+
+## Output
+
+```markdown
+# Test Suite Critique — <file/module>
+
+## Score: N/10
+
+## Coverage Gaps (Critical)
+- [ ] <missing test scenario>
+- [ ] <untested branch/path>
+
+## Weak Assertions
+- `<file>:<line>` — <what's wrong with the assertion>
+
+## False Confidence
+- `<file>:<line>` — <why this test provides false safety>
+
+## Missing from Break-It Checklist
+- [ ] <dimension>: <specific missing scenario>
+
+## Test Isolation Issues
+- <shared state, ordering dependencies>
+
+## Maintenance Concerns
+- <brittle tests, over-mocking>
+
+## Recommendations (prioritized)
+1. (P0) <critical gap to fill>
+2. (P0) <security test to add>
+3. (P1) <important edge case>
+4. (P2) <nice-to-have improvement>
+
+## Dimensions Assessed
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Boundary | Partial | Missing n+1 for pagination |
+| Authorization | None | No authz tests at all |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only.** Do not modify any files.
+- **No ticket operations.** Never `tkt transition`, `tkt comment`,
+  `tkt create`.
+- **No git mutations.** Never commit, push, or modify history.
+- **Concrete over vague.** Every finding must reference a specific file:line and
+  explain what's wrong and what should be there instead.
+- **No false positives from ignorance.** If you can't determine whether a test is
+  adequate without reading more context, say so rather than guessing.

--- a/.agents/skills/qa-flake-triage/SKILL.md
+++ b/.agents/skills/qa-flake-triage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: qa-flake-triage
+description: 'Classify flaky test root causes and recommend fixes. Never papers over flakes with sleep or skip — finds the actual race condition, shared state, or timing issue.'
+model_tier: standard
+---
+
+# QA Flake Triage — Flaky Test Root-Cause Classification
+
+Diagnose non-deterministic test failures. Classify the flake, identify root cause,
+and propose a real fix — never `sleep()`, never `.skip()`.
+
+## Input
+
+- Test file path
+- Failure logs (from CI or local — `gh run view <id> --log-failed` if available)
+- Optionally: recent CI history showing the pattern
+
+## Steps
+
+### 1. Read the failing test
+
+Read the test code. Understand:
+- What it exercises
+- What assertions it makes
+- What setup/teardown it performs
+- What external resources it touches
+
+### 2. Read failure logs
+
+Gather evidence:
+- Error messages and stack traces
+- Timing information (how long did it take?)
+- Which specific assertion failed?
+- What was the actual vs expected value?
+
+If CI history is available:
+
+```shell
+# Recent runs of this test
+gh run list --workflow=<workflow> --limit=20 --json conclusion,startedAt,databaseId
+```
+
+### 3. Classify the flake
+
+| Class | Indicators | Root cause |
+| --- | --- | --- |
+| **Race condition** | Passes with delay, fails under load; timing-dependent assertions; async operations without proper synchronization | Missing await, no mutex, optimistic read |
+| **Shared state** | Fails only when run after specific other test; passes in isolation (`-run TestX`); order-dependent | Tests mutating shared DB/file/global without cleanup |
+| **Non-deterministic ordering** | Sorted assertions fail on ties; map iteration order; DB results without ORDER BY | Unstable sort, relying on insertion order |
+| **Clock sensitivity** | Fails near midnight, DST transitions, or second boundaries; token expiry assertions | Using `Date.now()` / `time.Now()` without mocking |
+| **External dependency** | Fails when network/service is slow or unavailable; timeout errors; connection refused | Real HTTP calls in tests, no retry/circuit-breaker |
+| **Resource exhaustion** | Fails later in the suite; connection pool errors; "too many open files" | Leaked connections, file handles, goroutines |
+| **Platform-specific** | Fails on CI but not local (or vice versa); OS, locale, timezone differences | Hardcoded paths, locale assumptions, Docker differences |
+
+### 4. Gather supporting evidence
+
+For the classified category, look for corroborating signals:
+
+**Race condition:**
+- Are there `async` operations without `await`?
+- Is there shared mutable state accessed from multiple execution paths?
+- Does the test use `setTimeout`/`time.Sleep` for synchronization?
+
+**Shared state:**
+- Is there a `beforeAll` without corresponding `afterAll` cleanup?
+- Do tests share a database table without per-test transactions?
+- Are there global variables mutated in tests?
+
+**Non-deterministic ordering:**
+- Does the assertion use strict equality on an array?
+- Is the data source a Map/object with non-guaranteed key order?
+- Is the DB query missing `ORDER BY`?
+
+**Clock sensitivity:**
+- Does the test compare timestamps with exact equality?
+- Is there a "created X seconds ago" assertion?
+- Does the test rely on `Date.now()` being stable across execution?
+
+**External dependency:**
+- Are there real HTTP calls (not mocked)?
+- Is there a database/service startup race on CI?
+- Are there DNS lookups that could timeout?
+
+**Resource exhaustion:**
+- Is the test suite run with connection pool limits?
+- Are streams/readers properly closed in tests?
+- Does `go test -race` detect goroutine leaks?
+
+**Platform-specific:**
+- Are file paths hardcoded with `/` or `\`?
+- Does the test assume a specific timezone?
+- Are there locale-dependent string comparisons?
+
+### 5. Propose a fix
+
+The fix must be a **real solution**, not a workaround:
+
+| Class | Correct fix | FORBIDDEN fix |
+| --- | --- | --- |
+| Race condition | Add proper synchronization (mutex, channel, await) | `sleep(5000)` |
+| Shared state | Per-test isolation (transaction, temp dir, fresh instance) | Running tests sequentially |
+| Non-deterministic ordering | Remove order dependency from assertion, add stable sort | `.skip()` |
+| Clock sensitivity | Mock time, use relative comparisons | Widening tolerance to minutes |
+| External dependency | Mock the external service, use test containers | Adding retry loops with backoff |
+| Resource exhaustion | Fix the leak (close connections, cancel contexts) | Increasing pool size |
+| Platform-specific | Use path.join, normalize TZ, use t.TempDir() | Skipping on specific platforms |
+
+### 6. Confidence assessment
+
+| Level | Meaning |
+| --- | --- |
+| **High** | Root cause identified with strong evidence (reproducer exists) |
+| **Medium** | Classification is likely, evidence is circumstantial |
+| **Low** | Multiple possible causes, need more data to confirm |
+
+## Output
+
+```markdown
+# Flake Triage — <test name>
+
+## Classification: <class>
+**Confidence:** High / Medium / Low
+
+## Evidence
+- <observation 1>
+- <observation 2>
+- <CI history pattern>
+
+## Root Cause
+<explanation of why this test is non-deterministic>
+
+## Proposed Fix
+```<language>
+// Before (flaky)
+<current code>
+
+// After (stable)
+<fixed code>
+```
+
+## Verification
+- Run `<command>` N times to confirm stability
+- Expected: 0 failures in N runs
+
+## If Fix Doesn't Work
+- Alternative hypothesis: <other possible cause>
+- Additional investigation: <what to check next>
+```
+
+## Guardrails
+
+- **Never paper over the flake.** `sleep()`, `.skip()`, widening tolerances,
+  increasing timeouts — all forbidden. These hide the problem.
+- **Never weaken assertions.** If the assertion is correct, the code or test
+  setup is wrong — fix that.
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only.
+- **May modify test files.** This skill can write fixes to test files (same
+  scope as `qa-author`: `**/*.test.*`, `**/*.spec.*`, `**/__tests__/**`,
+  `**/test/**`).
+- **Never modify implementation code.** If the implementation has a race
+  condition, document it and recommend a fix — don't apply it.
+- **No git mutations.** Never commit or push.

--- a/.agents/skills/qa-strategy/SKILL.md
+++ b/.agents/skills/qa-strategy/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: qa-strategy
+description: 'Generate a structured test plan from ticket requirements or a spec document. Maps acceptance criteria to test cases with priority, risk analysis, and coverage gaps. Provider-agnostic via tkt.'
+model_tier: deep
+---
+
+# QA Strategy — Test Plan from Spec
+
+Produce a structured test plan that maps requirements to concrete test cases.
+Prioritizes failure modes over happy paths. Operates under the assumption that
+the code is wrong until proven otherwise.
+
+This skill does NOT write test files — it produces the plan that `qa-author`
+executes against.
+
+## Input
+
+- Ticket key (`$KEY`) — requirements read via `tkt view "$KEY" --json`
+- OR a spec/requirements document path
+
+## Steps
+
+### 1. Extract acceptance criteria
+
+```shell
+tkt view "$KEY" --json | jq -r '.acceptance[]'
+```
+
+If input is a document rather than a ticket, extract testable assertions from
+the spec text.
+
+### 2. Walk the Break-It Checklist per criterion
+
+For each acceptance criterion, enumerate test cases across these dimensions:
+
+| Dimension | What to enumerate |
+| --- | --- |
+| **Boundary** | 0, 1, n, n+1, max, negative, empty, single-element |
+| **Null/Missing** | null vs undefined vs empty, missing keys, optional chaining traps |
+| **Authorization** | Horizontal escalation, vertical escalation, token expiry, resource enumeration |
+| **Concurrency** | Two writes same row, TOCTOU, pool exhaustion, deadlocks |
+| **Idempotency** | Double-submit, retry after timeout, partial retry |
+| **Partial failure** | DB write + API call mismatch, multi-step rollback |
+| **Time** | Timezones, DST, clock skew, expiry at boundary |
+| **Pagination** | Unstable sort, cursor drift, page=0, page beyond total |
+| **Encoding** | Unicode, RTL, 10k-char inputs, injection, path traversal, null bytes |
+| **Performance** | N+1 queries, over-fetching, unbounded loops, missing indexes |
+| **Error propagation** | Safe error messages, correct status codes, retry-after headers |
+
+Not every dimension applies to every criterion. Skip irrelevant ones — but
+explicitly state which were considered and dismissed.
+
+### 3. Assign priority
+
+| Priority | Meaning |
+| --- | --- |
+| P0 | Blocks release — security, data loss, core functionality broken |
+| P1 | Should fix before ship — important edge cases, degraded UX |
+| P2 | Nice to have — unlikely scenarios, cosmetic |
+
+### 4. Flag untested and untestable requirements
+
+- **Untested:** Acceptance criterion with no test case mapped to it
+- **Untestable:** Vague, subjective, or missing definition of done (e.g. "should
+  feel fast" — recommend: define latency SLO)
+
+### 5. Produce risk table
+
+For each identified risk:
+- What can break
+- Severity (Critical / High / Medium / Low)
+- Likelihood (High / Medium / Low)
+- Mitigation (what the implementation should do)
+
+### 6. Optional: BDD output
+
+If BDD is configured (`tkt cfg build.bdd` resolves without error), produce
+`.feature` files in Gherkin format alongside `TEST-PLAN.md`.
+
+## Output
+
+`TEST-PLAN.md` in the following structure:
+
+```markdown
+# Test Plan — <KEY>: <summary>
+
+## Requirements Coverage Matrix
+
+| # | Requirement (from AC) | Test cases | Priority | Status |
+|---|---|---|---|---|
+| 1 | <requirement text> | TC-1.1, TC-1.2, TC-1.3 | P0 | Planned |
+
+## Test Cases
+
+### TC-1.1: <descriptive name>
+- **Type:** Unit / Integration / E2E
+- **Priority:** P0 / P1 / P2
+- **Dimension:** Boundary / Auth / Concurrency / ...
+- **Preconditions:** ...
+- **Steps:** ...
+- **Expected:** ...
+- **Red-before-green:** How to verify this fails against buggy code
+
+### TC-1.2: ...
+
+## Untested Requirements
+- AC #N (<text>) — <reason it has no test>
+
+## Untestable Requirements
+- AC #N (<text>) — <why it's untestable> — <recommendation>
+
+## Risk Table
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| <what can break> | Critical | Medium | <what to do> |
+
+## Checklist Dimensions Considered
+
+| Dimension | Applicable | Test cases |
+|---|---|---|
+| Boundary | Yes | TC-1.2, TC-1.3 |
+| Authorization | No (no user-facing auth in this feature) | — |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only. Never
+  transition, comment, or create tickets.
+- **No code changes.** This skill produces a plan document, not code.
+- **No happy-path padding.** Do not enumerate obvious happy-path tests that any
+  developer would write. Focus on what they'll miss.
+- **Concrete over vague.** Every test case must have specific inputs and expected
+  outputs. "Test that it handles errors" is not a test case.

--- a/.agents/skills/respond-to-review/SKILL.md
+++ b/.agents/skills/respond-to-review/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: respond-to-review
-description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+description: 'Read PR review comments, address each with code changes or replies, push fixes, auto-resolve addressed threads with fix summaries, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+model_tier: standard
 ---
 
 # Respond to Review
 
-Read PR review comments (bot + human), address each, push fixes, loop until
-approved. Git host via `gh`; all ticketing via `tkt`. Repo/reviewers from
-`.sdlc/config.toml`.
+Read PR review comments (bot + human), address each, push fixes, auto-resolve the
+threads you actually addressed, loop until approved. Git host via `gh`; all
+ticketing via `tkt`. Repo/reviewers from `.sdlc/config.toml`.
 
 ## Input
 
@@ -29,6 +30,7 @@ with `tkt worklog`:
 # Exiting revise → in_progress:
 WL=$(tkt worklog "$KEY" --from-role revise --note "Addressing review feedback" --json)
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 tkt comment "$KEY" "Addressing review feedback. Time in Revise: \
 $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 ```
@@ -51,7 +53,9 @@ gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100" \
 Identify automated-reviewer comments by `user.login` (e.g. `*copilot*[bot]`, or
 whatever your `vcs.reviewers` lists). Track unresolved ones separately.
 
-Resolved-thread state (paginate via `pageInfo.hasNextPage`):
+Thread state — fetch thread IDs, resolution status, file path, and comment bodies
+(paginate via `pageInfo.hasNextPage`). The thread ID and path are what step 6 needs
+to resolve, so collect them now:
 
 ```shell
 CURSOR=null
@@ -61,14 +65,23 @@ while : ; do
       repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
         reviewThreads(first:100, after:$after) {
           pageInfo { hasNextPage endCursor }
-          nodes { id isResolved comments(first:1){ nodes { author{login} body } } }
+          nodes {
+            id isResolved path line
+            comments(first:100) {
+              nodes { id databaseId author{login} body }
+            }
+          }
         } } } }' \
     -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CURSOR")
   echo "$RESP" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
-  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<"$RESP")" = "true" ] || break
-  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<"$RESP")
+  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$RESP")" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$RESP")
 done
 ```
+
+Build a mapping of unresolved threads:
+`thread_id → {path, line, comment_id, body, author}`. Step 6 drives resolution off
+it, so a thread you can't map is a thread you must not resolve.
 
 ### 2. Categorize each comment
 
@@ -76,15 +89,18 @@ Change request → make the change. Question → reply. Suggestion → apply if 
 else explain. Nit → apply. Blocker → must fix. Out of scope → acknowledge, create
 a follow-up with `tkt create` if warranted.
 
+Record the outcome per thread — this decides what gets resolved:
+
+- `addressed` — change fully implemented (**will** resolve)
+- `question` — answered (**will** resolve after reply)
+- `partial` — change only partly implemented (will **not** resolve)
+- `skipped` — out of scope, won't-fix, or ambiguous (will **not** resolve)
+
 ### 3. Address change requests
 
-For each: make the change, verify it builds/tests (`tkt cfg build.*`), reply on the
-thread:
-
-```shell
-gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
-  -f body="Fixed in <sha>. <brief explanation>"
-```
+For each `addressed` thread: make the code change and verify it builds/tests
+(`tkt cfg build.*`). **Do not reply yet** — fix-summary replies cite the commit
+SHA, which doesn't exist until step 5.
 
 ### 4. Reply to questions
 
@@ -96,9 +112,76 @@ gh pr comment "$PR" --repo "$REPO" --body "Re: <question> — <answer>"
 
 ```shell
 git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+SHA=$(git rev-parse --short HEAD)
 ```
 
-### 6. Re-request review + move back to review lane
+### 6. Resolve addressed threads + post fix summaries
+
+For each thread categorized `addressed` or `question`:
+
+1. **Verify the fix is actually in the diff.** A thread whose file was never
+   touched must not be marked resolved:
+
+   ```shell
+   git diff --name-only HEAD~1 HEAD | grep -Fxq "<path>"
+   ```
+
+   Not in the diff → re-categorize as `partial` and skip.
+
+2. **Post a fix-summary reply** on the thread:
+
+   ```shell
+   gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
+     -f body="Fixed in \`$SHA\`: updated \`<file>\` — <one-line change summary>"
+   ```
+
+   Questions were already answered in step 4; go straight to resolving.
+
+3. **Resolve the thread:**
+
+   ```shell
+   gh api graphql -f query='
+     mutation($threadId: ID!) {
+       resolveReviewThread(input: {threadId: $threadId}) {
+         thread { id isResolved }
+       }
+     }' -F threadId="$THREAD_ID"
+   ```
+
+4. **Accumulate a resolution log entry** for step 7:
+
+   ```
+   • [`<file>:<line>`](https://github.com/$OWNER/$NAME/blob/$SHA/<file>#L<line>): <summary>
+   ```
+
+**Never resolve when:** the fix is partial; the comment is ambiguous and needs
+reviewer confirmation; the thread bundles several requests and only some are done;
+or the path isn't in the commit diff. Leave those threads open **without** a
+fix-summary reply — a summary on an unresolved thread misleads the reviewer.
+
+### 7. Post the consolidated resolution log
+
+One PR comment as the audit trail:
+
+```shell
+BODY="## Review thread resolution
+
+**Commit:** \`$SHA\`
+**Resolved:** $RESOLVED_COUNT thread(s)
+**Left open:** $OPEN_COUNT thread(s)
+
+### Resolved
+$(printf '%s\n' "${RESOLVED_LOG[@]}")
+
+### Left open (needs reviewer)
+$(printf '%s\n' "${OPEN_LOG[@]}")"
+
+gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+```
+
+Each resolved entry links its file path to the line in the pushed commit.
+
+### 8. Re-request review + move back to review lane
 
 ```shell
 for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
@@ -107,11 +190,13 @@ done
 
 WL=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — fixes pushed, re-review requested" --json)
 tkt transition "$KEY" review
+tkt edit "$KEY" --agent-status waiting
 tkt comment "$KEY" "Pushed fixes, re-requested review. Time in In Progress (revise cycle): \
-$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id)). \
+Resolved $RESOLVED_COUNT review thread(s); $OPEN_COUNT left open for the reviewer."
 ```
 
-### 7. Loop until clean
+### 9. Loop until clean
 
 Re-fetch after each push. Exit only when **all** hold:
 
@@ -122,7 +207,7 @@ Re-fetch after each push. Exit only when **all** hold:
 Cap at **5** cycles. If a bot repeats the same nit after 2 attempts, reply with a
 one-line "won't fix" justification and resolve the thread.
 
-### 8. If stuck after 5 cycles
+### 10. If stuck after 5 cycles
 
 ```shell
 gh pr comment "$PR" --repo "$REPO" --body "5 review cycles complete. Remaining items need human judgment — requesting sync review."
@@ -134,7 +219,7 @@ Time in review so far: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -
 (`$KEY` is the ticket; `$PR` is the PR number — unrelated. Always pass `$PR`
 explicitly to `gh pr comment`.)
 
-### 9. On loop exit, annotate review lane time
+### 11. On loop exit, annotate review lane time
 
 ```shell
 WL=$(tkt worklog "$KEY" --from-role review --note "Review loop complete. Cycles: <N>" --json)
@@ -146,4 +231,5 @@ $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 
 - Review status: approved / changes requested / stuck
 - Comments addressed (count)
+- Threads resolved vs. left open (count)
 - Outstanding items

--- a/.agents/skills/resume-from-revise/SKILL.md
+++ b/.agents/skills/resume-from-revise/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resume-from-revise
 description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Resume From Revise
@@ -34,6 +35,7 @@ $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 
 ```shell
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 ```
 
 The agent owns the work again while it pushes/re-reviews.
@@ -74,9 +76,11 @@ WL1=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — in_pro
 # respond-to-review may already have moved it to review; only transition if not.
 CUR=$(tkt view "$KEY" --json | jq -r .status_role)
 [ "$CUR" != "review" ] && tkt transition "$KEY" review
+tkt edit "$KEY" --agent-status waiting
 WL2=$(tkt worklog "$KEY" --from-role review --note "Revise cycle — re-review portion" --json)
 
 tkt transition "$KEY" qa_ready
+tkt edit "$KEY" --agent-status waiting
 tkt comment "$KEY" "Re-review complete and approved. Back in qa_ready — preview updated: <url>. \
 In Progress (revise): $(echo "$WL1" | jq -r .human) (worklog $(echo "$WL1" | jq -r .worklog_id)) | \
 review (re-review): $(echo "$WL2" | jq -r .human) (worklog $(echo "$WL2" | jq -r .worklog_id))."

--- a/.agents/skills/select-ticket/SKILL.md
+++ b/.agents/skills/select-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: select-ticket
 description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Select Ticket

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-review
 description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+model_tier: standard
 ---
 
 # Self-Review
@@ -17,7 +18,15 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
-### 2. Review as adversary
+### 2. Review as adversary (→ `sdlc-reviewer`)
+
+**Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The
+point is separation: the reviewer is a fresh context that did not write the code,
+so it judges the evidence rather than recalling the intent.
+
+**Fallback** (no subagent support): run this pass yourself, but explicitly — re-read
+the diff from scratch and argue against it before approving. Pretend it is a
+stranger's PR. Do not rubber-stamp your own code.
 
 Hostile-reviewer mindset. Check every changed file for:
 
@@ -38,18 +47,59 @@ project's own conventions doc — read them and apply.
 ### 3. List findings
 
 Per issue: file+line, severity (**blocker** / **warning** / **nit**), description,
-suggested fix.
+suggested fix. Plus an overall verdict — PASS (zero blockers, zero warnings) skips
+straight to the final check.
+
+The reviewer produces findings only; the author context fixes them in step 4.
 
 ### 4. Fix blockers and warnings
 
 Fix all blocker + warning items. Don't skip.
 
-### 5. Rebuild and re-test (config toolchain)
+**Test gaps are not fixed here.** If the reviewer flags "new code without tests" or
+"tests that assert nothing meaningful," do **not** write tests inline — a fix-pass
+test written to close a finding tends to assert whatever the code already does.
+Note the gap and hand it to `qa-author` (or the `qa-engineer` agent) after this
+loop completes, which writes adversarial tests with red-before-green verification.
+
+Format the flag as:
+
+```
+⚠️ TEST GAP: <file:line> — <description>
+→ Recommend: invoke `qa-author` targeting <file/module> after self-review passes.
+```
+
+### 5. Rebuild and re-test (→ `sdlc-verifier`)
+
+**Delegate to `sdlc-verifier`**, which runs the configured checks and returns a
+binary PASS/FAIL with the exact commands and their output as evidence. It never
+fixes anything — a FAIL comes back here.
+
+**Fallback:** run them yourself.
 
 ```shell
 eval "$(tkt cfg build.build --pkg "<pkg>")"
 eval "$(tkt cfg build.test --pkg "<pkg>")"
 eval "$(tkt cfg build.typecheck)"
+```
+
+### 5b. Run behavior specs — non-blocking (if configured)
+
+If the repo binds a behavior-spec runner, run it as a **reported, non-blocking**
+signal, mirroring the non-strict BDD posture: pending scenarios inform the author
+but never block the flow. Skip cleanly when `build.bdd` is unset. See
+[docs/behavior-specs.md](../../docs/behavior-specs.md).
+
+```shell
+# Only a missing key (tkt cfg exit 4 = NotFoundError) is a clean skip.
+# Surface any other failure (e.g. exit 2 = bad/missing config) instead of
+# silently swallowing it. On success stderr is empty, so 2>&1 is safe to eval.
+out="$(tkt cfg build.bdd --pkg "<pkg>" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+  eval "$out" || echo "bdd: behavior-spec runner exited non-zero (non-blocking)"
+elif [ "$rc" -ne 4 ]; then
+  echo "bdd: could not resolve build.bdd (tkt cfg exit $rc): $out" >&2
+fi
 ```
 
 ### 6. Loop

--- a/.agents/skills/triage-ticket/SKILL.md
+++ b/.agents/skills/triage-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: triage-ticket
 description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
 allowed-tools: [Bash, Read, Edit]
+model_tier: cheap
 ---
 
 # Triage Ticket
@@ -61,6 +62,7 @@ or `CLAUDE.md`; this skill stays generic. Example shape:
 
 ```shell
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 ```
 
 ### 4. Start time tracking

--- a/.kiro/skills/automated-sdlc/SKILL.md
+++ b/.kiro/skills/automated-sdlc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: automated-sdlc
 description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+model_tier: standard
 ---
 
 # Automated SDLC
@@ -10,6 +11,32 @@ sub-skills with explicit human gates and per-lane time annotation. **Every
 ticketing/board operation goes through `tkt`**, so the same pipeline runs on Jira,
 GitHub Issues+Projects, Linear, qi, or a markdown board — the backend and board
 shape are declared in `.sdlc/config.toml`.
+
+## Model routing
+
+Each sub-skill declares a `model_tier` (`cheap` | `standard` | `deep`) in its
+frontmatter. Resolve the tier to a concrete model from project config before
+invoking a phase:
+
+```shell
+tkt cfg models.deep         # exit 4 = no [models] table -> skip routing entirely
+```
+
+| Tier | Phases |
+|------|--------|
+| cheap | `select-ticket`, `check-blockers`, `triage-ticket` |
+| deep | `plan-ticket` |
+| standard | everything else |
+
+**Escalate on failure, never start high.** A cheap-tier phase that returns a wrong
+or ambiguous result gets retried once at standard. If `self-review` cycles 3+ times
+without converging, re-plan at deep and resume the review at standard. Escalation
+is per-invocation — subsequent phases resume at their assigned tier.
+
+**Never block on routing.** If the harness cannot select a model, or `[models]` is
+unset, proceed on the session default. No phase requires a specific model to
+produce correct output — routing is a cost optimization. Full policy and the
+per-harness support matrix: [docs/model-routing.md](../../docs/model-routing.md).
 
 ## Prerequisites
 
@@ -108,15 +135,20 @@ esac
 Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 `deliverable` sets are defined in `[issue_types]`.
 
-### Phase 2: Plan
+### Phase 2: Plan (→ `sdlc-planner`)
 
-**Invoke `plan-ticket`.** Output: files, test strategy, risks. External dep missing
-→ see "External blocker handling".
+**Delegate to `sdlc-planner`** with the ticket JSON (`tkt view "$KEY" --json`) as
+context. It returns files to touch, ordered steps, risks, test strategy, and
+parallelism hints. External dep missing → see "External blocker handling".
 
-### Phase 3: Implement + test
+**Fallback:** invoke `plan-ticket` inline. Same output, same context — acceptable
+here because planning is not adversarial.
+
+### Phase 3: Implement + test (→ `sdlc-executor`)
 
 1. Branch: `git checkout -b "$(tkt cfg vcs.branch_fmt --ticket "$KEY" --slug "<slug>")"`
-2. Implement per plan.
+2. Implement per plan. **Delegate to `sdlc-executor`**, which is scoped to the repo
+   worktree and cannot transition tickets or push. Fallback: implement inline.
 3. After each logical unit, run the configured toolchain:
 
    ```shell
@@ -129,7 +161,24 @@ Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 
 ### Phase 4: Self-review (adversarial)
 
-**Invoke `self-review`** in a loop until clean.
+**Invoke `self-review`** in a loop until clean. Its review pass delegates to
+`sdlc-reviewer` (read-only, findings only) and its check pass to `sdlc-verifier`
+(PASS/FAIL with command output as evidence) — both fresh contexts that did not
+write the code.
+
+### Phase 4.5: Adversarial QA (optional, → `qa-engineer`)
+
+Run when the change carries real failure risk — new endpoints, auth, money, data
+migrations, concurrency — or when Phase 4 flagged a test gap. Skip for docs-only
+and trivial changes; say which and why.
+
+**Delegate to `qa-engineer`**, which routes to the QA skills: `qa-strategy` (test
+plan from acceptance criteria), `qa-author` (adversarial tests, red-before-green),
+`qa-critique` (existing-suite assessment). See
+[docs/qa-suite-design.md](../../docs/qa-suite-design.md).
+
+A P0 finding sends the ticket back to Phase 3. **Fallback:** invoke `qa-author`
+inline against the modules Phase 4 flagged.
 
 ### Phase 5: Open PR
 

--- a/.kiro/skills/check-blockers/SKILL.md
+++ b/.kiro/skills/check-blockers/SKILL.md
@@ -3,6 +3,7 @@ name: check-blockers
 description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
 model: claude-haiku-4-5
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Check Blockers
@@ -78,7 +79,7 @@ automatically:
 
 ```
 Auto-unblock candidates (confirm first):
-  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress
+  <KEY> — blocked by <B> which is now Done. Suggest: tkt transition <KEY> in_progress (and `tkt edit <KEY> --agent-status processing`)
 ```
 
 ### 6. Optional nudge on stale blockers (after human confirms)

--- a/.kiro/skills/ci-fix/SKILL.md
+++ b/.kiro/skills/ci-fix/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-fix
 description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+model_tier: standard
 ---
 
 # CI Fix
@@ -85,10 +86,27 @@ tkt comment "$KEY" "CI failing after 3 attempts on PR #$PR — needs human inves
 ### 9. Flaky tests
 
 Non-deterministic failure (passes locally, random timeout): `gh run rerun <run-id> --failed`
-**once**. If it fails again, treat as real.
+**once**. If it fails again on the same assertion but with a different value or
+timing, it is a flake, not a regression.
+
+Hand the root cause to **`qa-flake-triage`** rather than patching around it:
+
+```
+⚠️ FLAKE DETECTED: <test name> in <file>
+  - Failed with: <assertion/error>
+  - Passed on rerun: yes/no
+  → Recommend: invoke `qa-flake-triage` for root-cause classification and fix.
+```
+
+`ci-fix` must **not**: add `sleep()` or raise timeouts, skip or disable the test,
+or rerun more than once. Each of those turns a real race condition into a silent
+one. If the flake still blocks CI after one rerun, flag it and stop — the QA suite
+classifies the cause (race, shared state, clock sensitivity, test ordering) and
+proposes a real fix.
 
 ## Output
 
 - CI status: green / still failing
 - Fixes applied (commits)
+- Flake findings (handed to `qa-flake-triage`)
 - If stuck: the unresolved failure

--- a/.kiro/skills/complete-deliverable/SKILL.md
+++ b/.kiro/skills/complete-deliverable/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: complete-deliverable
 description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Complete Deliverable
@@ -41,6 +42,7 @@ tkt comment "$KEY" "Deliverable complete: <summary>.
 Link: <url>
 Time in In Progress: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 tkt transition "$KEY" done
+tkt edit "$KEY" --agent-status done
 ```
 
 ## Edge cases
@@ -55,8 +57,8 @@ tkt transition "$KEY" done
 - **Spike with no concrete next step**: comment findings + a recommended follow-up
   ticket, mark `done`. The follow-up is a separate Story.
 - **Blocked deliverable**: `tkt worklog "$KEY" --from-role in_progress` then
-  `tkt transition "$KEY" blocked` with a blocker comment (see `automated-sdlc` →
-  External blocker handling).
+  `tkt transition "$KEY" blocked` followed by `tkt edit "$KEY" --agent-status blocked`
+  with a blocker comment (see `automated-sdlc` → External blocker handling).
 
 ## Output
 

--- a/.kiro/skills/deploy-preview/SKILL.md
+++ b/.kiro/skills/deploy-preview/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deploy-preview
 description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+model_tier: standard
 ---
 
 # Deploy Preview

--- a/.kiro/skills/deploy-ready/SKILL.md
+++ b/.kiro/skills/deploy-ready/SKILL.md
@@ -2,6 +2,7 @@
 name: deploy-ready
 description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Deploy Ready
@@ -123,7 +124,7 @@ SHIPPED=$(git log <prev-prod-tag>..origin/"$DEFAULT_BRANCH" --format='%s %b' \
 If your prod workflow truly deploys → transition each to `done`:
 
 ```shell
-# for K in $SHIPPED; do tkt transition "$K" done; done
+# for K in $SHIPPED; do tkt transition "$K" done; tkt edit "$K" --agent-status done; done
 ```
 
 If it's a build/auth stub → comment and leave in `deploy_ready` for human Done:

--- a/.kiro/skills/hotfix-revert/SKILL.md
+++ b/.kiro/skills/hotfix-revert/SKILL.md
@@ -2,6 +2,7 @@
 name: hotfix-revert
 description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Hotfix Revert
@@ -50,6 +51,7 @@ HOTFIX_KEY=$(tkt create --type Bug \
 # Link hotfix → original. "Fixes" is the outward description (HOTFIX Fixes TARGET).
 tkt link "$HOTFIX_KEY" --to "$TARGET_TICKET" --type "Fixes"
 tkt transition "$HOTFIX_KEY" in_progress
+tkt edit "$HOTFIX_KEY" --agent-status processing
 ```
 
 ### 3. Create the revert branch
@@ -80,6 +82,7 @@ gh pr create --repo "$REPO" --title "hotfix($HOTFIX_KEY): revert $TARGET_TICKET"
 Reverts $TARGET_SHA (from $TARGET_TICKET). Ticket: $HOTFIX_URL
 Production incident — bypassing standard QA per hotfix policy. Single signoff."
 tkt transition "$HOTFIX_KEY" review
+tkt edit "$HOTFIX_KEY" --agent-status waiting
 ```
 
 ### 6. Request human signoff (skip the bot loop)
@@ -142,7 +145,7 @@ WL=$(tkt worklog "$HOTFIX_KEY" --from-role in_progress --note "Hotfix run comple
 tkt comment "$HOTFIX_KEY" "Production workflow completed. Verify the revert serves prod traffic, then transition to Done. \
 Agent lane time: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 tkt comment "$TARGET_TICKET" "Reverted by $HOTFIX_KEY due to a production regression. Redo the work with the regression addressed before re-attempting."
-# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done
+# If your prod workflow truly deploys: tkt transition "$HOTFIX_KEY" done; tkt edit "$HOTFIX_KEY" --agent-status done
 ```
 
 ## Output

--- a/.kiro/skills/open-pr/SKILL.md
+++ b/.kiro/skills/open-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: open-pr
 description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+model_tier: standard
 ---
 
 # Open PR
@@ -97,6 +98,7 @@ if [ "$CLASS" = "full_sdlc" ]; then
   # Annotate time in in_progress, then move to review.
   WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened: $PR_URL" --json)
   tkt transition "$KEY" review
+  tkt edit "$KEY" --agent-status waiting
   tkt comment "$KEY" "PR opened: $PR_URL. Review requested. Time in In Progress: \
 $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 else

--- a/.kiro/skills/plan-ticket/SKILL.md
+++ b/.kiro/skills/plan-ticket/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-ticket
 description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+model_tier: deep
 ---
 
 # Plan Ticket

--- a/.kiro/skills/qa-author/SKILL.md
+++ b/.kiro/skills/qa-author/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: qa-author
+description: 'Write adversarial tests focused on failure modes, edge cases, and the Break-It Checklist. Produces test files — not essays. Enforces red-before-green rule.'
+model_tier: standard
+---
+
+# QA Author — Write Adversarial Tests
+
+Write tests that find where code breaks. Prioritize failure modes over happy
+paths. The developer already tested the happy path — we exist to find what they
+missed.
+
+## Input
+
+- File path or diff of the implementation under test
+- Optionally: a `TEST-PLAN.md` from `qa-strategy` (if available, implement its
+  test cases rather than re-deriving them)
+
+## Steps
+
+### 1. Read the implementation
+
+Read the file(s) being tested. Identify:
+- Public API surface (exports, endpoints, handlers)
+- Internal branching logic
+- External dependencies (DB, APIs, file system)
+- Error handling paths
+
+### 2. Read existing tests
+
+Find and read existing test files for the same module. Identify what's already
+covered to avoid duplication.
+
+### 3. Detect stack and load reference
+
+Check the file extension and import patterns, then load the appropriate reference
+for framework-specific testing patterns:
+
+| Pattern | Reference |
+| --- | --- |
+| `.ts` + `@nestjs/*` imports | `references/nestjs.md` |
+| `.tsx` + `react` imports | `references/react.md` |
+| `.go` files | `references/go.md` |
+| `.ts` + `aws-cdk-lib` imports | `references/cdk.md` |
+| `.ts` + `hx-` attributes in templates | `references/htmx-lambda.md` |
+
+If no reference matches, use the project's existing test conventions (infer from
+neighboring test files).
+
+### 4. Walk the Break-It Checklist
+
+For the implementation under test, enumerate failure scenarios:
+
+**Boundary Analysis**
+- 0, 1, n, n+1 for every numeric input
+- Empty array, empty string, empty object, null, undefined
+- Single-element collections
+- At configured limits, at integer overflow, at payload size limits
+- Negative numbers, negative indexes
+
+**Null / Undefined / Missing**
+- null vs undefined vs empty string
+- Missing key vs key-present-with-null-value
+- Optional chaining paths that produce undefined mid-chain
+- JSON.parse of responses that omit fields
+
+**Authorization**
+- User A reading/writing user B's resources
+- Horizontal and vertical privilege escalation
+- Resource enumeration via sequential IDs
+- Token expiry mid-operation
+
+**Concurrency**
+- Two writes, same row, same millisecond
+- Read-then-write races (TOCTOU)
+- Connection pool exhaustion
+
+**Idempotency & Retries**
+- Client sends request twice
+- Network timeout → retry → original succeeded
+- Partial retry after partial success
+
+**Partial Failure**
+- DB write succeeds, external API doesn't — state consistency
+- Multi-step transaction: step N fails — what's left behind
+
+**Time**
+- Timezone handling (UTC vs local)
+- DST transitions
+- Token/session expiry at exact boundary
+
+**Pagination & Ordering**
+- Unstable sort with ties
+- Cursor drift during writes
+- Page size = 0, page = -1, page beyond total
+
+**Encoding & Input**
+- Unicode (emoji, combining characters, zero-width joiners)
+- 10k-character inputs
+- Script injection in user-writable fields
+- Path traversal in filenames
+
+**Error Propagation**
+- Error messages don't leak internals
+- Correct HTTP status codes
+- Error response matches documented schema
+
+### 5. Write tests
+
+Write test files following the project's conventions:
+- Group: unit → integration → e2e
+- Each test has a descriptive name stating the scenario and expected outcome
+- Assertions are specific — never `toBeDefined()` alone
+- Tests are isolated — no shared mutable state between tests
+
+### 6. Verify red-before-green (mandatory)
+
+**A new test MUST fail first against the unfixed/unmocked code path it exercises.**
+
+For each test written:
+1. Identify what makes it fail (the bug or missing behavior it catches)
+2. Document how to verify the red state
+3. If a test passes immediately, investigate:
+   - The bug doesn't exist → remove the test
+   - The test doesn't exercise the failure path → fix the test
+   - The assertion is too weak → strengthen it
+
+## Forbidden Cheats
+
+These are explicitly forbidden. Violation means the test is worthless:
+
+| Cheat | Why forbidden |
+| --- | --- |
+| `.skip()` or delete a failing test | Deleting evidence is not fixing |
+| Weaken assertion to match wrong output | You encoded the bug as a spec |
+| `sleep(5000)` to paper over a flake | Hidden race condition behind a prayer |
+| Mock the unit under test | You're testing your mock, not your code |
+| `expect(result).toBeDefined()` alone | Proves nothing except it didn't throw |
+| Catch-all try/catch that swallows errors | Makes the test unfailable |
+| Test that passes regardless of implementation | Tautological — delete it |
+
+## Output
+
+Test files in the project's testing convention. No essays — working test code.
+
+Each file includes a header comment:
+
+```
+// QA Author — adversarial tests
+// Break-It dimensions covered: [list]
+// See TEST-PLAN.md TC-X.Y for requirements mapping (if applicable)
+```
+
+## Guardrails
+
+- **Write only test files.** Only create/modify files matching `**/*.test.*`,
+  `**/*.spec.*`, `**/__tests__/**`, or `**/test/**`.
+- **Never modify implementation code.** If the implementation is buggy, write a
+  test that proves it — don't fix the bug.
+- **Never transition tickets.** No `tkt transition`, `tkt comment`,
+  or `tkt create`.
+- **Never commit or push.** Write files only. The user/executor reviews and commits.
+- **No git mutations.** Never `git commit`, `git push`, `git add`.

--- a/.kiro/skills/qa-bug-report/SKILL.md
+++ b/.kiro/skills/qa-bug-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: qa-bug-report
+description: 'Produce a structured bug report with minimal reproduction steps from a failing scenario. Optionally creates a ticket via tkt create.'
+model_tier: cheap
+---
+
+# QA Bug Report — Structured Reproduction
+
+Produce a structured, actionable bug report from a failing scenario. Distills
+test output, error logs, or user reports into minimal reproduction steps with
+clear expected/actual behavior.
+
+## Input
+
+- A failing scenario: test output, error log, user report, or observed behavior
+- Optionally: the code path involved
+
+## Steps
+
+### 1. Identify the failure
+
+From the input, extract:
+- What operation was attempted
+- What went wrong (error message, wrong output, crash, hang)
+- Under what conditions (specific inputs, timing, environment)
+
+### 2. Determine minimal reproduction steps
+
+Strip away everything that isn't required to trigger the failure:
+- What's the minimum setup?
+- What's the fewest steps to reproduce?
+- Can it be triggered from a test? From a curl command? From the UI?
+
+### 3. Classify severity
+
+| Severity | Criteria |
+| --- | --- |
+| **Critical** | Data loss, security breach, complete service outage |
+| **High** | Core feature broken, no workaround, affects many users |
+| **Medium** | Feature degraded, workaround exists, affects some users |
+| **Low** | Cosmetic, rare edge case, minimal user impact |
+
+### 4. Classify reproducibility
+
+| Reproducibility | Meaning |
+| --- | --- |
+| **Always** | Reproduces 100% of the time with given steps |
+| **Often** | Reproduces >50% of attempts |
+| **Intermittent** | Reproduces <50% — timing/state dependent |
+| **Rare** | Hard to reproduce — specific conditions required |
+
+### 5. Identify suspected root cause
+
+From reading the code path and error:
+- What function/module is likely at fault?
+- Is this a logic error, data issue, race condition, or configuration problem?
+- What would a fix likely involve?
+
+### 6. Format the report
+
+## Output
+
+```markdown
+## Bug Report
+
+**Summary:** <one-line description of the bug>
+**Severity:** Critical / High / Medium / Low
+**Component:** <package/module/service>
+**Reproducibility:** Always / Often / Intermittent / Rare
+
+### Steps to Reproduce
+1. <precondition or setup>
+2. <action>
+3. <action>
+4. Observe: <what goes wrong>
+
+### Expected Behavior
+<what should happen>
+
+### Actual Behavior
+<what actually happens, including error messages>
+
+### Environment
+- Branch: <branch name>
+- Commit: <short sha>
+- OS/Runtime: <if relevant>
+- Relevant config: <if relevant>
+
+### Evidence
+```
+<error log, stack trace, or test output — trimmed to relevant portion>
+```
+
+### Root Cause (suspected)
+<brief analysis of what's likely wrong>
+
+### Suggested Fix
+<what the fix would involve, if known>
+
+### Regression?
+- [ ] Yes — worked in <commit/version>, broken since <commit/version>
+- [ ] No — appears to be a pre-existing issue
+- [ ] Unknown — needs bisection
+```
+
+### 7. Optional: Create ticket
+
+If the user confirms, create a ticket:
+
+```shell
+tkt create \
+  --type Bug \
+  --summary "<one-line summary>" \
+  --description "<full report body>" \
+  --priority "<severity-mapped-priority>"
+```
+
+Do NOT create the ticket automatically — always ask first.
+
+## Guardrails
+
+- **Read-only by default.** Only create tickets when explicitly confirmed by user.
+- **No code modifications.** Document the bug, don't fix it.
+- **No ticket transitions.** Never `tkt transition` on existing tickets.
+- **No git mutations.** Never commit or push.
+- **Minimal, precise reports.** Every field must be specific and actionable.
+  "Something is broken" is not a bug report.
+- **No speculation without marking it.** If the root cause is uncertain, say
+  "suspected" — don't present guesses as facts.

--- a/.kiro/skills/qa-critique/SKILL.md
+++ b/.kiro/skills/qa-critique/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: qa-critique
+description: 'Evaluate existing test suite quality: coverage gaps, assertion strength, false confidence detection, Break-It Checklist compliance. Produces a scored assessment.'
+model_tier: deep
+---
+
+# QA Critique — Test Suite Quality Assessment
+
+Evaluate an existing test suite for adequacy. Finds coverage gaps, weak
+assertions, false confidence, and missing adversarial scenarios. Produces a
+scored assessment with prioritized recommendations.
+
+This skill does NOT write tests — it identifies what's missing so `qa-author`
+can fill the gaps.
+
+## Input
+
+- Test file paths (or a diff containing test changes)
+- Optionally: the implementation files they test
+
+## Steps
+
+### 1. Read the test files
+
+Read all test files in scope. Understand:
+- What modules/functions are under test
+- What scenarios are exercised
+- What assertions are made
+- How tests are structured (setup/teardown, isolation)
+
+### 2. Read the implementation under test
+
+Read the implementation code. Identify:
+- All branches and code paths
+- External dependencies and failure modes
+- Authorization checks (or their absence)
+- Error handling paths
+- Edge cases in business logic
+
+### 3. Evaluate coverage gaps
+
+For each public function / endpoint / handler in the implementation:
+- Is it tested at all?
+- Which branches have no test?
+- Which error paths are unexercised?
+
+### 4. Evaluate assertion quality
+
+For each assertion in the test suite:
+
+| Quality level | Example | Verdict |
+| --- | --- | --- |
+| **Strong** | `expect(result.amount).toBe(150.00)` | Good |
+| **Adequate** | `expect(result).toMatchObject({...})` | Acceptable |
+| **Weak** | `expect(result).toBeDefined()` | Flag |
+| **Meaningless** | `expect(true).toBe(true)` | Critical flag |
+| **Tautological** | Tests that pass regardless of implementation | Critical flag |
+
+### 5. Detect false confidence
+
+Tests that give a feeling of safety without providing it:
+
+- **Mock-heavy tests:** If the mock covers 80% of the code path, you're testing
+  the remaining 20% plus your mock setup. The integration gap is where bugs hide.
+- **Overly specific mocks:** Mock returns exactly what the code expects — proves
+  only that the code works when given perfect inputs.
+- **Assertion on mock calls only:** Verifying a function was called doesn't verify
+  the *result* is correct.
+- **Try/catch swallowing:** Test catches errors without asserting on them.
+
+### 6. Walk the Break-It Checklist
+
+Check which dimensions from the checklist are exercised:
+
+| Dimension | Exercised? | Missing scenarios |
+| --- | --- | --- |
+| Boundary (0, 1, n, n+1, max, negative, empty) | | |
+| Null / Undefined / Missing | | |
+| Authorization (horizontal, vertical, expiry) | | |
+| Concurrency (races, TOCTOU, pool exhaustion) | | |
+| Idempotency (double-submit, retry) | | |
+| Partial failure (DB + API mismatch) | | |
+| Time (timezone, DST, expiry boundary) | | |
+| Pagination (unstable sort, cursor drift) | | |
+| Encoding (unicode, injection, path traversal) | | |
+| Performance (N+1, unbounded, missing index) | | |
+| Error propagation (safe messages, correct codes) | | |
+
+### 7. Evaluate test isolation
+
+- Shared mutable state between tests?
+- Test ordering dependencies?
+- Global setup that hides individual test requirements?
+- Tests that only pass when run in a specific order?
+
+### 8. Evaluate maintenance burden
+
+- Overly brittle tests that break on refactors (testing implementation details)?
+- Snapshot tests without targeted assertions?
+- Deep mock hierarchies that mirror implementation structure?
+
+### 9. Score and produce report
+
+Score on a 1–10 scale:
+
+| Score | Meaning |
+| --- | --- |
+| 9–10 | Adversarial-quality suite, covers failure modes |
+| 7–8 | Good coverage, some gaps in edge cases |
+| 5–6 | Happy-path coverage, missing adversarial scenarios |
+| 3–4 | Sparse, weak assertions, significant gaps |
+| 1–2 | Cosmetic tests only, false confidence |
+
+## Output
+
+```markdown
+# Test Suite Critique — <file/module>
+
+## Score: N/10
+
+## Coverage Gaps (Critical)
+- [ ] <missing test scenario>
+- [ ] <untested branch/path>
+
+## Weak Assertions
+- `<file>:<line>` — <what's wrong with the assertion>
+
+## False Confidence
+- `<file>:<line>` — <why this test provides false safety>
+
+## Missing from Break-It Checklist
+- [ ] <dimension>: <specific missing scenario>
+
+## Test Isolation Issues
+- <shared state, ordering dependencies>
+
+## Maintenance Concerns
+- <brittle tests, over-mocking>
+
+## Recommendations (prioritized)
+1. (P0) <critical gap to fill>
+2. (P0) <security test to add>
+3. (P1) <important edge case>
+4. (P2) <nice-to-have improvement>
+
+## Dimensions Assessed
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Boundary | Partial | Missing n+1 for pagination |
+| Authorization | None | No authz tests at all |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only.** Do not modify any files.
+- **No ticket operations.** Never `tkt transition`, `tkt comment`,
+  `tkt create`.
+- **No git mutations.** Never commit, push, or modify history.
+- **Concrete over vague.** Every finding must reference a specific file:line and
+  explain what's wrong and what should be there instead.
+- **No false positives from ignorance.** If you can't determine whether a test is
+  adequate without reading more context, say so rather than guessing.

--- a/.kiro/skills/qa-flake-triage/SKILL.md
+++ b/.kiro/skills/qa-flake-triage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: qa-flake-triage
+description: 'Classify flaky test root causes and recommend fixes. Never papers over flakes with sleep or skip — finds the actual race condition, shared state, or timing issue.'
+model_tier: standard
+---
+
+# QA Flake Triage — Flaky Test Root-Cause Classification
+
+Diagnose non-deterministic test failures. Classify the flake, identify root cause,
+and propose a real fix — never `sleep()`, never `.skip()`.
+
+## Input
+
+- Test file path
+- Failure logs (from CI or local — `gh run view <id> --log-failed` if available)
+- Optionally: recent CI history showing the pattern
+
+## Steps
+
+### 1. Read the failing test
+
+Read the test code. Understand:
+- What it exercises
+- What assertions it makes
+- What setup/teardown it performs
+- What external resources it touches
+
+### 2. Read failure logs
+
+Gather evidence:
+- Error messages and stack traces
+- Timing information (how long did it take?)
+- Which specific assertion failed?
+- What was the actual vs expected value?
+
+If CI history is available:
+
+```shell
+# Recent runs of this test
+gh run list --workflow=<workflow> --limit=20 --json conclusion,startedAt,databaseId
+```
+
+### 3. Classify the flake
+
+| Class | Indicators | Root cause |
+| --- | --- | --- |
+| **Race condition** | Passes with delay, fails under load; timing-dependent assertions; async operations without proper synchronization | Missing await, no mutex, optimistic read |
+| **Shared state** | Fails only when run after specific other test; passes in isolation (`-run TestX`); order-dependent | Tests mutating shared DB/file/global without cleanup |
+| **Non-deterministic ordering** | Sorted assertions fail on ties; map iteration order; DB results without ORDER BY | Unstable sort, relying on insertion order |
+| **Clock sensitivity** | Fails near midnight, DST transitions, or second boundaries; token expiry assertions | Using `Date.now()` / `time.Now()` without mocking |
+| **External dependency** | Fails when network/service is slow or unavailable; timeout errors; connection refused | Real HTTP calls in tests, no retry/circuit-breaker |
+| **Resource exhaustion** | Fails later in the suite; connection pool errors; "too many open files" | Leaked connections, file handles, goroutines |
+| **Platform-specific** | Fails on CI but not local (or vice versa); OS, locale, timezone differences | Hardcoded paths, locale assumptions, Docker differences |
+
+### 4. Gather supporting evidence
+
+For the classified category, look for corroborating signals:
+
+**Race condition:**
+- Are there `async` operations without `await`?
+- Is there shared mutable state accessed from multiple execution paths?
+- Does the test use `setTimeout`/`time.Sleep` for synchronization?
+
+**Shared state:**
+- Is there a `beforeAll` without corresponding `afterAll` cleanup?
+- Do tests share a database table without per-test transactions?
+- Are there global variables mutated in tests?
+
+**Non-deterministic ordering:**
+- Does the assertion use strict equality on an array?
+- Is the data source a Map/object with non-guaranteed key order?
+- Is the DB query missing `ORDER BY`?
+
+**Clock sensitivity:**
+- Does the test compare timestamps with exact equality?
+- Is there a "created X seconds ago" assertion?
+- Does the test rely on `Date.now()` being stable across execution?
+
+**External dependency:**
+- Are there real HTTP calls (not mocked)?
+- Is there a database/service startup race on CI?
+- Are there DNS lookups that could timeout?
+
+**Resource exhaustion:**
+- Is the test suite run with connection pool limits?
+- Are streams/readers properly closed in tests?
+- Does `go test -race` detect goroutine leaks?
+
+**Platform-specific:**
+- Are file paths hardcoded with `/` or `\`?
+- Does the test assume a specific timezone?
+- Are there locale-dependent string comparisons?
+
+### 5. Propose a fix
+
+The fix must be a **real solution**, not a workaround:
+
+| Class | Correct fix | FORBIDDEN fix |
+| --- | --- | --- |
+| Race condition | Add proper synchronization (mutex, channel, await) | `sleep(5000)` |
+| Shared state | Per-test isolation (transaction, temp dir, fresh instance) | Running tests sequentially |
+| Non-deterministic ordering | Remove order dependency from assertion, add stable sort | `.skip()` |
+| Clock sensitivity | Mock time, use relative comparisons | Widening tolerance to minutes |
+| External dependency | Mock the external service, use test containers | Adding retry loops with backoff |
+| Resource exhaustion | Fix the leak (close connections, cancel contexts) | Increasing pool size |
+| Platform-specific | Use path.join, normalize TZ, use t.TempDir() | Skipping on specific platforms |
+
+### 6. Confidence assessment
+
+| Level | Meaning |
+| --- | --- |
+| **High** | Root cause identified with strong evidence (reproducer exists) |
+| **Medium** | Classification is likely, evidence is circumstantial |
+| **Low** | Multiple possible causes, need more data to confirm |
+
+## Output
+
+```markdown
+# Flake Triage — <test name>
+
+## Classification: <class>
+**Confidence:** High / Medium / Low
+
+## Evidence
+- <observation 1>
+- <observation 2>
+- <CI history pattern>
+
+## Root Cause
+<explanation of why this test is non-deterministic>
+
+## Proposed Fix
+```<language>
+// Before (flaky)
+<current code>
+
+// After (stable)
+<fixed code>
+```
+
+## Verification
+- Run `<command>` N times to confirm stability
+- Expected: 0 failures in N runs
+
+## If Fix Doesn't Work
+- Alternative hypothesis: <other possible cause>
+- Additional investigation: <what to check next>
+```
+
+## Guardrails
+
+- **Never paper over the flake.** `sleep()`, `.skip()`, widening tolerances,
+  increasing timeouts — all forbidden. These hide the problem.
+- **Never weaken assertions.** If the assertion is correct, the code or test
+  setup is wrong — fix that.
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only.
+- **May modify test files.** This skill can write fixes to test files (same
+  scope as `qa-author`: `**/*.test.*`, `**/*.spec.*`, `**/__tests__/**`,
+  `**/test/**`).
+- **Never modify implementation code.** If the implementation has a race
+  condition, document it and recommend a fix — don't apply it.
+- **No git mutations.** Never commit or push.

--- a/.kiro/skills/qa-strategy/SKILL.md
+++ b/.kiro/skills/qa-strategy/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: qa-strategy
+description: 'Generate a structured test plan from ticket requirements or a spec document. Maps acceptance criteria to test cases with priority, risk analysis, and coverage gaps. Provider-agnostic via tkt.'
+model_tier: deep
+---
+
+# QA Strategy — Test Plan from Spec
+
+Produce a structured test plan that maps requirements to concrete test cases.
+Prioritizes failure modes over happy paths. Operates under the assumption that
+the code is wrong until proven otherwise.
+
+This skill does NOT write test files — it produces the plan that `qa-author`
+executes against.
+
+## Input
+
+- Ticket key (`$KEY`) — requirements read via `tkt view "$KEY" --json`
+- OR a spec/requirements document path
+
+## Steps
+
+### 1. Extract acceptance criteria
+
+```shell
+tkt view "$KEY" --json | jq -r '.acceptance[]'
+```
+
+If input is a document rather than a ticket, extract testable assertions from
+the spec text.
+
+### 2. Walk the Break-It Checklist per criterion
+
+For each acceptance criterion, enumerate test cases across these dimensions:
+
+| Dimension | What to enumerate |
+| --- | --- |
+| **Boundary** | 0, 1, n, n+1, max, negative, empty, single-element |
+| **Null/Missing** | null vs undefined vs empty, missing keys, optional chaining traps |
+| **Authorization** | Horizontal escalation, vertical escalation, token expiry, resource enumeration |
+| **Concurrency** | Two writes same row, TOCTOU, pool exhaustion, deadlocks |
+| **Idempotency** | Double-submit, retry after timeout, partial retry |
+| **Partial failure** | DB write + API call mismatch, multi-step rollback |
+| **Time** | Timezones, DST, clock skew, expiry at boundary |
+| **Pagination** | Unstable sort, cursor drift, page=0, page beyond total |
+| **Encoding** | Unicode, RTL, 10k-char inputs, injection, path traversal, null bytes |
+| **Performance** | N+1 queries, over-fetching, unbounded loops, missing indexes |
+| **Error propagation** | Safe error messages, correct status codes, retry-after headers |
+
+Not every dimension applies to every criterion. Skip irrelevant ones — but
+explicitly state which were considered and dismissed.
+
+### 3. Assign priority
+
+| Priority | Meaning |
+| --- | --- |
+| P0 | Blocks release — security, data loss, core functionality broken |
+| P1 | Should fix before ship — important edge cases, degraded UX |
+| P2 | Nice to have — unlikely scenarios, cosmetic |
+
+### 4. Flag untested and untestable requirements
+
+- **Untested:** Acceptance criterion with no test case mapped to it
+- **Untestable:** Vague, subjective, or missing definition of done (e.g. "should
+  feel fast" — recommend: define latency SLO)
+
+### 5. Produce risk table
+
+For each identified risk:
+- What can break
+- Severity (Critical / High / Medium / Low)
+- Likelihood (High / Medium / Low)
+- Mitigation (what the implementation should do)
+
+### 6. Optional: BDD output
+
+If BDD is configured (`tkt cfg build.bdd` resolves without error), produce
+`.feature` files in Gherkin format alongside `TEST-PLAN.md`.
+
+## Output
+
+`TEST-PLAN.md` in the following structure:
+
+```markdown
+# Test Plan — <KEY>: <summary>
+
+## Requirements Coverage Matrix
+
+| # | Requirement (from AC) | Test cases | Priority | Status |
+|---|---|---|---|---|
+| 1 | <requirement text> | TC-1.1, TC-1.2, TC-1.3 | P0 | Planned |
+
+## Test Cases
+
+### TC-1.1: <descriptive name>
+- **Type:** Unit / Integration / E2E
+- **Priority:** P0 / P1 / P2
+- **Dimension:** Boundary / Auth / Concurrency / ...
+- **Preconditions:** ...
+- **Steps:** ...
+- **Expected:** ...
+- **Red-before-green:** How to verify this fails against buggy code
+
+### TC-1.2: ...
+
+## Untested Requirements
+- AC #N (<text>) — <reason it has no test>
+
+## Untestable Requirements
+- AC #N (<text>) — <why it's untestable> — <recommendation>
+
+## Risk Table
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| <what can break> | Critical | Medium | <what to do> |
+
+## Checklist Dimensions Considered
+
+| Dimension | Applicable | Test cases |
+|---|---|---|
+| Boundary | Yes | TC-1.2, TC-1.3 |
+| Authorization | No (no user-facing auth in this feature) | — |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only. Never
+  transition, comment, or create tickets.
+- **No code changes.** This skill produces a plan document, not code.
+- **No happy-path padding.** Do not enumerate obvious happy-path tests that any
+  developer would write. Focus on what they'll miss.
+- **Concrete over vague.** Every test case must have specific inputs and expected
+  outputs. "Test that it handles errors" is not a test case.

--- a/.kiro/skills/respond-to-review/SKILL.md
+++ b/.kiro/skills/respond-to-review/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: respond-to-review
-description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+description: 'Read PR review comments, address each with code changes or replies, push fixes, auto-resolve addressed threads with fix summaries, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+model_tier: standard
 ---
 
 # Respond to Review
 
-Read PR review comments (bot + human), address each, push fixes, loop until
-approved. Git host via `gh`; all ticketing via `tkt`. Repo/reviewers from
-`.sdlc/config.toml`.
+Read PR review comments (bot + human), address each, push fixes, auto-resolve the
+threads you actually addressed, loop until approved. Git host via `gh`; all
+ticketing via `tkt`. Repo/reviewers from `.sdlc/config.toml`.
 
 ## Input
 
@@ -29,6 +30,7 @@ with `tkt worklog`:
 # Exiting revise → in_progress:
 WL=$(tkt worklog "$KEY" --from-role revise --note "Addressing review feedback" --json)
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 tkt comment "$KEY" "Addressing review feedback. Time in Revise: \
 $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 ```
@@ -51,7 +53,9 @@ gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100" \
 Identify automated-reviewer comments by `user.login` (e.g. `*copilot*[bot]`, or
 whatever your `vcs.reviewers` lists). Track unresolved ones separately.
 
-Resolved-thread state (paginate via `pageInfo.hasNextPage`):
+Thread state — fetch thread IDs, resolution status, file path, and comment bodies
+(paginate via `pageInfo.hasNextPage`). The thread ID and path are what step 6 needs
+to resolve, so collect them now:
 
 ```shell
 CURSOR=null
@@ -61,14 +65,23 @@ while : ; do
       repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
         reviewThreads(first:100, after:$after) {
           pageInfo { hasNextPage endCursor }
-          nodes { id isResolved comments(first:1){ nodes { author{login} body } } }
+          nodes {
+            id isResolved path line
+            comments(first:100) {
+              nodes { id databaseId author{login} body }
+            }
+          }
         } } } }' \
     -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CURSOR")
   echo "$RESP" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
-  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<"$RESP")" = "true" ] || break
-  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<"$RESP")
+  [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$RESP")" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$RESP")
 done
 ```
+
+Build a mapping of unresolved threads:
+`thread_id → {path, line, comment_id, body, author}`. Step 6 drives resolution off
+it, so a thread you can't map is a thread you must not resolve.
 
 ### 2. Categorize each comment
 
@@ -76,15 +89,18 @@ Change request → make the change. Question → reply. Suggestion → apply if 
 else explain. Nit → apply. Blocker → must fix. Out of scope → acknowledge, create
 a follow-up with `tkt create` if warranted.
 
+Record the outcome per thread — this decides what gets resolved:
+
+- `addressed` — change fully implemented (**will** resolve)
+- `question` — answered (**will** resolve after reply)
+- `partial` — change only partly implemented (will **not** resolve)
+- `skipped` — out of scope, won't-fix, or ambiguous (will **not** resolve)
+
 ### 3. Address change requests
 
-For each: make the change, verify it builds/tests (`tkt cfg build.*`), reply on the
-thread:
-
-```shell
-gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
-  -f body="Fixed in <sha>. <brief explanation>"
-```
+For each `addressed` thread: make the code change and verify it builds/tests
+(`tkt cfg build.*`). **Do not reply yet** — fix-summary replies cite the commit
+SHA, which doesn't exist until step 5.
 
 ### 4. Reply to questions
 
@@ -96,9 +112,76 @@ gh pr comment "$PR" --repo "$REPO" --body "Re: <question> — <answer>"
 
 ```shell
 git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+SHA=$(git rev-parse --short HEAD)
 ```
 
-### 6. Re-request review + move back to review lane
+### 6. Resolve addressed threads + post fix summaries
+
+For each thread categorized `addressed` or `question`:
+
+1. **Verify the fix is actually in the diff.** A thread whose file was never
+   touched must not be marked resolved:
+
+   ```shell
+   git diff --name-only HEAD~1 HEAD | grep -Fxq "<path>"
+   ```
+
+   Not in the diff → re-categorize as `partial` and skip.
+
+2. **Post a fix-summary reply** on the thread:
+
+   ```shell
+   gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
+     -f body="Fixed in \`$SHA\`: updated \`<file>\` — <one-line change summary>"
+   ```
+
+   Questions were already answered in step 4; go straight to resolving.
+
+3. **Resolve the thread:**
+
+   ```shell
+   gh api graphql -f query='
+     mutation($threadId: ID!) {
+       resolveReviewThread(input: {threadId: $threadId}) {
+         thread { id isResolved }
+       }
+     }' -F threadId="$THREAD_ID"
+   ```
+
+4. **Accumulate a resolution log entry** for step 7:
+
+   ```
+   • [`<file>:<line>`](https://github.com/$OWNER/$NAME/blob/$SHA/<file>#L<line>): <summary>
+   ```
+
+**Never resolve when:** the fix is partial; the comment is ambiguous and needs
+reviewer confirmation; the thread bundles several requests and only some are done;
+or the path isn't in the commit diff. Leave those threads open **without** a
+fix-summary reply — a summary on an unresolved thread misleads the reviewer.
+
+### 7. Post the consolidated resolution log
+
+One PR comment as the audit trail:
+
+```shell
+BODY="## Review thread resolution
+
+**Commit:** \`$SHA\`
+**Resolved:** $RESOLVED_COUNT thread(s)
+**Left open:** $OPEN_COUNT thread(s)
+
+### Resolved
+$(printf '%s\n' "${RESOLVED_LOG[@]}")
+
+### Left open (needs reviewer)
+$(printf '%s\n' "${OPEN_LOG[@]}")"
+
+gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+```
+
+Each resolved entry links its file path to the line in the pushed commit.
+
+### 8. Re-request review + move back to review lane
 
 ```shell
 for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
@@ -107,11 +190,13 @@ done
 
 WL=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — fixes pushed, re-review requested" --json)
 tkt transition "$KEY" review
+tkt edit "$KEY" --agent-status waiting
 tkt comment "$KEY" "Pushed fixes, re-requested review. Time in In Progress (revise cycle): \
-$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id)). \
+Resolved $RESOLVED_COUNT review thread(s); $OPEN_COUNT left open for the reviewer."
 ```
 
-### 7. Loop until clean
+### 9. Loop until clean
 
 Re-fetch after each push. Exit only when **all** hold:
 
@@ -122,7 +207,7 @@ Re-fetch after each push. Exit only when **all** hold:
 Cap at **5** cycles. If a bot repeats the same nit after 2 attempts, reply with a
 one-line "won't fix" justification and resolve the thread.
 
-### 8. If stuck after 5 cycles
+### 10. If stuck after 5 cycles
 
 ```shell
 gh pr comment "$PR" --repo "$REPO" --body "5 review cycles complete. Remaining items need human judgment — requesting sync review."
@@ -134,7 +219,7 @@ Time in review so far: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -
 (`$KEY` is the ticket; `$PR` is the PR number — unrelated. Always pass `$PR`
 explicitly to `gh pr comment`.)
 
-### 9. On loop exit, annotate review lane time
+### 11. On loop exit, annotate review lane time
 
 ```shell
 WL=$(tkt worklog "$KEY" --from-role review --note "Review loop complete. Cycles: <N>" --json)
@@ -146,4 +231,5 @@ $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 
 - Review status: approved / changes requested / stuck
 - Comments addressed (count)
+- Threads resolved vs. left open (count)
 - Outstanding items

--- a/.kiro/skills/resume-from-revise/SKILL.md
+++ b/.kiro/skills/resume-from-revise/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resume-from-revise
 description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Resume From Revise
@@ -34,6 +35,7 @@ $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 
 ```shell
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 ```
 
 The agent owns the work again while it pushes/re-reviews.
@@ -74,9 +76,11 @@ WL1=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — in_pro
 # respond-to-review may already have moved it to review; only transition if not.
 CUR=$(tkt view "$KEY" --json | jq -r .status_role)
 [ "$CUR" != "review" ] && tkt transition "$KEY" review
+tkt edit "$KEY" --agent-status waiting
 WL2=$(tkt worklog "$KEY" --from-role review --note "Revise cycle — re-review portion" --json)
 
 tkt transition "$KEY" qa_ready
+tkt edit "$KEY" --agent-status waiting
 tkt comment "$KEY" "Re-review complete and approved. Back in qa_ready — preview updated: <url>. \
 In Progress (revise): $(echo "$WL1" | jq -r .human) (worklog $(echo "$WL1" | jq -r .worklog_id)) | \
 review (re-review): $(echo "$WL2" | jq -r .human) (worklog $(echo "$WL2" | jq -r .worklog_id))."

--- a/.kiro/skills/select-ticket/SKILL.md
+++ b/.kiro/skills/select-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: select-ticket
 description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Select Ticket

--- a/.kiro/skills/self-review/SKILL.md
+++ b/.kiro/skills/self-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-review
 description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+model_tier: standard
 ---
 
 # Self-Review
@@ -17,7 +18,15 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
-### 2. Review as adversary
+### 2. Review as adversary (→ `sdlc-reviewer`)
+
+**Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The
+point is separation: the reviewer is a fresh context that did not write the code,
+so it judges the evidence rather than recalling the intent.
+
+**Fallback** (no subagent support): run this pass yourself, but explicitly — re-read
+the diff from scratch and argue against it before approving. Pretend it is a
+stranger's PR. Do not rubber-stamp your own code.
 
 Hostile-reviewer mindset. Check every changed file for:
 
@@ -38,18 +47,59 @@ project's own conventions doc — read them and apply.
 ### 3. List findings
 
 Per issue: file+line, severity (**blocker** / **warning** / **nit**), description,
-suggested fix.
+suggested fix. Plus an overall verdict — PASS (zero blockers, zero warnings) skips
+straight to the final check.
+
+The reviewer produces findings only; the author context fixes them in step 4.
 
 ### 4. Fix blockers and warnings
 
 Fix all blocker + warning items. Don't skip.
 
-### 5. Rebuild and re-test (config toolchain)
+**Test gaps are not fixed here.** If the reviewer flags "new code without tests" or
+"tests that assert nothing meaningful," do **not** write tests inline — a fix-pass
+test written to close a finding tends to assert whatever the code already does.
+Note the gap and hand it to `qa-author` (or the `qa-engineer` agent) after this
+loop completes, which writes adversarial tests with red-before-green verification.
+
+Format the flag as:
+
+```
+⚠️ TEST GAP: <file:line> — <description>
+→ Recommend: invoke `qa-author` targeting <file/module> after self-review passes.
+```
+
+### 5. Rebuild and re-test (→ `sdlc-verifier`)
+
+**Delegate to `sdlc-verifier`**, which runs the configured checks and returns a
+binary PASS/FAIL with the exact commands and their output as evidence. It never
+fixes anything — a FAIL comes back here.
+
+**Fallback:** run them yourself.
 
 ```shell
 eval "$(tkt cfg build.build --pkg "<pkg>")"
 eval "$(tkt cfg build.test --pkg "<pkg>")"
 eval "$(tkt cfg build.typecheck)"
+```
+
+### 5b. Run behavior specs — non-blocking (if configured)
+
+If the repo binds a behavior-spec runner, run it as a **reported, non-blocking**
+signal, mirroring the non-strict BDD posture: pending scenarios inform the author
+but never block the flow. Skip cleanly when `build.bdd` is unset. See
+[docs/behavior-specs.md](../../docs/behavior-specs.md).
+
+```shell
+# Only a missing key (tkt cfg exit 4 = NotFoundError) is a clean skip.
+# Surface any other failure (e.g. exit 2 = bad/missing config) instead of
+# silently swallowing it. On success stderr is empty, so 2>&1 is safe to eval.
+out="$(tkt cfg build.bdd --pkg "<pkg>" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+  eval "$out" || echo "bdd: behavior-spec runner exited non-zero (non-blocking)"
+elif [ "$rc" -ne 4 ]; then
+  echo "bdd: could not resolve build.bdd (tkt cfg exit $rc): $out" >&2
+fi
 ```
 
 ### 6. Loop

--- a/.kiro/skills/triage-ticket/SKILL.md
+++ b/.kiro/skills/triage-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: triage-ticket
 description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
 allowed-tools: [Bash, Read, Edit]
+model_tier: cheap
 ---
 
 # Triage Ticket
@@ -61,6 +62,7 @@ or `CLAUDE.md`; this skill stays generic. Example shape:
 
 ```shell
 tkt transition "$KEY" in_progress
+tkt edit "$KEY" --agent-status processing
 ```
 
 ### 4. Start time tracking

--- a/.kiro/steering/sdlc-config.md
+++ b/.kiro/steering/sdlc-config.md
@@ -1,0 +1,186 @@
+---
+inclusion: fileMatch
+fileMatchPattern: '.sdlc/config.toml'
+---
+
+# .sdlc/config.toml — Schema Reference
+
+When editing `.sdlc/config.toml`, follow this schema. All sections are optional
+except `[ticketing]` and `[vcs]`.
+
+## `[ticketing]`
+
+```toml
+[ticketing]
+provider = "jira"          # "jira" | "github" | "linear" | "markdown"
+project  = "PROJ"          # project key (Jira/Linear) or unused (GitHub)
+board_id = "123"           # Jira board ID (optional)
+auth_env = ["VAR1"]        # env vars required for auth (validated by `tkt doctor`)
+```
+
+### GitHub-specific: `[github]`
+
+```toml
+[github]
+board          = "projectv2"          # "projectv2" | "labels"
+repo           = "org/repo"
+project_owner  = "@me"                # login, org, or "@me"
+project_number = 1                    # Projects v2 number
+status_field   = "Status"             # single-select field name
+priority_label_prefix = "Priority: "  # label prefix for priority extraction
+type_label_prefix     = ""            # "" matches [issue_types] names directly
+status_label_prefix   = "Status: "    # labels mode only
+```
+
+## `[board.roles]`
+
+Maps canonical roles to the provider's literal lane/status names (case-sensitive):
+
+```toml
+[board.roles]
+backlog      = "Backlog"
+todo         = "To Do"
+in_progress  = "In Progress"
+review       = "PR Needs Review"
+qa_ready     = "Ready for QA"
+qa           = "QA"
+deploy_ready = "Ready for Deploy"
+done         = "Done"
+revise       = "Revise"
+blocked      = "Blocked"
+cancelled    = "Cancelled"
+```
+
+Not every role is required — boards without a lane (e.g. no `qa_ready`) simply omit
+that role. Type routing and ownership keep tickets on the correct flow.
+
+## `[board.ownership]`
+
+Declares which transitions are agent-driven vs human-gated:
+
+```toml
+[board.ownership]
+"todo->in_progress"   = "agent"
+"in_progress->review" = "agent"
+"review->qa_ready"    = "agent"
+"qa_ready->qa"        = "human"
+"deploy_ready->done"  = "human"
+```
+
+## `[issue_types]`
+
+Determines `type_class` routing:
+
+```toml
+[issue_types]
+full_sdlc   = ["Story", "Bug"]                              # full PR/review/deploy pipeline
+deliverable = ["Task", "Sub-task", "Chore", "Epic", "Spike"] # short-circuit to done
+```
+
+## `[queries]`
+
+Named queries for ticket selection. Syntax is provider-native (JQL for Jira,
+Projects filter for GitHub projectv2, search syntax for GitHub labels mode):
+
+```toml
+[queries]
+tier1 = '...'          # highest priority, assigned to me
+tier2 = '...'          # any priority, assigned to me
+tier3 = '...'          # highest priority, unassigned
+tier4 = '...'          # any priority, unassigned
+tier5 = '...'          # backlog (promotion candidates)
+blocked = '...'        # blocked tickets, assigned to me
+blocked_team = '...'   # all blocked tickets
+deploy_ready = '...'   # tickets ready for deploy
+```
+
+Tiers 1-2 auto-select; tiers 3-5 recommend only.
+
+## `[vcs]`
+
+```toml
+[vcs]
+provider       = "github"                          # "github" | "gitlab"
+repo           = "org/repo"                        # full repo identifier
+default_branch = "main"                            # target branch for PRs
+branch_fmt     = "feature/{key-lower}-{slug}"      # template: {key}, {key-lower}, {slug}
+hotfix_fmt     = "hotfix/{key-lower}-{slug}"       # hotfix branch template
+reviewers      = ["user1", "bot[bot]"]             # default PR reviewers
+merge          = "squash"                          # "squash" | "merge" | "rebase"
+```
+
+## `[build]`
+
+```toml
+[build]
+build     = "make build"       # build command; {pkg} placeholder for monorepo filter
+test      = "make test"        # test command; {pkg} placeholder
+typecheck = "tsc --noEmit"     # type check command (use "true" to skip)
+lint      = "eslint ."         # lint command (use "true" to skip)
+bdd       = "npm run bdd"      # optional behavior-spec runner; see docs/behavior-specs.md
+```
+
+`bdd` is the only optional key here. When unset, `tkt cfg build.bdd` exits `4` and
+the caller skips cleanly; any other non-zero exit is a real error to surface.
+
+## `[models]` (optional)
+
+```toml
+[models]                       # tier -> model; resolved via `tkt cfg models.<tier>`
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+```
+
+Skills declare `model_tier: cheap|standard|deep` in frontmatter; this table maps
+it. Omit the whole table to run everything on the harness default. Unrelated to
+`[queries].tierN`, which selects *tickets*.
+
+## `[run]` (optional)
+
+```toml
+[run]
+harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+max_iterations     = 30        # total phase invocations before halting
+max_phase_attempts = 3         # failed attempts on one phase -> blocked
+invocation_timeout = 3600      # seconds per harness invocation
+```
+
+`harness_cmd` is required for `tkt run` and is the only key with no default.
+
+## `[deploy]`
+
+```toml
+[deploy]
+preview_workflow    = "deploy-preview.yml"
+staging_workflow    = "deploy-staging.yml"
+production_workflow = "deploy-production.yml"
+```
+
+## `[timetracking]`
+
+```toml
+[timetracking]
+provider = "none"        # "none" | "jira-worklog" | "tempo"
+billable = false         # whether worklogs default to billable
+auth_env = []            # env vars for time tracking auth
+```
+
+When `provider = "none"`, `tkt worklog` and `tkt lane-time` are safe
+no-ops — they return empty results without error.
+
+## `[docs]` (optional)
+
+```toml
+[docs]
+provider = "confluence"
+space    = "TEAM"
+```
+
+## Validation
+
+After editing, run `tkt doctor` to validate the config:
+- Auth env vars are set
+- Provider is reachable
+- Board roles resolve to real lanes/statuses
+- Queries parse without error

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,9 @@
+---
+inclusion: always
+---
+
+# Tech
+
+Full engineering rules live in AGENTS.md. Follow them exactly.
+
+#[[file:../../AGENTS.md]]

--- a/.kiro/steering/ticket-workflow.md
+++ b/.kiro/steering/ticket-workflow.md
@@ -1,0 +1,141 @@
+---
+inclusion: manual
+---
+
+# Ticket Workflow Reference
+
+Detailed reference for ticket lifecycle, type routing, lane-time annotation, and
+transition ownership. Include this context (`#ticket-workflow`) when working on
+tickets through the SDLC pipeline.
+
+## Board Flow
+
+```
+backlog → todo → in_progress → review → qa_ready → qa → deploy_ready → done
+```
+
+Side roles (can be entered from multiple points):
+- `blocked` — external dependency or unclear spec
+- `revise` — QA failure or reviewer changes-requested
+- `cancelled` — ticket abandoned
+
+## Type-Class Routing
+
+Check a ticket's `type_class` to determine the correct flow:
+
+```shell
+CLASS=$(tkt view "$KEY" --json | jq -r .type_class)
+```
+
+### `full_sdlc` (Story, Bug)
+
+Full pipeline:
+1. `select-ticket` — pick from tiered queries
+2. `triage-ticket` — read requirements, transition `todo → in_progress`
+3. `plan-ticket` — structured implementation plan
+4. Implement + test (using `tkt cfg build.*` commands)
+5. `self-review` — adversarial pre-PR review loop
+6. `open-pr` — push, open PR, request reviewers, transition `in_progress → review`
+7. `ci-fix` — watch CI, fix failures, loop until green
+8. `respond-to-review` — address reviewer comments, loop until approved
+9. `deploy-preview` — confirm preview URL, comment on ticket
+10. Promote to `qa_ready` (human QA gate — agent stops here)
+11. `deploy-ready` — merge, watch staging, gate production
+
+### `deliverable` (Task, Sub-task, Chore, Epic, Spike)
+
+Short-circuit:
+1. `select-ticket` / `triage-ticket` (same as above)
+2. Produce the deliverable (artifact, document, config, etc.)
+3. `complete-deliverable` — comment artifact link, transition straight to `done`
+
+No PR, no review loop, no deploy pipeline.
+
+## Lane-Time Annotation
+
+Every agent-driven transition out of a lane records elapsed time:
+
+```shell
+# Log time and get human-readable result
+WL=$(tkt worklog "$KEY" --from-role in_progress --note "PR opened" --json)
+
+# Post comment with the time
+tkt comment "$KEY" "PR opened. Time in In Progress: \
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+```
+
+### When to annotate
+
+| Transition | Note context |
+|------------|--------------|
+| `in_progress → review` | "PR opened" |
+| `review → qa_ready` | "Approved — promoting to QA" |
+| `deploy_ready → done` | "Deployed to production" |
+| `revise → in_progress` | "Revise fixes applied" |
+| `in_progress → blocked` | "Blocked — \<reason\>" |
+
+### No-op behavior
+
+When `[timetracking].provider = "none"`, `tkt worklog` returns:
+```json
+{"human": "(no time tracking)", "worklog_id": "", "seconds": 0}
+```
+
+Comments should still read naturally — embed the `.human` value as-is.
+
+## Transition Ownership
+
+Transitions are gated by ownership declared in `.sdlc/config.toml`:
+
+| Transition | Default owner |
+|------------|---------------|
+| `backlog → todo` | Human (refinement) |
+| `todo → in_progress` | **Agent** (after select + triage) |
+| `in_progress → review` | **Agent** (on PR open) |
+| `review → revise` | Reviewer or `respond-to-review` |
+| `revise → in_progress` | **Agent** (`resume-from-revise`) |
+| `review → qa_ready` | **Agent** (promotion gate) |
+| `qa_ready → qa` | **Human** (QA begins testing) |
+| `qa → revise` / `qa → deploy_ready` | **Human** (QA verdict) |
+| `deploy_ready → done` | **Human** (deploy confirmation) |
+
+The agent must never perform a human-gated transition. Check `[board.ownership]`
+in config if unsure.
+
+## Blocker Handling
+
+```shell
+# Check for unresolved blockers
+BLOCKERS=$(tkt blockers "$KEY" --json)
+COUNT=$(echo "$BLOCKERS" | jq 'length')
+
+# If blocked, transition and comment
+if [ "$COUNT" -gt 0 ]; then
+  WL=$(tkt worklog "$KEY" --from-role in_progress --note "Blocked" --json)
+  tkt transition "$KEY" blocked
+  tkt comment "$KEY" "BLOCKED: <description>. \
+Waiting on: <who>. Need: <what unblocks>. \
+Time in In Progress: $(echo "$WL" | jq -r .human)."
+fi
+```
+
+Run `check-blockers` periodically to classify and recommend unblock actions.
+
+## Decision Points
+
+| Condition | Action |
+|-----------|--------|
+| Tests fail after 3 fix attempts | Stop, transition to `blocked`, request human help |
+| CI flake (infra, not code) | `gh run rerun <id> --failed`; don't count against budget |
+| Reviewer requests changes | Loop via `respond-to-review` until approved |
+| Merge conflicts | Rebase on default branch, resolve, re-push |
+| Ticket unclear / spec gap | Transition to `blocked` with clarifying comment |
+| Scope > 400 LOC | Stop, recommend splitting via `plan-ticket` |
+
+## Abort Conditions
+
+Stop and comment on the ticket when:
+- 3+ non-converging review cycles
+- Infrastructure CI failure (not code-related)
+- Scope exceeds ~400 lines (split needed)
+- External blocker unresolved > 24h

--- a/.kiro/steering/tkt.md
+++ b/.kiro/steering/tkt.md
@@ -1,0 +1,88 @@
+# tkt — Core Rules
+
+This project uses **tkt**, a provider-agnostic ticketing CLI. All ticketing,
+board transitions, and project config are accessed through `tkt` commands —
+never through a backend API directly.
+
+## Portability Rules
+
+1. **No backend specifics in workflow logic.**
+   Use `tkt view`, `tkt transition`, `tkt comment`, `tkt blockers`,
+   `tkt worklog`, `tkt lane-time`, `tkt list`, `tkt create`, `tkt link`.
+   Never call `acli`, `gh issue`, Jira REST, Linear GraphQL, or any other
+   backend API directly for ticketing operations.
+
+2. **No repo/toolchain hardcoding.**
+   Read all values through `tkt cfg`:
+   - `tkt cfg vcs.repo` — repository identifier
+   - `tkt cfg vcs.default_branch` — main branch name
+   - `tkt cfg vcs.merge` — merge strategy (squash, merge, rebase)
+   - `tkt cfg vcs.reviewers --json` — PR reviewer list
+   - `tkt cfg vcs.branch_fmt --ticket KEY --slug s` — branch name template
+   - `tkt cfg build.build --pkg X` — build command
+   - `tkt cfg build.test --pkg X` — test command
+   - `tkt cfg build.typecheck` — type checking command
+   - `tkt cfg deploy.staging_workflow` — staging deploy workflow name
+   - `tkt cfg deploy.production_workflow` — production deploy workflow name
+
+3. **Speak in roles, not lane names.**
+   Canonical roles: `backlog`, `todo`, `in_progress`, `review`, `qa_ready`,
+   `qa`, `deploy_ready`, `done`, plus side roles `revise`, `blocked`, `cancelled`.
+   Use `tkt transition KEY review` to move tickets.
+   Use `tkt lane review` only when the provider's literal lane string is needed.
+
+4. **Respect `type_class` routing.**
+   - `full_sdlc` (Story/Bug): full pipeline — select, triage, plan, implement, self-review, open-pr, respond-to-review, deploy-ready.
+   - `deliverable` (Task/Epic/Spike/Chore): short-circuits via `complete-deliverable` straight to `done`.
+
+5. **`tkt worklog` / `tkt lane-time` are safe no-ops.**
+   When `[timetracking].provider = "none"`, these return empty worklogs.
+   Comments should still read naturally (e.g. "Time in In Progress: (no time tracking)").
+
+## Verb Contract
+
+| Command | Purpose |
+|---------|---------|
+| `tkt whoami` | current user id |
+| `tkt list --tier N` | run tiered query from config |
+| `tkt list --query NAME` | run named query from config |
+| `tkt view KEY --json` | normalized ticket JSON |
+| `tkt transition KEY ROLE` | move ticket to role's lane |
+| `tkt comment KEY BODY` | post activity comment |
+| `tkt blockers KEY --json` | unresolved blockers only |
+| `tkt worklog KEY --from-role ROLE [--note T]` | log time since lane entry |
+| `tkt lane-time KEY --role ROLE` | log time for closed lane interval |
+| `tkt create --type T --summary S ...` | create a ticket |
+| `tkt link KEY --to OTHER --type T` | link tickets |
+| `tkt lane ROLE` | resolve role to provider lane name |
+| `tkt apply [KEY] --file PATH` | create/update from a full ticket markdown doc |
+| `tkt edit KEY [--summary/--body/--agent-status/...]` | field-level update |
+| `tkt cfg DOTTED.KEY ...` | read config with template substitution |
+| `tkt init --provider P [...]` | scaffold `.sdlc/` in a project |
+| `tkt sync-pack [--dir D] [--check]` | install the pack as committed copies |
+| `tkt run [KEY] [--status/--stop/--dry-run]` | external loop driver, one phase per invocation |
+| `tkt doctor` | validate auth + reachability + board model + pack sync |
+
+Exit codes are the branch points: `4` is `NotFoundError` (an unset optional config
+key — a clean skip), `2` is a usage/config error (a real problem). Never treat a
+non-zero exit as interchangeable.
+
+## Validation
+
+When starting work or troubleshooting, run `tkt doctor` to confirm:
+- Ticketing auth is valid
+- Board model is reachable
+- Role-to-lane mappings resolve correctly
+
+## Configuration
+
+The project's SDLC configuration lives in `.sdlc/config.toml`. This file defines:
+- Ticketing provider and board structure
+- Role-to-lane mappings
+- Query tiers for ticket selection
+- VCS settings (repo, branch format, reviewers, merge strategy)
+- Build/test/lint commands, plus the optional `build.bdd` behavior-spec runner
+- Deploy workflow names
+- Time tracking provider
+- `[models]` — the tier→model mapping skills resolve via `tkt cfg models.<tier>`
+- `[run]` — harness command and caps for the `tkt run` loop driver

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ separate harness-specific files).
 | `tkt cfg priorities` | backend-aware priority list, highest-first |
 | `tkt init --provider P [--dir D] [--link-skills] [--sample] [--force] [--no-detect-build]` | scaffold `.sdlc/` (seeds `[build]` from the project's package manager) |
 | `tkt sync-pack [--dir D] [--all-harnesses] [--check]` | install the pack into a consumer repo as committed copies |
+| `tkt run [KEY] [--status] [--stop] [--max-iterations N] [--dry-run]` | external loop driver: one pipeline phase per harness invocation |
 | `tkt doctor` | validate auth + reachability + board model + pack sync |
 
 `--json` works on either side of the verb.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,8 @@ hand-maintained.
 - `agents/ticket-researcher.md` is the read-only lookup subagent.
 - `docs/install.md` — installing `tkt` and the pack.
 - `docs/markdown-ticketing.md` — the markdown provider's on-disk format.
+- `docs/model-routing.md` — the `model_tier` frontmatter key and the `[models]`
+  tier→model mapping skills resolve via `tkt cfg models.<tier>`.
 - `docs/extraction-history.md` — how this pack was extracted from its origin repo.
 - `scripts/` — `company-import.sh` (bulk import) and `smoke-sync-pack.sh`
   (sync-pack smoke test).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,11 @@ per-tool folders (`.opencode/commands/`, `.cursor/commands/`, `.cursor/skills/`,
 | `deploy-preview` | confirm preview env, post URL to ticket + PR |
 | `hotfix-revert` | fast-track prod revert |
 | `resume-from-revise` | re-enter the loop after a human revise fix |
+| `qa-strategy` | test plan from acceptance criteria (Break-It Checklist) |
+| `qa-author` | write adversarial tests, red-before-green enforced |
+| `qa-critique` | score an existing suite for coverage + assertion strength |
+| `qa-flake-triage` | classify a flaky test's root cause; never papers over it |
+| `qa-bug-report` | structured bug report with a minimal reproduction |
 | `sync-skills` | translate the canonical skills into each harness format |
 
 ### Editing skills
@@ -170,6 +175,7 @@ hand-maintained.
   | `sdlc-executor` | file read/write + build/test, no VCS push, no transitions | implement phase |
   | `sdlc-reviewer` | read-only | self-review, review pass |
   | `sdlc-verifier` | read + build/test only | self-review, check pass |
+  | `qa-engineer` | read + write tests + test runner | QA phase (P4.5) |
 
   Every phase that delegates also states an inline fallback, so harnesses without
   subagent support run the pipeline unchanged.
@@ -177,6 +183,9 @@ hand-maintained.
 - `docs/markdown-ticketing.md` — the markdown provider's on-disk format.
 - `docs/model-routing.md` — the `model_tier` frontmatter key and the `[models]`
   tier→model mapping skills resolve via `tkt cfg models.<tier>`.
+- `docs/behavior-specs.md` — the BDD practice behind the optional `build.bdd` key.
+- `docs/qa-suite-design.md` — how the five `qa-*` skills and `qa-engineer` fit
+  together, and the Break-It Checklist they share.
 - `docs/extraction-history.md` — how this pack was extracted from its origin repo.
 - `scripts/` — `company-import.sh` (bulk import) and `smoke-sync-pack.sh`
   (sync-pack smoke test).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,19 @@ hand-maintained.
 
 ## Meta
 
-- `agents/ticket-researcher.md` is the read-only lookup subagent.
+- `agents/` holds the subagent catalog, shipped to `.claude/agents/` by
+  `sync-pack`. Each is trust-scoped so the pipeline never self-approves:
+
+  | Agent | Trust | Used by |
+  | --- | --- | --- |
+  | `ticket-researcher` | read-only | ad-hoc ticket lookup |
+  | `sdlc-planner` | read-only | plan phase |
+  | `sdlc-executor` | file read/write + build/test, no VCS push, no transitions | implement phase |
+  | `sdlc-reviewer` | read-only | self-review, review pass |
+  | `sdlc-verifier` | read + build/test only | self-review, check pass |
+
+  Every phase that delegates also states an inline fallback, so harnesses without
+  subagent support run the pipeline unchanged.
 - `docs/install.md` — installing `tkt` and the pack.
 - `docs/markdown-ticketing.md` — the markdown provider's on-disk format.
 - `docs/model-routing.md` — the `model_tier` frontmatter key and the `[models]`

--- a/README.md
+++ b/README.md
@@ -327,6 +327,107 @@ repo, branch formats, reviewers, and workflow names are all config-driven, and
 genuinely infra-specific steps (e.g. preview-URL extraction) are clearly marked
 PROJECT-SPECIFIC in the skill text.
 
+## Unattended runs
+
+`tkt run` is an external loop driver: it invokes a configured AI harness
+headlessly, one pipeline phase per invocation, persisting state between calls.
+**The driver is the loop** — it never relies on the model "continuing" across
+sessions.
+
+### Why
+
+Every loop in the automated-sdlc pipeline (CI-fix retries, review cycles, the
+pipeline itself) exists only as prose inside whichever session runs the skill.
+When that session ends, times out, or compacts, the pipeline dies with it.
+`tkt run` moves the loop *outside* the harness: a process that invokes the harness
+once per phase, reads a structured result file, persists phase state on the
+ticket, and loops until a gate, a STOP signal, or a cap.
+
+### Usage
+
+```sh
+tkt run TKT-1                   # run/resume TKT-1's pipeline
+tkt run                         # P0 select-ticket first, then proceed
+tkt run --status TKT-1          # print the current phase marker
+tkt run --stop TKT-1            # halt at the next iteration boundary
+tkt run --dry-run TKT-1         # print the prompt without invoking
+tkt run --max-iterations 5 TKT-1
+```
+
+### Config (`[run]` section)
+
+```toml
+[run]
+harness_cmd = "claude -p {prompt} --permission-mode acceptEdits"
+max_iterations = 30        # total invocations per run
+max_phase_attempts = 3     # per-phase retry cap
+invocation_timeout = 3600  # seconds per harness invocation
+```
+
+`{prompt}` is replaced with the phase prompt. Per-harness examples:
+
+```toml
+harness_cmd = "claude -p {prompt} --permission-mode acceptEdits"   # Claude Code
+harness_cmd = "kiro-cli chat --no-interactive --trust-all-tools {prompt}"
+harness_cmd = "codex exec {prompt}"
+```
+
+On Windows the same commands work when the harness CLI is on `PATH`; reference
+`.cmd`/`.ps1` wrappers directly if that's how it was installed.
+
+### Resume model
+
+Authoritative phase state lives **on the ticket**, as a machine-readable marker
+comment:
+
+```
+[run] Phase P5 (open-pr), attempt 1 — advance
+<!-- tkt-run: {"phase":"P5","attempt":1,"outcome":"advance","next":"P6",...} -->
+```
+
+On start, `run` reads the newest marker to decide where to resume. Kill the
+driver, restart it on the same ticket, and it picks up from there.
+
+The verb contract has no "list comments" verb, so only the markdown adapter can
+read its own markers back. On every other backend the driver resumes from a local
+mirror at `.sdlc/state/run/<key>/marker.json`. The ticket comment therefore stays
+the human-readable and cross-machine record, but **resuming on a different machine
+is markdown-only** — elsewhere, a run resumed from a fresh worktree starts over.
+
+### Safety controls
+
+- **STOP file:** drop `.sdlc/state/run/<key>/STOP` (or run `tkt run --stop KEY`)
+  to halt at the next iteration boundary.
+- **Iteration cap:** `max_iterations` (default 30) bounds runaway loops.
+- **Per-phase attempt cap:** 3 failed attempts on one phase transitions the ticket
+  to `blocked` with log context.
+- **QA gate:** P9 (`qa_ready`) always halts. The human QA gate is never bypassed.
+- **Human-owned transitions:** any transition marked `human` in `[board.ownership]`
+  is never performed by the driver.
+- **Production deploy:** P10 is blocked unless `[board.ownership]` explicitly grants
+  `"deploy_ready->done" = "agent"`.
+- **Timeout:** the per-invocation timeout bounds a hung harness.
+
+### Result-file contract
+
+Each invocation's prompt instructs the agent to write
+`.sdlc/state/run/<key>/result.json`:
+
+```json
+{"phase":"P6","outcome":"advance","next":"P7","reason":"CI green"}
+```
+
+Valid outcomes: `advance` (move on), `retry` (same phase again), `blocked`
+(unrecoverable), `gate` (human gate reached). A missing or invalid result file
+counts as a failed attempt.
+
+### Security note
+
+A headless run executes with whatever permissions `harness_cmd` grants. Use
+least-privilege flags (`--permission-mode acceptEdits`, scoped tool trust) with
+`[board.ownership]` as the guardrail. The driver itself never performs VCS
+operations and never bypasses adapter verbs.
+
 ## Platform notes (Windows)
 
 Shell examples throughout this README use Unix syntax. The differences that

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ normalizes every backend into one JSON shape. Skills never touch `acli`/`gh`/RES
 
 This is a **standalone, portable package** — clone it once and point any project at
 it. Nothing here is specific to a single repo or backend. Requires Python 3.11+
-(uses stdlib `tomllib`); no third-party deps.
+(uses stdlib `tomllib`); no third-party deps. Runs on macOS, Linux, and Windows.
 
 Status: core + `jira`, `markdown`, `github`, `linear`, and `openkanban` adapters,
 plus the **full** ported SDLC skill pack — 14 skills + the ticket-researcher agent
@@ -16,6 +16,8 @@ implementing the verb contract; no skill changes.
 
 ## Install
 
+### macOS / Linux
+
 ```sh
 git clone <this-repo> ~/Development/tkt
 ln -s ~/Development/tkt/tkt /usr/local/bin/tkt   # put `tkt` on PATH (optional)
@@ -23,6 +25,39 @@ ln -s ~/Development/tkt/tkt /usr/local/bin/tkt   # put `tkt` on PATH (optional)
 
 `tkt` runs from anywhere; it locates its own `core/`/`adapters/` relative to the
 script, so the symlink target must resolve back to the repo (a symlink is fine).
+
+### Windows
+
+```powershell
+git clone <this-repo> C:\tools\tkt
+```
+
+Then put `tkt` on `PATH`. Either add `C:\tools\tkt` to `Path` (Settings → System →
+About → Advanced system settings → Environment Variables), or persist it from
+PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable("Path",
+  "$([Environment]::GetEnvironmentVariable('Path','User'));C:\tools\tkt",
+  "User")
+```
+
+The `tkt` entrypoint is a shebang script, which Windows shells don't honour, so
+invoke it through Python. A batch wrapper in a directory already on `PATH`:
+
+```bat
+@echo off
+python C:\tools\tkt\tkt %*
+```
+
+…or a PowerShell function in your `$PROFILE`:
+
+```powershell
+function tkt { python C:\tools\tkt\tkt @args }
+```
+
+> Windows symlinks (`mklink`, `New-Item -Type SymbolicLink`) need Developer Mode
+> or an elevated prompt. The PATH/wrapper approach avoids that entirely.
 
 ## Use in a project
 
@@ -55,6 +90,17 @@ Manual equivalent, if you prefer:
 ```sh
 mkdir -p .sdlc && cp ~/Development/tkt/examples/config.markdown.toml .sdlc/config.toml
 ln -s ~/Development/tkt/skills/* .claude/skills/
+```
+
+On Windows, use `tkt sync-pack` instead of the symlink step — `--link-skills` and
+`ln -s` both need Developer Mode or an elevated prompt, whereas `sync-pack` writes
+committed copies and needs no special permissions (it is also the better choice for
+shared and CI environments on any platform):
+
+```powershell
+mkdir .sdlc -Force
+copy C:\tools\tkt\examples\config.markdown.toml .sdlc\config.toml
+tkt sync-pack
 ```
 
 Config discovery order: `--config <path>` → `$TKT_CONFIG` → nearest `.sdlc/config.toml`
@@ -280,6 +326,37 @@ VCS (PR/CI/merge via `gh`) and infra (preview/deploy) remain GitHub/cloud-shaped
 repo, branch formats, reviewers, and workflow names are all config-driven, and
 genuinely infra-specific steps (e.g. preview-URL extraction) are clearly marked
 PROJECT-SPECIFIC in the skill text.
+
+## Platform notes (Windows)
+
+Shell examples throughout this README use Unix syntax. The differences that
+actually matter on Windows:
+
+- **Invocation.** `tkt` is a shebang script; Windows shells ignore shebangs, so run
+  it as `python tkt <verb>` or via the batch/PowerShell wrapper in Install above.
+- **Symlinks.** `tkt init --link-skills` calls `Path.symlink_to`, which needs
+  Developer Mode or an elevated prompt. Use `tkt sync-pack` (committed copies)
+  instead.
+- **Environment variables.** Auth env (`CONFLUENCE_API_TOKEN`, `LINEAR_API_KEY`, …)
+  and `TKT_CONFIG` are `$env:VAR = "value"` in PowerShell, `set VAR=value` in cmd.
+  Persist them via System Environment Variables or your `$PROFILE`.
+- **Path separators.** Config discovery is `pathlib`-based, so `.sdlc/config.toml`
+  and `.sdlc\config.toml` both resolve.
+- **Line endings.** Ticket documents and JSONL sidecars are parsed with
+  `splitlines()`, so CRLF is read correctly. Git's `core.autocrlf` can still churn
+  the markdown board's files — add `* text=auto eol=lf` to `.gitattributes`.
+- **Shell translation:**
+
+  | Unix | PowerShell | cmd |
+  |------|------------|-----|
+  | `export VAR=value` | `$env:VAR = "value"` | `set VAR=value` |
+  | `cmd1 && cmd2` | `cmd1; cmd2` (`&&` works in PS 7+) | `cmd1 && cmd2` |
+  | `mkdir -p dir` | `mkdir dir -Force` | `mkdir dir` |
+  | `$EDITOR file` | `code file` / `notepad file` | `notepad file` |
+  | `ln -s target link` | `New-Item -Type SymbolicLink -Path link -Target target` | `mklink link target` |
+
+The provider CLIs each backend shells out to (`acli`, `gh`) must be on `PATH`
+independently; `tkt doctor` reports when one is missing.
 
 ## Architecture
 

--- a/adapters/jira.py
+++ b/adapters/jira.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import subprocess
 import time
 import urllib.request
@@ -53,14 +54,254 @@ def _adf_to_text(node) -> str:
     return "".join(out)
 
 
-def _text_to_adf(text: str) -> dict:
-    """Wrap plaintext as a minimal ADF document — one paragraph per line."""
-    content = []
-    for line in text.split("\n"):
-        para: dict = {"type": "paragraph", "content": []}
-        if line:
-            para["content"] = [{"type": "text", "text": line}]
-        content.append(para)
+# ---- Markdown -> ADF ---------------------------------------------------
+#
+# Jira's REST v3 API stores rich text as Atlassian Document Format (ADF), a JSON
+# tree — not wiki markup, and not plain text. Skills author ticket bodies and
+# comments in Markdown, so every write path (create/apply descriptions, comments)
+# runs the body through this converter. Without it, Markdown lands as literal
+# text ("## Heading", "**bold**", "- item" shown verbatim). This is a pragmatic,
+# dependency-free subset of CommonMark — enough for the block/inline constructs
+# skills actually emit; anything unrecognized degrades to a plain paragraph.
+
+_INLINE_CODE = re.compile(r"`([^`]+)`")
+_LINK = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+_STRONG_STAR = re.compile(r"\*\*(?!\s)(.+?)(?<!\s)\*\*")
+_STRONG_UND = re.compile(r"__(?!\s)(.+?)(?<!\s)__")
+_STRIKE = re.compile(r"~~(?!\s)(.+?)(?<!\s)~~")
+_EM_STAR = re.compile(r"\*(?!\s)(.+?)(?<!\s)\*")
+_EM_UND = re.compile(r"(?<![A-Za-z0-9_])_(?!\s)(.+?)(?<!\s)_(?![A-Za-z0-9_])")
+
+# Priority order matters: earliest match in the text wins; ties break to the
+# order here, so code/link/strong resolve before em (`**x**` is strong, not two
+# ems). Each entry is (kind, compiled-regex); every regex captures its inner text
+# in group(1) (link also captures its href in group(2)).
+_INLINE_RULES = [
+    ("code", _INLINE_CODE),
+    ("link", _LINK),
+    ("strong", _STRONG_STAR),
+    ("strong", _STRONG_UND),
+    ("strike", _STRIKE),
+    ("em", _EM_STAR),
+    ("em", _EM_UND),
+]
+
+# Only mark links whose target is safe to render: an explicit allowed scheme, or
+# a schemeless relative/anchor path. Anything else (javascript:, data:, and a
+# protocol-relative //host) stays plain text so a hostile target never lands in
+# the ADF.
+_HREF_SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
+_ALLOWED_HREF_SCHEMES = ("http:", "https:", "mailto:")
+
+
+def _is_safe_href(href: str) -> bool:
+    h = href.strip()
+    if h.startswith("//"):  # protocol-relative — reject to be safe
+        return False
+    if not _HREF_SCHEME.match(h):  # schemeless relative path or #anchor
+        return True
+    return h.lower().startswith(_ALLOWED_HREF_SCHEMES)
+
+_LIST_RE = re.compile(r"^(\s*)([-*+]|\d+[.)])\s+(.*)$")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_FENCE_OPEN_RE = re.compile(r"^(```+|~~~+)\s*([\w+#.-]*)\s*$")
+_FENCE_CLOSE_RE = re.compile(r"^(```+|~~~+)\s*$")
+_HR_RE = re.compile(r"^\s*([-*_])(?:\s*\1){2,}\s*$")
+_QUOTE_RE = re.compile(r"^\s*>\s?")
+
+
+def _text_node(text: str, marks: list | None = None) -> dict:
+    node: dict = {"type": "text", "text": text}
+    if marks:
+        node["marks"] = list(marks)
+    return node
+
+
+def _add_mark(nodes: list, mark: dict) -> None:
+    """Add a mark to every text node, without duplicating a mark type (so a
+    bold link keeps both its link and strong marks, but never two strongs)."""
+    for node in nodes:
+        if node.get("type") == "text":
+            marks = node.setdefault("marks", [])
+            if not any(m.get("type") == mark.get("type") for m in marks):
+                marks.append(mark)
+
+
+def _inline(text: str) -> list:
+    """Parse inline Markdown (code, links, bold/italic/strike) into ADF text
+    nodes. Unmatched markup characters (a lone `*` in `services/*`) stay literal
+    because the emphasis regexes require a properly flanked, closed pair."""
+    nodes: list = []
+    pos = 0
+    while pos < len(text):
+        best = None  # (start, kind, match)
+        for kind, pat in _INLINE_RULES:
+            m = pat.search(text, pos)
+            if m and (best is None or m.start() < best[0]):
+                best = (m.start(), kind, m)
+        if best is None:
+            nodes.append(_text_node(text[pos:]))
+            break
+        start, kind, m = best
+        if start > pos:
+            nodes.append(_text_node(text[pos:start]))
+        if kind == "code":
+            nodes.append(_text_node(m.group(1), marks=[{"type": "code"}]))
+        elif kind == "link":
+            inner = _inline(m.group(1))
+            if _is_safe_href(m.group(2)):
+                _add_mark(inner, {"type": "link", "attrs": {"href": m.group(2)}})
+            nodes.extend(inner)
+        elif kind == "strong":
+            inner = _inline(m.group(1))
+            _add_mark(inner, {"type": "strong"})
+            nodes.extend(inner)
+        elif kind == "strike":
+            inner = _inline(m.group(1))
+            _add_mark(inner, {"type": "strike"})
+            nodes.extend(inner)
+        elif kind == "em":
+            inner = _inline(m.group(1))
+            _add_mark(inner, {"type": "em"})
+            nodes.extend(inner)
+        pos = m.end()
+    return [n for n in nodes if not (n.get("type") == "text" and n.get("text") == "")]
+
+
+def _paragraph(text: str) -> dict:
+    return {"type": "paragraph", "content": _inline(text)}
+
+
+def _starts_block(line: str) -> bool:
+    return bool(
+        _HEADING_RE.match(line)
+        or _FENCE_OPEN_RE.match(line.strip())
+        or _HR_RE.match(line)
+        or _QUOTE_RE.match(line)
+        or _LIST_RE.match(line)
+    )
+
+
+def _parse_list(lines: list, i: int, end: int, base_indent: int):
+    """Build a (possibly nested) bullet/ordered list starting at lines[i]. A
+    deeper-indented list line becomes a sublist on the current item."""
+    ordered = bool(re.match(r"\d+[.)]", _LIST_RE.match(lines[i]).group(2)))
+    items: list = []
+    while i < end:
+        line = lines[i]
+        if not line.strip():
+            # Tolerate a blank line between items (a "loose" list) as long as the
+            # list actually continues; otherwise the list has ended.
+            k = i + 1
+            while k < end and not lines[k].strip():
+                k += 1
+            nxt = _LIST_RE.match(lines[k]) if k < end else None
+            if nxt and len(nxt.group(1)) >= base_indent:
+                i = k
+                continue
+            break
+        m = _LIST_RE.match(line)
+        if not m or len(m.group(1)) < base_indent:
+            break
+        if len(m.group(1)) > base_indent:  # defensive; handled as a sublist below
+            break
+        para = _paragraph(m.group(3))
+        item_content: list = [para]
+        i += 1
+        nxt = _LIST_RE.match(lines[i]) if i < end else None
+        if nxt and len(nxt.group(1)) > base_indent:
+            sub, i = _parse_list(lines, i, end, base_indent=len(nxt.group(1)))
+            if sub["content"]:  # never attach an all-empty sublist
+                item_content.append(sub)
+        # Skip a wholly empty item (a bare marker with no text and no sublist).
+        if para["content"] or len(item_content) > 1:
+            items.append({"type": "listItem", "content": item_content})
+    return {"type": "orderedList" if ordered else "bulletList", "content": items}, i
+
+
+# ADF's blockquote content model allows only these block types (notably not
+# heading, rule, or a nested blockquote), so anything else parsed inside a `>`
+# is degraded here — otherwise Jira rejects the whole document with a 400.
+_BLOCKQUOTE_ALLOWED = {"paragraph", "bulletList", "orderedList", "codeBlock"}
+
+
+def _coerce_blockquote_children(nodes: list) -> list:
+    out: list = []
+    for node in nodes:
+        ntype = node.get("type")
+        if ntype in _BLOCKQUOTE_ALLOWED:
+            out.append(node)
+        elif ntype == "heading":  # keep the text, drop the heading level
+            out.append({"type": "paragraph", "content": node.get("content", [])})
+        elif ntype == "blockquote":  # flatten a nested quote into this one
+            out.extend(_coerce_blockquote_children(node.get("content", [])))
+        # rule (and anything else carrying no text) is dropped
+    return out
+
+
+def _blocks(lines: list, i: int, end: int) -> list:
+    out: list = []
+    while i < end:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        fence = _FENCE_OPEN_RE.match(line.strip())
+        if fence:
+            lang, buf, j = fence.group(2), [], i + 1
+            while j < end and not _FENCE_CLOSE_RE.match(lines[j].strip()):
+                buf.append(lines[j])
+                j += 1
+            node: dict = {"type": "codeBlock"}
+            if lang:
+                node["attrs"] = {"language": lang}
+            if buf:
+                node["content"] = [_text_node("\n".join(buf))]
+            out.append(node)
+            i = j + 1
+            continue
+        heading = _HEADING_RE.match(line)
+        if heading and heading.group(2).strip():
+            out.append({
+                "type": "heading",
+                "attrs": {"level": len(heading.group(1))},
+                "content": _inline(heading.group(2).strip()),
+            })
+            i += 1
+            continue
+        if _HR_RE.match(line):
+            out.append({"type": "rule"})
+            i += 1
+            continue
+        if _QUOTE_RE.match(line):
+            buf = []
+            while i < end and _QUOTE_RE.match(lines[i]):
+                buf.append(_QUOTE_RE.sub("", lines[i], count=1))
+                i += 1
+            inner = _coerce_blockquote_children(_blocks(buf, 0, len(buf)))
+            out.append({"type": "blockquote",
+                        "content": inner or [{"type": "paragraph", "content": []}]})
+            continue
+        if _LIST_RE.match(line):
+            indent = len(_LIST_RE.match(line).group(1))
+            node, i = _parse_list(lines, i, end, base_indent=indent)
+            if node["content"]:  # an all-empty list emits no (invalid) empty list
+                out.append(node)
+            continue
+        # Paragraph: gather soft-wrapped lines until a blank line or a new block.
+        buf = [line.strip()]
+        i += 1
+        while i < end and lines[i].strip() and not _starts_block(lines[i]):
+            buf.append(lines[i].strip())
+            i += 1
+        out.append(_paragraph(" ".join(buf)))
+    return out
+
+
+def _md_to_adf(text: str) -> dict:
+    """Convert a Markdown string into an ADF document for the Jira REST API."""
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    content = _blocks(lines, 0, len(lines))
     if not content:
         content = [{"type": "paragraph", "content": []}]
     return {"type": "doc", "version": 1, "content": content}
@@ -289,9 +530,10 @@ class JiraAdapter(Adapter):
         if assignee:
             args += ["--assignee", assignee]
         if body:
+            # acli's --description only accepts plain text, so Markdown would land
+            # literally. Pass it as a plain-text fallback (so a REST-less setup still
+            # gets content) and overwrite it with rendered ADF via REST below.
             args += ["--description", body]
-        # acli `create` has no --priority flag (nor does `edit`); set it via REST
-        # post-create when a token is available, otherwise warn.
         created = self._acli_json(*args)
         key = created.get("key") if isinstance(created, dict) else None
         if not key:
@@ -299,14 +541,20 @@ class JiraAdapter(Adapter):
             key = (created[0].get("key") if isinstance(created, list) and created else None)
         if not key:
             raise ProviderError(f"acli create returned no key: {created}")
-        if priority:
-            if self.have_rest:
-                self._jira("PUT", f"/rest/api/3/issue/{key}",
-                           {"fields": {"priority": {"name": priority}}})
-            else:
-                print(f"tkt: priority '{priority}' not set on {key} — acli can't set "
-                      f"priority and no REST token is configured. Set it manually.",
-                      flush=True)
+        # acli `create` has neither a --priority flag nor ADF descriptions; patch
+        # both via REST post-create when a token is available, otherwise warn.
+        if self.have_rest:
+            fields: dict = {}
+            if priority:
+                fields["priority"] = {"name": priority}
+            if body:
+                fields["description"] = _md_to_adf(body)
+            if fields:
+                self._jira("PUT", f"/rest/api/3/issue/{key}", {"fields": fields})
+        elif priority:
+            print(f"tkt: priority '{priority}' not set on {key} — acli can't set "
+                  f"priority and no REST token is configured. Set it manually.",
+                  flush=True)
         return self.view(key)
 
     def apply_template(self):
@@ -346,7 +594,7 @@ class JiraAdapter(Adapter):
             raise ProviderError(
                 "apply update needs a REST token (set CONFLUENCE_SITE/EMAIL/"
                 "API_TOKEN); acli cannot patch issue fields")
-        fields: dict = {"summary": summary, "description": _text_to_adf(desc)}
+        fields: dict = {"summary": summary, "description": _md_to_adf(desc)}
         if "priority" in fm_in:
             fields["priority"] = {"name": str(fm_in["priority"])}
         if "labels" in fm_in:
@@ -367,6 +615,12 @@ class JiraAdapter(Adapter):
                    "--status", lane, "--yes")
 
     def comment(self, key, body):
+        # REST accepts ADF, so comments render their Markdown (headings, lists,
+        # bold). acli's --body is plain-text only, so it's the REST-less fallback.
+        if self.have_rest:
+            self._jira("POST", f"/rest/api/3/issue/{key}/comment",
+                       {"body": _md_to_adf(body)})
+            return
         self._acli("jira", "workitem", "comment", "create", "--key", key, "--body", body)
 
     def blockers(self, key):

--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -1,0 +1,199 @@
+---
+name: qa-engineer
+description: Adversarial QA analysis — finds what the developer missed. Routes to QA skills, produces risk tables, and writes test files. Read-only for implementation code.
+tools: [Bash, Read, Write]
+model_tier: deep
+model: opus
+---
+
+# QA Engineer
+
+You are a pessimist who has seen production burn. You assume:
+
+- The developer tested the happy path and nothing else
+- Every type annotation is a lie until a runtime check proves it
+- Every "this can't happen" comment is a prediction, not a fact
+- The existing test suite has gaps the developer doesn't know about
+
+Your job is NOT to prove the code works. Your job is to find where it doesn't.
+
+## Tools
+
+**Read:** Any file in the repo worktree.
+
+**Write:** Only test-related files:
+- `**/*.test.*`
+- `**/*.spec.*`
+- `**/__tests__/**`
+- `**/test/**`
+- `**/TEST-PLAN.md`
+
+**Bash (read-only):**
+- `git diff`, `git log`, `git show` — read changes and history
+- `tkt view <KEY> --json` — read ticket for requirement context
+- `tkt cfg <DOTTED.KEY>` — read project config
+- Test runner execution (to verify red-before-green)
+
+**Bash (write):** Test runner execution only.
+
+## Guardrails
+
+- **NEVER modify implementation code.** Only test files and test plans.
+- **No ticket transitions.** Never run `tkt transition`, `tkt comment`,
+  `tkt create`, `tkt link`, or `tkt worklog`.
+- **No git mutations.** Never run `git commit`, `git push`, `git checkout`,
+  `git add`, or `git branch`.
+- **No build/deploy commands.** Never run build, install, or deploy commands.
+  Test runners are allowed.
+
+## Routing
+
+You are the primary entry point for QA requests. Route to the appropriate skill
+based on the user's intent:
+
+| User says | Skill | What happens |
+| --- | --- | --- |
+| "what could break here?" | (inline) | Adversarial analysis → risk table |
+| "generate tests from this spec" / "what should we test?" | `qa-strategy` → `qa-author` | Plan then write tests |
+| "write tests for this" / "add tests" | `qa-author` | Write adversarial tests |
+| "review these tests" / "are these tests good enough?" | `qa-critique` | Score and critique test suite |
+| "why is this test flaky?" / "test keeps failing randomly" | `qa-flake-triage` | Classify and fix the flake |
+| "file a bug" / "document this failure" | `qa-bug-report` | Structured reproduction report |
+| "review this PR from QA perspective" | `qa-critique` + `qa-strategy` | Critique existing + gap analysis |
+
+When the request is ambiguous, prefer the more adversarial interpretation. "Look
+at this code" means "find what's wrong with it," not "admire it."
+
+## Adversarial Analysis (inline)
+
+When asked "what could break?" or performing a general QA analysis, walk the
+Break-It Checklist against the code:
+
+### The Break-It Checklist
+
+**1. Boundary Analysis**
+- 0, 1, n, n+1 for every numeric input
+- Empty array, empty string, empty object, null, undefined
+- Single-element collections (different code path than n)
+- At configured limits, at integer overflow, at payload size limits
+- Negative numbers, negative indexes, counts below zero
+
+**2. Null / Undefined / Missing**
+- null vs undefined vs empty string
+- Missing key vs key-present-with-null-value
+- Optional chaining paths that produce undefined mid-chain
+- JSON.parse of responses that omit fields
+
+**3. Authorization**
+- Can user A read/write user B's resources? Every endpoint. Every query.
+- Horizontal privilege escalation (same role, different tenant/org)
+- Vertical privilege escalation (lower role accessing higher-role resources)
+- Resource enumeration via sequential IDs
+- Token expiry mid-operation
+- Permission changes between authentication and resource access
+
+**4. Concurrency**
+- Two writes, same row, same millisecond
+- Read-then-write races (TOCTOU)
+- Concurrent list + delete (item disappears mid-iteration)
+- Connection pool exhaustion under parallel requests
+- Deadlock potential in multi-table operations
+
+**5. Idempotency & Retries**
+- Client sends it twice — what happens?
+- Network timeout → retry → original request already succeeded
+- Partial retry after partial success
+- Queue consumers processing the same message twice
+
+**6. Partial Failure**
+- DB write succeeds, external API call doesn't — state consistency?
+- Multi-step transaction: step 3 of 5 fails — what's left behind?
+- S3 upload succeeds, metadata write fails
+- Webhook delivery succeeds, local state update doesn't
+
+**7. Time**
+- Timezones: UTC vs local, server vs client
+- DST transitions (the 2 AM that happens twice, the 2 AM that doesn't exist)
+- Clock skew between services
+- Token/session expiry at exact boundary
+- "Created 0 seconds ago" edge (Date.now() comparison)
+
+**8. Pagination & Ordering**
+- Unstable sort with ties (insertion order varies by DB engine)
+- Cursor drift when items are inserted/deleted mid-pagination
+- Page size = 0, page = -1, page beyond total
+- First page vs last page vs empty result set
+
+**9. Encoding & Input**
+- Unicode: emoji, combining characters, zero-width joiners
+- RTL text in LTR contexts
+- 10k-character inputs (above typical validation, below hard limit)
+- Script injection in every user-writable field
+- SQL injection (parameterized queries should prevent — verify)
+- Path traversal in filenames
+- Null bytes in strings
+- Multi-byte characters at truncation boundaries
+
+**10. Performance & Data Volume**
+- N+1 queries
+- Over-fetching (requesting 50 fields when you need 3)
+- Large result sets without streaming/pagination
+- Missing database indexes on filtered/sorted columns
+- Unbounded loops or recursion
+- Memory accumulation in long-running processes
+
+**11. Error Propagation**
+- Is the error message safe to show the user? (no stack traces, no internal paths)
+- Does the error response match the documented schema?
+- Are error codes/statuses correct? (not everything is 500)
+- Retry-after headers on rate limits
+- Graceful degradation vs hard failure
+
+### Output for adversarial analysis
+
+```markdown
+# Adversarial Analysis — <file/feature>
+
+## Risk Table
+
+| # | Risk | Severity | Likelihood | Dimension | Mitigation |
+|---|---|---|---|---|---|
+| 1 | <what can break> | Critical/High/Medium/Low | High/Medium/Low | <checklist dimension> | <what should be done> |
+
+## Detailed Findings
+
+### Finding 1: <title>
+- **File:** <path:line>
+- **Dimension:** <from checklist>
+- **Scenario:** <specific failure scenario>
+- **Impact:** <what happens when this breaks>
+- **Current protection:** <what exists today, if anything>
+- **Recommendation:** <test to write or code to fix>
+
+## Summary
+- Critical risks: N
+- High risks: N
+- Medium risks: N
+- Dimensions analyzed: N/11
+- Recommendations: <prioritized list>
+```
+
+## The Red-Before-Green Rule
+
+When writing tests (via `qa-author`), every new test MUST fail first against the
+unfixed code. If a test passes immediately:
+1. The bug doesn't exist (remove the test, investigate further)
+2. The test doesn't exercise the failure path (fix the test)
+3. The assertion is too weak (strengthen it)
+
+## Forbidden Cheats
+
+| Cheat | Why forbidden |
+| --- | --- |
+| `.skip()` or delete a failing test | Deleting evidence is not fixing |
+| Weaken assertion to match wrong output | You encoded the bug as a spec |
+| `sleep(5000)` to paper over a flake | Hidden race condition behind a prayer |
+| Mock the unit under test | You're testing your mock, not your code |
+| `expect(result).toBeDefined()` alone | Proves nothing except it didn't throw |
+| Catch-all try/catch that swallows errors | Makes the test unfailable |
+| Test that passes regardless of implementation | Tautological — delete it |

--- a/agents/sdlc-executor.md
+++ b/agents/sdlc-executor.md
@@ -1,0 +1,63 @@
+---
+name: sdlc-executor
+description: Implement a plan — edit code, write tests, run builds. Scoped to the repo worktree; no ticket transitions.
+tools: [Bash, Read, Write, Edit]
+model_tier: standard
+model: sonnet
+---
+
+# SDLC Executor
+
+Focused implementer. You receive a plan (from `sdlc-planner`) and execute it:
+edit code, write tests, run the build/test toolchain. Report what changed and
+how to verify.
+
+## Tools
+
+- File read/write/edit (scoped to the repo worktree)
+- Bash for build, test, and typecheck:
+
+  ```shell
+  eval "$(tkt cfg build.build --pkg "<pkg>")"
+  eval "$(tkt cfg build.test --pkg "<pkg>")"
+  eval "$(tkt cfg build.typecheck)"
+  ```
+
+- `git add`, `git status`, `git diff` (staging only — no push)
+- `tkt cfg` for reading config values
+
+## Guardrails
+
+- **No ticket transitions.** Never run `tkt transition`, `tkt comment`,
+  `tkt create`, `tkt link`, or `tkt worklog`.
+- **No pushes.** Never run `git push` or `gh pr`.
+- **No scope expansion.** Implement exactly the assigned task. Do not add
+  features, abstractions, or defensive code beyond what the plan specifies.
+- **You do not self-approve.** A reviewer/verifier checks your work. When done,
+  report files changed and how to verify — do not claim the work is correct.
+
+## Workflow
+
+1. Read the plan.
+2. Read existing code before editing.
+3. Implement per plan — minimal, idiomatic changes matching surrounding code.
+4. Run build + test after each logical unit.
+5. If tests fail, diagnose and fix (up to 3 attempts per failure).
+6. Report: files changed, tests passing, verification steps.
+
+## Output format
+
+```
+## Implementation complete
+
+### Files changed
+- path/to/file.py — what was done
+
+### Build/test
+- build: PASS
+- typecheck: PASS
+- tests: PASS (N suites, M tests)
+
+### Verification
+- <how a reviewer can verify correctness>
+```

--- a/agents/sdlc-planner.md
+++ b/agents/sdlc-planner.md
@@ -1,0 +1,65 @@
+---
+name: sdlc-planner
+description: Decompose a ticket into a structured implementation plan; read-only — no code changes, no transitions.
+tools: [Bash, Read]
+model_tier: deep
+model: opus
+---
+
+# SDLC Planner
+
+Decompose a ticket into a concrete, ordered implementation plan. You receive a
+ticket key (or a goal description) and produce: files to touch, ordered steps,
+risks, test strategy, and parallelism hints. **You never write code or transition
+tickets.**
+
+You are a fresh, independent context. Judge only the evidence in front of you;
+do not assume the author's intent was met.
+
+## Tools
+
+**Read-only.** You may use:
+
+- File reading (any source file in the repo worktree)
+- `tkt view <KEY> --json` — read a ticket
+- `tkt cfg <DOTTED.KEY>` — read project config
+- `tkt blockers <KEY> --json` — check blockers
+- `tkt list --query <name> --json` — search tickets
+- `git log`, `git diff`, `git show` — read history
+
+## Guardrails
+
+- **Read-only.** You must NEVER modify files, create files, run build commands,
+  or execute any command that changes state.
+- **No ticket transitions.** Never run `tkt transition`, `tkt comment`,
+  `tkt create`, `tkt link`, or `tkt worklog`.
+- **No git mutations.** Never run `git commit`, `git push`, `git checkout`, or
+  `git branch`.
+- If asked to implement, return the plan and stop.
+
+## Output format
+
+```
+## Plan: <ticket key or goal>
+
+### Files
+- path/to/file.py — what changes
+- ...
+
+### Steps (ordered)
+1. <step> [parallel: yes/no]
+2. ...
+
+### Test strategy
+- <what to test and how>
+
+### Risks
+- <risk + mitigation>
+
+### Scope estimate
+- ~N lines changed across M files
+- If > 400 LOC: recommend splitting
+```
+
+Keep plans concise (under 60 lines). Identify steps that can run in parallel vs.
+those with sequential dependencies.

--- a/agents/sdlc-reviewer.md
+++ b/agents/sdlc-reviewer.md
@@ -1,0 +1,74 @@
+---
+name: sdlc-reviewer
+description: Adversarial code review of a diff — findings only, no fixes. Read-only.
+tools: [Bash, Read]
+model_tier: standard
+model: sonnet
+---
+
+# SDLC Reviewer
+
+Adversarial code reviewer. You receive a diff (or a description of changes) and
+review it for correctness, security, quality, and requirement fit. You produce
+findings — you never fix code.
+
+You are a fresh, independent context. Judge only the evidence in front of you;
+do not assume the author's intent was met.
+
+## Tools
+
+**Read-only.** You may use:
+
+- File reading (any source file in the repo worktree)
+- `git diff`, `git log`, `git show` — read changes and history
+- `tkt view <KEY> --json` — read the ticket for requirement context
+- `tkt cfg <DOTTED.KEY>` — read project config
+
+## Guardrails
+
+- **You must NEVER modify files.** If asked to fix, return findings and stop.
+- **No ticket transitions.** Never run `tkt transition`, `tkt comment`,
+  `tkt create`, `tkt link`, or `tkt worklog`.
+- **No git mutations.** Never run `git commit`, `git push`, `git checkout`,
+  `git add`, or `git branch`.
+- **No build commands.** Never run build, test, or install commands.
+- If you cannot access the diff, say so and stop.
+
+## Review checklist
+
+| Category | Look for |
+| --- | --- |
+| **Correctness** | Logic errors, off-by-ones, wrong return values, unhandled branches |
+| **Security** | Injection, auth bypass, secrets in code, unvalidated input |
+| **Types** | Loose types, missing null checks, unguarded casts |
+| **Errors** | Unhandled rejections, missing error responses, wrong status codes |
+| **Tests** | New code without tests; tests that assert nothing meaningful |
+| **Style** | Lint violations, debug logging left in, naming conventions |
+| **Breaking** | Changed exports, API contract changes, schema migrations |
+| **Performance** | N+1 queries, missing indexes, unbounded loops, large payloads |
+| **Edge cases** | Empty arrays, nulls, concurrency, expired tokens |
+
+## Output format
+
+Per finding:
+
+```
+### [BLOCKER|WARNING|NIT] <short title>
+
+- **File:** path/to/file.py:NN
+- **Problem:** <what's wrong>
+- **Suggested fix:** <how to fix>
+```
+
+End with a summary:
+
+```
+## Summary
+
+- Blockers: N
+- Warnings: N
+- Nits: N
+- Verdict: PASS (no blockers) | FAIL (blockers found)
+```
+
+If the diff is clean, say so explicitly: "No issues found. Verdict: PASS."

--- a/agents/sdlc-verifier.md
+++ b/agents/sdlc-verifier.md
@@ -1,0 +1,71 @@
+---
+name: sdlc-verifier
+description: Run tests/lint/build and return a binary PASS/FAIL verdict with exact commands and output as evidence.
+tools: [Bash, Read]
+model_tier: standard
+model: sonnet
+---
+
+# SDLC Verifier
+
+Verification agent. Run the project's tests, linter, type checker, and build.
+Return a binary PASS/FAIL verdict with the exact commands run and their output
+as evidence. **You never fix code — verify only.**
+
+You are a fresh, independent context. Judge only the evidence in front of you;
+do not assume the author's intent was met.
+
+## Tools
+
+- File reading (any source file in the repo worktree)
+- Bash — for running build/test/lint commands:
+
+  ```shell
+  eval "$(tkt cfg build.build --pkg "<pkg>")"
+  eval "$(tkt cfg build.test --pkg "<pkg>")"
+  eval "$(tkt cfg build.typecheck)"
+  ```
+
+- `git diff`, `git status`, `git log` — read state (never mutate)
+
+## Guardrails
+
+- **You must NEVER modify files.** Do not edit, create, or delete any file.
+- **No ticket transitions.** Never run `tkt transition`, `tkt comment`,
+  `tkt create`, `tkt link`, or `tkt worklog`.
+- **No git mutations.** Never run `git push`, `git commit`, `git add`,
+  `git checkout`, `git branch`, `git reset`, or `git clean`.
+- **No destructive commands.** Never run `rm -rf`, `gh pr merge`, or any
+  network install commands (`npm install`, `pip install`, `apt-get`, etc.).
+- **No pushes or PR operations.** Never run `git push` or `gh pr`.
+- If a check fails, report the failure — do not attempt to fix it.
+
+## Workflow
+
+1. Determine the relevant checks from config:
+   - `tkt cfg build.build --pkg "<pkg>"`
+   - `tkt cfg build.test --pkg "<pkg>"`
+   - `tkt cfg build.typecheck`
+2. Run each check. Capture exit code and output.
+3. Report results.
+
+## Output format
+
+```
+## Verification
+
+### Commands run
+1. `<command>` → exit <N>
+2. `<command>` → exit <N>
+...
+
+### Evidence
+<relevant output snippets — failures in full, successes summarized>
+
+### Verdict: PASS | FAIL
+
+<if FAIL: state the smallest next step to unblock>
+```
+
+Keep evidence concise but complete for failures. For passing checks, a one-line
+confirmation suffices.

--- a/agents/ticket-researcher.md
+++ b/agents/ticket-researcher.md
@@ -2,7 +2,8 @@
 name: ticket-researcher
 description: Look up ticket details, related tickets, blockers, and recent comments via tkt (provider-agnostic, read-only)
 tools: [Bash]
-model: claude-haiku-4-5
+model_tier: cheap
+model: haiku
 ---
 
 # Ticket Researcher Subagent

--- a/core/cli.py
+++ b/core/cli.py
@@ -168,6 +168,18 @@ def build_parser() -> argparse.ArgumentParser:
                     help="report-only: list missing/locally-modified/out-of-date "
                          "pack files and exit 1 if any; writes nothing")
 
+    sp = add("run")
+    sp.add_argument("key", nargs="?", default=None,
+                    help="ticket key to run/resume; omit to select a P0 candidate")
+    sp.add_argument("--status", action="store_true",
+                    help="print the current marker/phase without running")
+    sp.add_argument("--stop", action="store_true",
+                    help="drop a STOP file to halt the run at the next boundary")
+    sp.add_argument("--max-iterations", type=int, default=None, dest="max_iterations",
+                    help="override max iterations for this run")
+    sp.add_argument("--dry-run", action="store_true", dest="dry_run",
+                    help="print the prompt and command without invoking the harness")
+
     sp = add("cfg")
     sp.add_argument("key", help="dotted config path, e.g. build.test or vcs.repo")
     sp.add_argument("--pkg", default="", help="substitute {pkg} in the value")
@@ -397,6 +409,18 @@ def main(argv: list[str]) -> int:
                 print(json.dumps(t.to_dict(), indent=2))
             else:
                 _print_ticket_human(t)
+
+        elif args.verb == "run":
+            from .run import cmd_run, cmd_status, cmd_stop
+            if args.stop:
+                if not args.key:
+                    raise UsageError("run --stop requires a ticket KEY")
+                return cmd_stop(config, args.key)
+            if args.status:
+                if not args.key:
+                    raise UsageError("run --status requires a ticket KEY")
+                return cmd_status(config, args.key)
+            return cmd_run(config, args.key, args.max_iterations, args.dry_run)
 
         elif args.verb == "doctor":
             checks = adapter.doctor()

--- a/core/config.py
+++ b/core/config.py
@@ -38,6 +38,8 @@ class Config:
         self.queries: dict[str, str] = dict(data.get("queries", {}))
         self.vcs = data.get("vcs", {})
         self.build = data.get("build", {})
+        # tier → model identifier; advisory routing hints, empty when unset.
+        self.models: dict[str, str] = dict(data.get("models", {}))
         self.timetracking = data.get("timetracking", {})
         self.docs = data.get("docs", {})
         # provider-specific blocks (e.g. [markdown], [github])

--- a/core/config.py
+++ b/core/config.py
@@ -40,6 +40,8 @@ class Config:
         self.build = data.get("build", {})
         # tier → model identifier; advisory routing hints, empty when unset.
         self.models: dict[str, str] = dict(data.get("models", {}))
+        # external loop driver settings (see core/run.py); empty when unset.
+        self.run = data.get("run", {})
         self.timetracking = data.get("timetracking", {})
         self.docs = data.get("docs", {})
         # provider-specific blocks (e.g. [markdown], [github])

--- a/core/pack.py
+++ b/core/pack.py
@@ -103,9 +103,7 @@ def _add_tree(plan: list, base: Path, dest_prefix: str) -> None:
 def _default_plan() -> list:
     plan: list = []
     _add_tree(plan, PACK_ROOT / "skills", ".claude/skills")
-    agent = PACK_ROOT / "agents" / "ticket-researcher.md"
-    if agent.is_file():
-        plan.append((agent, ".claude/agents/ticket-researcher.md"))
+    _add_tree(plan, PACK_ROOT / "agents", ".claude/agents")
     _add_tree(plan, PACK_ROOT / ".github" / "prompts", ".github/prompts")
     _add_tree(plan, PACK_ROOT / ".kiro" / "skills", ".kiro/skills")
     return plan

--- a/core/pack.py
+++ b/core/pack.py
@@ -42,6 +42,7 @@ _EXCLUDE_SKILLS = {"sync-skills"}
 _EXTRA_HARNESS_DIRS = [
     ".gemini/commands",
     ".agents/skills",
+    ".agents/workflows",
     ".cursor/skills",
     ".cursor/commands",
     ".windsurf/workflows",
@@ -106,6 +107,10 @@ def _default_plan() -> list:
     _add_tree(plan, PACK_ROOT / "agents", ".claude/agents")
     _add_tree(plan, PACK_ROOT / ".github" / "prompts", ".github/prompts")
     _add_tree(plan, PACK_ROOT / ".kiro" / "skills", ".kiro/skills")
+    # Kiro does not read AGENTS.md — steering is its only project-convention
+    # surface, so it ships by default rather than under --all-harnesses.
+    _add_tree(plan, PACK_ROOT / ".kiro" / "steering", ".kiro/steering")
+    _add_tree(plan, PACK_ROOT / ".kiro" / "agents", ".kiro/agents")
     return plan
 
 

--- a/core/run.py
+++ b/core/run.py
@@ -1,0 +1,697 @@
+"""External loop driver for headless pipeline execution.
+
+Invokes the configured harness one phase at a time, persists phase state as
+ticket markers (comments), and loops until a gate, STOP signal, or cap.
+
+The driver never performs VCS operations or bypasses adapter verbs — it
+orchestrates invocations and ticket state only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import Config
+from .errors import ConfigError, TktError
+from .registry import get_adapter
+
+# ---- Constants ---------------------------------------------------------------
+
+# Pipeline phases in order. The driver advances through these.
+PHASES = [
+    "P0",   # select-ticket
+    "P1",   # triage
+    "P1.5", # type-route
+    "P2",   # plan
+    "P3",   # implement/test
+    "P4",   # self-review
+    "P5",   # open-pr
+    "P6",   # ci-fix
+    "P7",   # respond-to-review
+    "P8",   # deploy-preview
+    "P9",   # qa_ready (human QA gate — always stop)
+    "P10",  # deploy-ready
+]
+
+PHASE_NAMES = {
+    "P0": "select-ticket",
+    "P1": "triage",
+    "P1.5": "type-route",
+    "P2": "plan",
+    "P3": "implement/test",
+    "P4": "self-review",
+    "P5": "open-pr",
+    "P6": "ci-fix",
+    "P7": "respond-to-review",
+    "P8": "deploy-preview",
+    "P9": "qa_ready",
+    "P10": "deploy-ready",
+}
+
+# Valid outcomes from the harness result file.
+VALID_OUTCOMES = ("advance", "retry", "blocked", "gate")
+
+# Marker comment pattern for parsing/writing ticket state.
+MARKER_PREFIX = "<!-- tkt-run: "
+MARKER_SUFFIX = " -->"
+MARKER_RE = re.compile(
+    r"<!-- tkt-run: (\{.*?\}) -->", re.DOTALL
+)
+
+# Default config values.
+DEFAULT_MAX_ITERATIONS = 30
+DEFAULT_MAX_PHASE_ATTEMPTS = 3
+DEFAULT_INVOCATION_TIMEOUT = 3600
+
+
+# ---- Run config access -------------------------------------------------------
+
+class RunConfig:
+    """Parsed [run] section from .sdlc/config.toml."""
+
+    def __init__(self, config: Config):
+        run = config._d.get("run", {})
+        self.harness_cmd: str = run.get("harness_cmd", "")
+        self.max_iterations: int = int(run.get("max_iterations", DEFAULT_MAX_ITERATIONS))
+        self.max_phase_attempts: int = int(run.get("max_phase_attempts", DEFAULT_MAX_PHASE_ATTEMPTS))
+        self.invocation_timeout: int = int(run.get("invocation_timeout", DEFAULT_INVOCATION_TIMEOUT))
+
+        if not self.harness_cmd:
+            raise ConfigError(
+                "[run].harness_cmd is required for `tkt run`. "
+                "Set it in .sdlc/config.toml, e.g.:\n"
+                '  harness_cmd = "claude -p {prompt} --permission-mode acceptEdits"'
+            )
+
+
+# ---- Ticket marker operations ------------------------------------------------
+
+def _build_marker(state: dict[str, Any]) -> str:
+    """Build a machine-readable marker comment string."""
+    return f"{MARKER_PREFIX}{json.dumps(state, separators=(',', ':'))}{MARKER_SUFFIX}"
+
+
+def _parse_marker(comment_body: str) -> dict[str, Any] | None:
+    """Extract the most recent tkt-run marker from a comment body."""
+    matches = MARKER_RE.findall(comment_body)
+    if not matches:
+        return None
+    # Return the last match (most recent).
+    try:
+        return json.loads(matches[-1])
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def read_ticket_marker(adapter, key: str,
+                       state_dir: Path | None = None) -> dict[str, Any] | None:
+    """Read the newest run marker for a ticket, or None if there is none.
+
+    The ticket comment is the authoritative record — it survives a lost
+    worktree and is readable from another machine — but only the markdown
+    adapter can hand back raw comment bodies to scan (`_read_raw`). The verb
+    contract has no "list comments" verb, so on every other backend the marker
+    is recovered from the local mirror `write_ticket_marker` keeps. Without
+    that fallback a resume on Jira/GitHub/Linear would silently restart at P1.
+    """
+    if hasattr(adapter, "_read_raw"):
+        try:
+            _, body = adapter._read_raw(key)
+        except (TktError, OSError):
+            body = ""
+        matches = MARKER_RE.findall(body)
+        if matches:
+            try:
+                return json.loads(matches[-1])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    if state_dir is not None:
+        path = state_dir / "marker.json"
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                return None
+            if isinstance(data, dict):
+                return data
+
+    return None
+
+
+def write_ticket_marker(adapter, key: str, state: dict[str, Any],
+                        state_dir: Path | None = None) -> None:
+    """Append a phase marker comment to the ticket, mirroring it locally.
+
+    The local mirror is what `read_ticket_marker` falls back to on backends
+    whose comments it cannot read back (see above).
+    """
+    phase = state.get("phase", "?")
+    attempt = state.get("attempt", 1)
+    outcome = state.get("outcome", "")
+    human_line = f"[run] Phase {phase} ({PHASE_NAMES.get(phase, phase)}), attempt {attempt}"
+    if outcome:
+        human_line += f" — {outcome}"
+    marker = _build_marker(state)
+    comment = f"{human_line}\n{marker}"
+    adapter.comment(key, comment)
+
+    if state_dir is not None:
+        try:
+            (state_dir / "marker.json").write_text(
+                json.dumps(state, separators=(",", ":"))
+            )
+        except OSError:
+            # The ticket comment already landed; a failed mirror must not
+            # abort the run, it only costs resume fidelity on this machine.
+            pass
+
+
+# ---- Local state management --------------------------------------------------
+
+def _state_dir(config: Config, key: str) -> Path:
+    """Resolve .sdlc/state/run/<key>/ relative to the project root."""
+    cfg_dir = config.path.parent
+    base = cfg_dir.parent if cfg_dir.name == ".sdlc" else cfg_dir
+    return base / ".sdlc" / "state" / "run" / key
+
+
+def ensure_state_dir(config: Config, key: str) -> Path:
+    """Create and return the local state dir for a run."""
+    d = _state_dir(config, key)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def check_stop_file(state_dir: Path) -> bool:
+    """Return True if a STOP file exists."""
+    return (state_dir / "STOP").is_file()
+
+
+def create_stop_file(config: Config, key: str) -> Path:
+    """Create the STOP file for a given ticket key."""
+    d = ensure_state_dir(config, key)
+    stop = d / "STOP"
+    stop.touch()
+    return stop
+
+
+def read_result_file(state_dir: Path) -> dict[str, Any] | None:
+    """Read and validate result.json; return None if missing/invalid."""
+    path = state_dir / "result.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    # Validate schema.
+    if not isinstance(data, dict):
+        return None
+    if data.get("outcome") not in VALID_OUTCOMES:
+        return None
+    if "phase" not in data:
+        return None
+    return data
+
+
+def delete_result_file(state_dir: Path) -> None:
+    """Remove result.json after processing."""
+    path = state_dir / "result.json"
+    if path.is_file():
+        path.unlink()
+
+
+def append_run_log(state_dir: Path, entry: dict[str, Any]) -> None:
+    """Append a JSONL line to run.log."""
+    log_path = state_dir / "run.log"
+    with open(log_path, "a") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+# ---- Phase prompt builder ----------------------------------------------------
+
+def build_phase_prompt(
+    key: str,
+    phase: str,
+    attempt: int,
+    state_dir: Path,
+) -> str:
+    """Build the prompt string passed to the harness."""
+    result_path = state_dir / "result.json"
+    return (
+        f"You are executing ONE phase of the automated SDLC pipeline for ticket {key}.\n"
+        f"\n"
+        f"Current phase: {phase} ({PHASE_NAMES.get(phase, phase)})\n"
+        f"Attempt: {attempt}\n"
+        f"\n"
+        f"Execute EXACTLY this one phase per skills/automated-sdlc/SKILL.md, then write\n"
+        f"the result to: {result_path}\n"
+        f"\n"
+        f"Result file contract (JSON):\n"
+        f'{{"phase":"{phase}","outcome":"<advance|retry|blocked|gate>","next":"<next_phase>","reason":"<explanation>"}}\n'
+        f"\n"
+        f"Outcomes:\n"
+        f"  advance — phase completed successfully, move to next phase\n"
+        f"  retry   — phase failed but is retryable (e.g. test failure)\n"
+        f"  blocked — unrecoverable blocker, ticket should be blocked\n"
+        f"  gate    — human gate reached, stop the run\n"
+        f"\n"
+        f"After writing result.json, exit. Do not proceed to the next phase.\n"
+    )
+
+
+# ---- Harness invocation ------------------------------------------------------
+
+def invoke_harness(
+    harness_cmd: str,
+    prompt: str,
+    timeout: int,
+    state_dir: Path,
+    dry_run: bool = False,
+) -> tuple[int, str]:
+    """Invoke the harness command with the prompt substituted.
+
+    Returns (exit_code, log_output). On timeout, returns (1, <timeout msg>).
+    On dry_run, returns (0, "") without executing.
+    """
+    # Substitute {prompt} in the command template.
+    # Shell-escape the prompt for safe embedding.
+    escaped_prompt = prompt.replace("'", "'\\''")
+    cmd = harness_cmd.replace("{prompt}", f"'{escaped_prompt}'")
+
+    if dry_run:
+        return 0, f"[dry-run] would execute:\n{cmd}"
+
+    log_path = state_dir / "run.log"
+    try:
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout if timeout > 0 else None,
+            cwd=os.getcwd(),
+        )
+        output = result.stdout + result.stderr
+        return result.returncode, output
+    except subprocess.TimeoutExpired:
+        return 1, f"[timeout] harness exceeded {timeout}s"
+    except OSError as e:
+        return 1, f"[error] failed to invoke harness: {e}"
+
+
+# ---- Gate logic --------------------------------------------------------------
+
+def is_human_owned_transition(config: Config, from_role: str, to_role: str) -> bool:
+    """Check if a transition is human-owned per [board.ownership]."""
+    ownership = config.ownership
+    transition_key = f"{from_role}->{to_role}"
+    owner = ownership.get(transition_key, "")
+    return owner.lower() == "human"
+
+
+def is_gate_phase(phase: str) -> bool:
+    """P9 (qa_ready) is always a hard gate."""
+    return phase == "P9"
+
+
+def is_production_phase(phase: str, config: Config) -> bool:
+    """P10 (deploy-ready) is blocked unless config explicitly grants agent ownership."""
+    if phase != "P10":
+        return False
+    # Check if deploy_ready->done is agent-owned.
+    owner = config.ownership.get("deploy_ready->done", "human")
+    return owner.lower() != "agent"
+
+
+# ---- Main driver loop --------------------------------------------------------
+
+class RunDriver:
+    """The external loop driver."""
+
+    def __init__(
+        self,
+        config: Config,
+        run_config: RunConfig,
+        key: str | None = None,
+        max_iterations: int | None = None,
+        dry_run: bool = False,
+    ):
+        self.config = config
+        self.run_config = run_config
+        self.adapter = get_adapter(config)
+        self.key = key
+        self.max_iterations = max_iterations or run_config.max_iterations
+        self.max_phase_attempts = run_config.max_phase_attempts
+        self.timeout = run_config.invocation_timeout
+        self.dry_run = dry_run
+
+        # Runtime state.
+        self.phase: str = "P0"
+        self.attempt: int = 1
+        self.iteration: int = 0
+        self.state_dir: Path | None = None
+
+    def run(self) -> int:
+        """Execute the driver loop. Returns exit code."""
+        # If no key, first phase is P0 (select-ticket) which picks one.
+        if self.key:
+            self._init_state()
+            self._resume_from_marker()
+        else:
+            # We need a temporary state dir; after P0 we'll know the key.
+            self.phase = "P0"
+            self.attempt = 1
+
+        return self._loop()
+
+    def status(self) -> dict[str, Any]:
+        """Return current status without running."""
+        if not self.key:
+            return {"error": "no ticket key specified"}
+        marker = read_ticket_marker(self.adapter, self.key,
+                                   _state_dir(self.config, self.key))
+        if marker is None:
+            return {"key": self.key, "phase": None, "status": "no run marker found"}
+        return {"key": self.key, **marker}
+
+    def _init_state(self) -> None:
+        """Initialize state dir for the current key."""
+        assert self.key is not None
+        self.state_dir = ensure_state_dir(self.config, self.key)
+
+    def _resume_from_marker(self) -> None:
+        """Resume from the ticket's last marker, if any."""
+        marker = read_ticket_marker(self.adapter, self.key, self.state_dir)
+        if marker is None:
+            # Fresh run — start from P0 or P1 depending on whether we have a key.
+            self.phase = "P1" if self.key else "P0"
+            self.attempt = 1
+            return
+        # Resume from the marker.
+        last_phase = marker.get("phase", "P0")
+        last_outcome = marker.get("outcome", "")
+        if last_outcome == "advance":
+            # Advance to the next phase.
+            self.phase = marker.get("next", self._next_phase(last_phase))
+            self.attempt = 1
+        elif last_outcome == "retry":
+            # Retry the same phase.
+            self.phase = last_phase
+            self.attempt = marker.get("attempt", 1) + 1
+        else:
+            # blocked/gate/unknown — resume from where we were.
+            self.phase = last_phase
+            self.attempt = marker.get("attempt", 1)
+
+    def _next_phase(self, current: str) -> str:
+        """Get the next phase after current."""
+        try:
+            idx = PHASES.index(current)
+            if idx + 1 < len(PHASES):
+                return PHASES[idx + 1]
+        except ValueError:
+            pass
+        return current  # Stay on current if unknown.
+
+    def _loop(self) -> int:
+        """Main iteration loop."""
+        while True:
+            # --- Pre-iteration checks ---
+
+            # For keyless start, we need a temp state dir for P0.
+            if self.key is None and self.state_dir is None:
+                # Use a temporary placeholder dir for P0.
+                self.state_dir = ensure_state_dir(self.config, "_select")
+
+            assert self.state_dir is not None
+
+            # Check STOP file.
+            if check_stop_file(self.state_dir):
+                self._log("STOP file found — halting.")
+                if self.key:
+                    self._write_marker("stopped by operator")
+                return 0
+
+            # Check iteration cap.
+            if self.iteration >= self.max_iterations:
+                self._log(f"max iterations ({self.max_iterations}) reached — halting.")
+                if self.key:
+                    self._write_marker("max iterations reached")
+                return 1
+
+            # Check per-phase attempt cap.
+            if self.attempt > self.max_phase_attempts:
+                self._log(
+                    f"phase {self.phase} failed {self.max_phase_attempts} attempts "
+                    f"— transitioning to blocked."
+                )
+                if self.key:
+                    self._transition_blocked()
+                return 1
+
+            # Gate checks BEFORE invocation.
+            if is_gate_phase(self.phase):
+                self._log(f"phase {self.phase} is a human QA gate — halting.")
+                if self.key:
+                    self._write_marker("gate: human QA")
+                return 0
+
+            if self.key and is_production_phase(self.phase, self.config):
+                self._log(
+                    f"phase {self.phase} (deploy) is not agent-owned — halting."
+                )
+                self._write_marker("gate: production deploy not agent-owned")
+                return 0
+
+            # Check human-owned transitions if we'd be performing one.
+            if self.key and self.phase != "P0":
+                # Determine the from/to roles for this phase.
+                from_role, to_role = self._phase_transition_roles(self.phase)
+                if from_role and to_role and is_human_owned_transition(
+                    self.config, from_role, to_role
+                ):
+                    self._log(
+                        f"transition {from_role}->{to_role} is human-owned — halting."
+                    )
+                    self._write_marker(f"gate: {from_role}->{to_role} is human-owned")
+                    return 0
+
+            # --- Invoke harness ---
+            self.iteration += 1
+            started = _now_iso()
+            self._log(
+                f"iteration {self.iteration}/{self.max_iterations}, "
+                f"phase {self.phase}, attempt {self.attempt}"
+            )
+
+            prompt = build_phase_prompt(
+                key=self.key or "<pending-select>",
+                phase=self.phase,
+                attempt=self.attempt,
+                state_dir=self.state_dir,
+            )
+
+            rc, output = invoke_harness(
+                self.run_config.harness_cmd,
+                prompt,
+                self.timeout,
+                self.state_dir,
+                dry_run=self.dry_run,
+            )
+
+            ended = _now_iso()
+
+            if self.dry_run:
+                self._log(output)
+                return 0
+
+            # --- Process result ---
+            result = read_result_file(self.state_dir)
+
+            if result is None:
+                # Missing/invalid result → treat as retry.
+                self._log(
+                    f"result.json missing or invalid after iteration "
+                    f"(rc={rc}) — counting as failed attempt."
+                )
+                outcome = "retry"
+                next_phase = self.phase
+                reason = "no valid result.json"
+            else:
+                outcome = result["outcome"]
+                next_phase = result.get("next", self._next_phase(self.phase))
+                reason = result.get("reason", "")
+                delete_result_file(self.state_dir)
+
+            # If P0 succeeded, extract the ticket key from result.
+            if self.phase == "P0" and outcome == "advance":
+                new_key = result.get("ticket_key") if result else None
+                if new_key:
+                    self.key = new_key
+                    self._init_state()
+                else:
+                    # If the agent didn't provide a key, we can't continue.
+                    self._log("P0 advance but no ticket_key in result — halting.")
+                    return 1
+
+            # Log the iteration.
+            log_entry = {
+                "iteration": self.iteration,
+                "phase": self.phase,
+                "attempt": self.attempt,
+                "outcome": outcome,
+                "reason": reason,
+                "started": started,
+                "ended": ended,
+                "rc": rc,
+            }
+            append_run_log(self.state_dir, log_entry)
+
+            # Handle outcome.
+            if outcome == "advance":
+                if self.key:
+                    self._write_marker_with_outcome("advance", next_phase)
+                self.phase = next_phase
+                self.attempt = 1
+            elif outcome == "retry":
+                if self.key:
+                    self._write_marker_with_outcome("retry", self.phase)
+                self.attempt += 1
+            elif outcome == "blocked":
+                self._log(f"phase {self.phase} reported blocked: {reason}")
+                if self.key:
+                    self._transition_blocked(reason)
+                return 1
+            elif outcome == "gate":
+                self._log(f"phase {self.phase} reported gate: {reason}")
+                if self.key:
+                    self._write_marker(f"gate: {reason}")
+                return 0
+
+    def _phase_transition_roles(self, phase: str) -> tuple[str, str]:
+        """Return (from_role, to_role) for a phase's expected transition.
+
+        Returns ("", "") for phases that don't perform a board transition.
+        """
+        mapping = {
+            "P1": ("todo", "in_progress"),
+            "P5": ("in_progress", "review"),
+            "P9": ("review", "qa_ready"),
+            "P10": ("deploy_ready", "done"),
+        }
+        return mapping.get(phase, ("", ""))
+
+    def _transition_blocked(self, reason: str = "") -> None:
+        """Transition the ticket to blocked and post a comment."""
+        try:
+            self.adapter.transition(self.key, "blocked")
+        except TktError:
+            pass  # Best-effort; maybe lane doesn't exist.
+        msg = (
+            f"[run] Blocked after {self.max_phase_attempts} failed attempts "
+            f"on phase {self.phase} ({PHASE_NAMES.get(self.phase, self.phase)})."
+        )
+        if reason:
+            msg += f"\nReason: {reason}"
+        # Include last log lines.
+        if self.state_dir:
+            log_tail = self._log_tail(5)
+            if log_tail:
+                msg += f"\n\nRecent log:\n```\n{log_tail}\n```"
+        state = {
+            "phase": self.phase,
+            "attempt": self.attempt,
+            "outcome": "blocked",
+            "reason": reason or "max attempts exceeded",
+            "updated": _now_iso(),
+        }
+        marker = _build_marker(state)
+        self.adapter.comment(self.key, f"{msg}\n{marker}")
+        if self.state_dir:
+            try:
+                (self.state_dir / "marker.json").write_text(
+                    json.dumps(state, separators=(",", ":"))
+                )
+            except OSError:
+                pass
+
+    def _write_marker(self, reason: str) -> None:
+        """Write a status marker to the ticket."""
+        state = {
+            "phase": self.phase,
+            "attempt": self.attempt,
+            "outcome": "halted",
+            "reason": reason,
+            "updated": _now_iso(),
+        }
+        write_ticket_marker(self.adapter, self.key, state, self.state_dir)
+
+    def _write_marker_with_outcome(self, outcome: str, next_phase: str) -> None:
+        """Write an advance/retry marker to the ticket."""
+        state = {
+            "phase": self.phase,
+            "attempt": self.attempt,
+            "outcome": outcome,
+            "next": next_phase,
+            "updated": _now_iso(),
+        }
+        write_ticket_marker(self.adapter, self.key, state, self.state_dir)
+
+    def _log(self, msg: str) -> None:
+        """Print a log line to stderr."""
+        ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
+        print(f"[{ts}] run: {msg}", file=sys.stderr)
+
+    def _log_tail(self, n: int) -> str:
+        """Return the last n lines from run.log."""
+        if not self.state_dir:
+            return ""
+        log_path = self.state_dir / "run.log"
+        if not log_path.is_file():
+            return ""
+        lines = log_path.read_text().splitlines()
+        return "\n".join(lines[-n:])
+
+
+# ---- Helpers -----------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---- CLI entry points --------------------------------------------------------
+
+def cmd_run(config: Config, key: str | None, max_iterations: int | None,
+            dry_run: bool) -> int:
+    """Entry point for `tkt run [KEY]`."""
+    run_config = RunConfig(config)
+    driver = RunDriver(
+        config, run_config, key=key,
+        max_iterations=max_iterations, dry_run=dry_run,
+    )
+    return driver.run()
+
+
+def cmd_status(config: Config, key: str) -> int:
+    """Entry point for `tkt run --status KEY`."""
+    run_config = RunConfig(config)
+    driver = RunDriver(config, run_config, key=key)
+    status = driver.status()
+    print(json.dumps(status, indent=2))
+    return 0
+
+
+def cmd_stop(config: Config, key: str) -> int:
+    """Entry point for `tkt run --stop KEY`."""
+    stop_path = create_stop_file(config, key)
+    print(f"STOP file created: {stop_path}")
+    return 0

--- a/docs/behavior-specs.md
+++ b/docs/behavior-specs.md
@@ -1,0 +1,103 @@
+# Behavior specs (BDD) — the portable practice
+
+This is the **process** half of behavior-driven development, owned by the SDLC
+pack so it is reusable across repos and languages. The concrete test **harness**
+(godog for Go, Cucumber.js/vitest-cucumber for TypeScript, pytest-bdd for Python,
+…) stays repo-owned and is bound through one config key — `build.bdd`. The pack
+never hardcodes a tool, exactly as it never hardcodes a ticketing backend.
+
+## Why this lives in the pack
+
+The pack's whole design is "one practice, many backends": skills speak semantic
+verbs and resolve the concrete command from `.sdlc/config.toml`. Behavior specs
+fit the same shape — the *methodology* (Gherkin + how CI treats it + how work is
+enabled per ticket) is identical everywhere; only the *runner* differs. Putting
+the methodology here lets a TypeScript app, a CLI tool, and a Go service all get
+the same executable-spec workflow without the pack ever depending on a harness.
+
+## The practice
+
+### 1. One feature file per capability
+
+Describe behavior in Gherkin (`Given` / `When` / `Then`), one `.feature` file per
+functional capability — not one per ticket. A single ticket may touch several
+features, and a feature may span several tickets. Write the **full** expected
+behavior up front so the spec is a living contract, even before any of it runs.
+
+### 2. Non-strict until wired, then promote to strict
+
+Run the suite **non-strict** by default: undefined / pending steps are reported
+but do **not** fail CI. This lets the complete feature set be authored early and
+wired incrementally as implementation lands, without turning CI red on scenarios
+nobody has implemented yet. Once every step for a capability is wired, promote
+that suite (or the whole repo) to **strict** so undefined steps fail — locking in
+the behavior against regression.
+
+### 3. Enable per ticket
+
+As each ticket is implemented:
+
+1. Identify which existing `.feature` scenarios cover the behavior.
+2. Write the step definitions against the real code (or in-memory fakes at
+   boundaries — see below).
+3. Wire them in (register the steps), so those scenarios start enforcing.
+4. Run the suite: the new scenarios pass; everything else stays pending (green).
+5. Push — CI stays green because undefined steps don't fail.
+
+### 4. Boundaries are interfaces with in-memory fakes
+
+Behavior specs pair naturally with keeping every external system (DB, queue,
+HTTP) behind an interface with an in-memory fake for tests. Steps exercise the
+real internal logic against fakes; concrete backends land behind the existing
+interface without touching call sites. This keeps the suite fast and hermetic and
+complements — does not replace — real-datastore integration tests.
+
+## The `build.bdd` hook
+
+Each repo binds its runner under `[build]` in `.sdlc/config.toml`:
+
+```toml
+[build]
+build     = "..."
+test      = "..."
+typecheck = "..."
+lint      = "..."
+bdd       = "go test ./features/..."   # optional; the repo's behavior-spec runner
+```
+
+Skills resolve it the same way they resolve every other build command:
+
+```sh
+tkt cfg build.bdd --pkg "<pkg>"
+```
+
+- **Optional.** `build.bdd` is absent by default. When the key is unset,
+  `tkt cfg build.bdd` prints `tkt: config key not found: build.bdd` to stderr and
+  exits `4` (`NotFoundError`). Skills treat **exit 4 specifically** as the clean
+  no-op — a repo with no behavior specs is unaffected. Any other non-zero exit
+  (e.g. `2` = a broken/missing `.sdlc/config.toml`) is a real error and is
+  surfaced rather than swallowed, so a misconfiguration never hides as a silent skip.
+- **Non-blocking.** Where a skill runs `build.bdd` (e.g. `self-review`), it runs
+  it as a **reported, non-blocking** signal, mirroring the non-strict CI posture:
+  pending scenarios inform the author but never block the flow. A repo makes BDD
+  blocking by pointing `build.bdd` at a strict runner once its steps are wired.
+
+## Adopting in a repo
+
+1. Add a `bdd` command under `[build]` in `.sdlc/config.toml` (see the
+   `examples/config.*.toml` files).
+2. Stand up the harness for your stack (the actual `.feature` files + step
+   runner). That harness — and its lint/build wiring — is repo-owned; record the
+   binding decision in a repo ADR.
+3. Author feature files per capability; enable them per ticket as above.
+
+Typical bindings, for reference:
+
+| Stack | Runner | `build.bdd` |
+|-------|--------|-------------|
+| Go | godog, `features/` + non-strict `features_test.go` | `go test ./features/...` |
+| TypeScript | Cucumber.js or vitest-cucumber | `npm run bdd` |
+| Python | pytest-bdd | `pytest tests/features` |
+
+The pack has no opinion beyond the key: whatever the command is, it must exit
+non-zero only when a *wired* scenario fails.

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,13 +62,16 @@ install the curated long tail of other harnesses, path-verbatim.
 
 | Destination | Harness | Default | `--all-harnesses` |
 |---|---|:---:|:---:|
-| `.claude/skills/` (14 skills) | Claude Code | ✓ | ✓ |
-| `.claude/agents/ticket-researcher.md` | Claude Code (lookup subagent) | ✓ | ✓ |
+| `.claude/skills/` (19 skills) | Claude Code | ✓ | ✓ |
+| `.claude/agents/` (6 subagents) | Claude Code | ✓ | ✓ |
 | `.github/prompts/` | GitHub Copilot | ✓ | ✓ |
-| `.kiro/skills/` | AWS Kiro | ✓ | ✓ |
+| `.kiro/skills/` | AWS Kiro (invocable skills) | ✓ | ✓ |
+| `.kiro/steering/` | AWS Kiro (project conventions) | ✓ | ✓ |
+| `.kiro/agents/` | AWS Kiro (sub-agent definitions) | ✓ | ✓ |
 | `AGENTS.md` managed block (`<!-- tkt-pack:begin/end -->`) | Universal fallback (Codex, Amp, Devin, …) | ✓ | ✓ |
 | `.gemini/commands/` | Gemini CLI | | ✓ |
 | `.agents/skills/` | Antigravity, Junie, Codex | | ✓ |
+| `.agents/workflows/` | Antigravity | | ✓ |
 | `.cursor/skills/` + `.cursor/commands/` | Cursor | | ✓ |
 | `.windsurf/workflows/` | Windsurf | | ✓ |
 | `.clinerules/workflows/` | Cline | | ✓ |

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -1,0 +1,103 @@
+# Model routing
+
+Three-tier routing policy for the SDLC pipeline. Each phase runs on the cheapest
+tier that preserves quality for that phase's workload.
+
+Routing is **advisory everywhere**. No skill requires a model switch to produce
+correct output — a harness with no model control runs the whole pipeline on its
+session default and must behave identically.
+
+## Tiers, not model IDs
+
+Skills and agents declare a **tier** in frontmatter:
+
+```yaml
+model_tier: cheap | standard | deep
+```
+
+The tier is the portable, backend-agnostic part. The concrete model is a project
+decision, mapped in `.sdlc/config.toml`:
+
+```toml
+[models]
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+```
+
+The orchestrator resolves a tier at invocation time:
+
+```shell
+tkt cfg models.deep        # -> claude-opus-5
+```
+
+This is the same rule the pack applies to every other project-specific value
+(`build.*`, `vcs.*`): the skill names *what it needs*, config names *what it is*.
+Model IDs change far faster than the pipeline does, so pinning them in skill text
+would mean editing 20 files per model generation across every consumer repo.
+
+`[models]` is optional. If the table is absent, `tkt cfg models.<tier>` exits 4
+(`NotFoundError`) — treat that as "no routing configured" and proceed on the
+session default.
+
+> `model_tier` is unrelated to `[queries].tierN` / `tkt list --tier N`, which
+> select *tickets* by priority band.
+
+## Tier assignment
+
+| Tier | Workload | Skills / agents |
+|------|----------|-----------------|
+| **cheap** | Board queries, filtering, mechanical transitions, pure lookup | `select-ticket`, `check-blockers`, `triage-ticket`, `ticket-researcher` |
+| **deep** | Decomposition, architecture, risk analysis — where reasoning depth pays for itself | `plan-ticket`, `sdlc-planner` |
+| **standard** | Everything else | `automated-sdlc`, `self-review`, `open-pr`, `ci-fix`, `respond-to-review`, `resume-from-revise`, `complete-deliverable`, `deploy-preview`, `deploy-ready`, `hotfix-revert`, `sdlc-executor`, `sdlc-reviewer`, `sdlc-verifier` |
+
+Route by **phase workload, not ticket importance**. A Story's triage is still
+mechanical; a Chore's plan may still warrant deep reasoning if its scope does.
+
+## Escalation
+
+Escalate on failure; never start high.
+
+| Condition | Action |
+|-----------|--------|
+| Cheap-tier phase returns a wrong or ambiguous result | Retry that step once at standard |
+| Standard-tier review cycles 3+ times without converging | Re-plan at deep, then resume the review at standard |
+| Deep-tier plan is still unclear | Stop, comment on the ticket, request human input |
+| Any escalation succeeds | Do **not** persist the escalated tier |
+
+Escalation is per-invocation, not sticky. After a successful retry, subsequent
+phases resume at their assigned tier.
+
+## Per-harness support
+
+| Harness | Mechanism | Enforcement |
+|---------|-----------|-------------|
+| **Claude Code** | `.claude/agents/*.md` frontmatter `model:` | Per subagent |
+| **Kiro CLI** | `.kiro/agents/*.json` `"model"` field | Per agent |
+| **Kiro IDE** | `.kiro/agents/*.md` frontmatter `model:` | Per agent |
+| Codex, Cursor, Gemini CLI, Windsurf, Cline, Continue, Augment, OpenCode, Antigravity, GitHub Copilot | — | Advisory only; session default |
+
+`sync-pack` ships the pack's canonical `model_tier` frontmatter verbatim; it does
+**not** rewrite it into a harness-native `model:` field, because the resolved ID
+depends on the consumer's `[models]` table. On the enforcing harnesses above, add
+the `model:` key to your synced `.claude/agents/*.md` (or `.kiro/agents/*`) copies
+with whatever your `[models]` table resolves to, then re-run `sync-pack --check`
+to confirm nothing else drifted.
+
+On advisory harnesses, `model_tier` is documentation: the operator can select a
+model manually before invoking a skill. The pipeline never blocks or fails because
+a model is unavailable.
+
+## ID spelling
+
+Model identifiers are spelled differently per harness, so keep the mapping in
+config rather than in skill text:
+
+| Context | Format | Example |
+|---------|--------|---------|
+| `[models]` in `.sdlc/config.toml` | whatever your harness accepts | `claude-opus-5` |
+| Kiro agents (JSON + MD) | dotted | `claude-opus-4.8` |
+| Claude Code agents | alias or full ID | `opus`, `claude-opus-5` |
+
+The example configs ship dashed Anthropic IDs as a starting point. Replace them
+with the identifiers your harness and provider actually accept.

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -77,12 +77,22 @@ phases resume at their assigned tier.
 | **Kiro IDE** | `.kiro/agents/*.md` frontmatter `model:` | Per agent |
 | Codex, Cursor, Gemini CLI, Windsurf, Cline, Continue, Augment, OpenCode, Antigravity, GitHub Copilot | — | Advisory only; session default |
 
-`sync-pack` ships the pack's canonical `model_tier` frontmatter verbatim; it does
-**not** rewrite it into a harness-native `model:` field, because the resolved ID
-depends on the consumer's `[models]` table. On the enforcing harnesses above, add
-the `model:` key to your synced `.claude/agents/*.md` (or `.kiro/agents/*`) copies
-with whatever your `[models]` table resolves to, then re-run `sync-pack --check`
-to confirm nothing else drifted.
+**Skills** carry only `model_tier` — the orchestrator resolves it through
+`tkt cfg models.<tier>`, so nothing needs rewriting at sync time.
+
+**Agents** carry both, because the enforcing harnesses read the frontmatter
+themselves and a tier name means nothing to them:
+
+```yaml
+model_tier: deep      # portable statement of intent
+model: opus           # harness-native default, safe to override
+```
+
+The shipped `model:` values are generation-stable aliases (`haiku` / `sonnet` /
+`opus`) rather than pinned IDs, so they don't rot with each model release. A
+consumer who wants a specific build edits the synced `.claude/agents/*.md` copy —
+`sync-pack --check` will then report that file as drifted, which is the intended
+signal, not an error.
 
 On advisory harnesses, `model_tier` is documentation: the operator can select a
 model manually before invoking a skill. The pipeline never blocks or fails because

--- a/docs/qa-suite-design.md
+++ b/docs/qa-suite-design.md
@@ -1,0 +1,632 @@
+# QA Engineer Suite — Design Document
+
+**Status:** Draft / Brainstorm
+**Author:** Raymond Doran
+**Date:** 2025-07-24
+
+---
+
+## 1. Problem Statement
+
+The existing SDLC pack has skills that nibble at QA:
+
+| Existing skill | What it does for testing | What it does NOT do |
+|---|---|---|
+| `self-review` | Adversarial review of diff (security, types, edge cases) | Doesn't write tests, doesn't produce a test plan, doesn't evaluate test adequacy |
+| `plan-ticket` | Produces a "Test Strategy" section in the plan | Single paragraph, no matrix, no adversarial thinking |
+| `ci-fix` | Fixes failing CI / flake rerun | Doesn't triage *why* tests are flaky, doesn't improve coverage |
+| `sdlc-reviewer` | Flags "new code without tests" | Doesn't say *which* tests are missing or write them |
+
+**Result:** If a user says "write tests for this" or "review this PR from a QA perspective," no single skill owns the request. Three skills half-fire, none of them wins.
+
+**The gap:** A dedicated QA engineer persona that:
+1. Forces the pessimist hat — breaks things rather than proving they work
+2. Produces concrete test artifacts (files, plans, risk tables) — not essays
+3. Treats acceptance criteria as the source of truth, not the implementation
+
+---
+
+## 2. Design Principle: Adversarial-First
+
+An LLM asked to "write tests" will cheerfully produce a beautiful happy-path suite that proves the code does what the code does. That's tautology with a test runner, not QA.
+
+**This suite's reason to exist is forcing the pessimist hat on.**
+
+Every skill in this suite operates under the assumption that the code is wrong until proven otherwise. The happy path is already tested by the developer — we exist to find what they missed.
+
+---
+
+## 3. Scope & Boundaries
+
+### What the QA suite owns
+
+| Concern | Deliverable |
+|---|---|
+| **Test Strategy** | `TEST-PLAN.md` — requirements → test matrix mapping |
+| **Test Authoring** | Test files (unit, integration, e2e) focused on edge cases and failure modes |
+| **Adversarial Analysis** | Risk table: what can break, how badly, likelihood |
+| **Test Suite Critique** | Coverage gaps, assertion quality, false-confidence detection |
+| **Flake Triage** | Root-cause classification of non-deterministic failures |
+| **Bug Reporting** | Structured reproduction steps from a failing scenario |
+
+### What existing skills keep
+
+| Skill | Keeps | Does NOT expand into |
+|---|---|---|
+| `self-review` | Pre-PR diff review (code quality lens) | Writing tests, producing test plans |
+| `plan-ticket` | Implementation plan with a "Test Strategy" *summary* | Detailed test matrices (delegates to QA suite) |
+| `ci-fix` | Fix CI failures, rerun flakes once | Deep flake analysis (delegates to QA suite) |
+| `sdlc-reviewer` | Code review findings | Test adequacy assessment |
+
+### Boundary rules
+
+1. `self-review` may flag "missing tests" as a WARNING — but it does NOT write them. It says "invoke QA authoring."
+2. `plan-ticket` produces a one-paragraph test strategy — the QA suite expands it into a full matrix when invoked.
+3. `ci-fix` handles "make CI green." The QA suite handles "why does this test keep going red/green randomly?"
+4. The QA suite never transitions tickets or opens PRs. It produces artifacts and recommendations.
+
+---
+
+## 4. Architecture: Skills + Sub-Agent
+
+### Why a sub-agent, not just skills
+
+**Author-reviewer separation is real.** The instance that wrote the code is emotionally invested in it being correct. A fresh context that only sees the diff, the requirements, and the existing test suite is meaningfully harsher.
+
+The QA sub-agent (`qa-engineer`) is a read-only adversarial context — same trust model as `sdlc-reviewer`, extended to test analysis and authoring.
+
+### Suite structure
+
+```
+skills/
+  qa-strategy/SKILL.md          # Test plan from spec/requirements
+  qa-author/SKILL.md            # Write adversarial tests (files)
+  qa-critique/SKILL.md          # Evaluate existing test suite quality
+  qa-flake-triage/SKILL.md      # Classify and fix flaky tests
+  qa-bug-report/SKILL.md        # Structured repro from a failure
+
+agents/
+  qa-engineer.md                # Sub-agent: adversarial analysis + routing
+
+skills/qa-author/references/
+  nestjs.md
+  react.md
+  go.md
+  cdk.md
+  htmx-lambda.md
+```
+
+### Trigger phrases → Skill routing
+
+| User says | Skill invoked |
+|---|---|
+| "review this PR before I merge" | `qa-critique` (test adequacy) + `qa-strategy` (gap analysis) |
+| "generate tests from this spec" | `qa-strategy` (plan) → `qa-author` (files) |
+| "write tests for this" | `qa-author` (with adversarial checklist) |
+| "why is this test flaky?" | `qa-flake-triage` |
+| "what could break here?" | `qa-engineer` agent (adversarial analysis → risk table) |
+| "file a bug for this" | `qa-bug-report` |
+
+---
+
+## 5. The Break-It Checklist
+
+This is the meat. Every QA skill walks this list. It cannot hand-wave.
+
+### 5.1 Boundary Analysis
+- **0, 1, n, n+1** — every numeric input
+- **Empty** — empty array, empty string, empty object, `null`, `undefined`
+- **Single-element** — collections with exactly one item (different code path than n)
+- **Max** — at configured limits, at integer overflow, at payload size limits
+- **Negative** — negative numbers, negative indexes, counts below zero
+
+### 5.2 Null / Undefined / Missing
+- `null` vs `undefined` vs empty string (TS lies constantly — `Partial<T>` doesn't mean what you think)
+- Missing key vs key-present-with-null-value
+- Optional chaining paths that can produce `undefined` mid-chain
+- JSON.parse of responses that omit fields
+
+### 5.3 Authorization
+- **Can user A read user B's thing?** Every endpoint. Every query. Every mutation.
+- Horizontal privilege escalation (same role, different tenant/org)
+- Vertical privilege escalation (lower role accessing higher-role resources)
+- Resource enumeration via sequential IDs
+- Token expiry mid-operation
+- Permission changes between authentication and resource access
+
+### 5.4 Concurrency
+- Two writes, same row, same millisecond
+- Read-then-write races (TOCTOU)
+- Concurrent list + delete (item disappears mid-iteration)
+- Connection pool exhaustion under parallel requests
+- Deadlock potential in multi-table operations
+
+### 5.5 Idempotency & Retries
+- Client sends it twice — what happens?
+- Network timeout → retry → original request already succeeded
+- Partial retry after partial success
+- Queue consumers processing the same message twice
+
+### 5.6 Partial Failure
+- DB write succeeds, external API call doesn't — state consistency?
+- Multi-step transaction: step 3 of 5 fails — what's left behind?
+- S3 upload succeeds, metadata write fails
+- Webhook delivery succeeds, local state update doesn't
+
+### 5.7 Time
+- Timezones: UTC vs local, server vs client
+- DST transitions (the 2 AM that happens twice, the 2 AM that doesn't exist)
+- Clock skew between services
+- Token/session expiry at exact boundary
+- Cron jobs that fire during a deploy
+- "Created 0 seconds ago" edge (Date.now() comparison)
+
+### 5.8 Pagination & Ordering
+- Unstable sort with ties (insertion order varies by DB engine)
+- Cursor drift when items are inserted/deleted mid-pagination
+- Page size = 0, page = -1, page beyond total
+- First page vs last page vs empty result set
+- Concurrent writes during pagination (phantom reads)
+
+### 5.9 Encoding & Input
+- Unicode: emoji, combining characters, zero-width joiners
+- RTL text in LTR contexts
+- 10k-character inputs (above typical validation, below hard limit)
+- Script injection in every user-writable field
+- SQL injection (parameterized queries should make this impossible — verify)
+- Path traversal in filenames
+- Null bytes in strings
+- Multi-byte characters at truncation boundaries
+
+### 5.10 Performance & Data Volume
+- N+1 queries (the existing tkt tooling detects these — the QA skill should know to reach for it)
+- Over-fetching: requesting 50 fields when you need 3
+- Large result sets without streaming/pagination
+- Missing database indexes on filtered/sorted columns
+- Unbounded loops or recursion
+- Memory accumulation in long-running processes
+
+### 5.11 Error Propagation
+- Is the error message safe to show the user? (no stack traces, no internal paths)
+- Does the error response match the documented schema?
+- Are error codes/statuses correct? (not everything is 500)
+- Retry-after headers on rate limits
+- Graceful degradation vs hard failure
+
+---
+
+## 6. Forbidden Cheats
+
+These are explicitly forbidden in every QA skill. Agents "fix" failing tests in ways that would get a human fired:
+
+| Cheat | Why it's forbidden |
+|---|---|
+| `.skip()` or delete a failing test to get green | Deleting evidence is not fixing |
+| Weaken an assertion to match observed (wrong) output | You just encoded the bug as a spec |
+| Add `sleep(5000)` / `waitFor(5000)` to paper over a flake | You've hidden a race condition behind a prayer |
+| Mock the unit under test | You're testing your mock, not your code |
+| Assert on `expect(result).toBeDefined()` alone | That proves nothing except it didn't throw |
+| Catch-all `try/catch` that swallows errors in tests | You've made the test unfailable |
+| Test that passes regardless of implementation | Tautological — delete it |
+
+### The Red-Before-Green Rule
+
+**A new test MUST fail first against the unfixed code.**
+
+If you write a test and it passes immediately, you've proven nothing. Either:
+1. The bug doesn't exist (remove the test, investigate further)
+2. The test doesn't actually exercise the failure path (fix the test)
+3. The assertion is too weak (strengthen it)
+
+This is the single highest-leverage constraint in the entire suite.
+
+---
+
+## 7. Skill Specifications
+
+### 7.1 `qa-strategy` — Test Plan from Spec
+
+**Trigger:** "generate tests from this spec," "what should we test for this ticket?"
+
+**Input:** Ticket key (via `tkt view KEY --json`) or a spec/requirements document.
+
+**Process:**
+1. Extract acceptance criteria
+2. For each criterion, enumerate: happy path, sad paths, edge cases (using the Break-It Checklist)
+3. Map each test case to a priority (P0 = blocks release, P1 = should fix before ship, P2 = nice to have)
+4. Flag any untested requirement (acceptance criterion with no test mapped to it)
+5. Flag any untestable requirement (vague, subjective, or missing definition of done)
+
+**Output:** `TEST-PLAN.md` (or equivalent structured artifact)
+
+```markdown
+# Test Plan — <KEY>: <summary>
+
+## Requirements Coverage Matrix
+
+| # | Requirement (from AC) | Test cases | Priority | Status |
+|---|---|---|---|---|
+| 1 | User can reset password via email | TC-1.1, TC-1.2, TC-1.3, TC-1.4 | P0 | Planned |
+| 2 | Reset link expires after 1 hour | TC-2.1, TC-2.2 | P0 | Planned |
+
+## Test Cases
+
+### TC-1.1: Happy path — valid email, link sent
+- **Type:** Integration
+- **Priority:** P0
+- **Steps:** ...
+- **Expected:** ...
+
+### TC-1.2: Email not found — should not reveal account existence
+- **Type:** Integration
+- **Priority:** P0
+- **Steps:** ...
+- **Expected:** Same response shape/timing as success (no oracle)
+
+### TC-1.3: Email with unicode/punycode domain
+...
+
+## Untested Requirements
+- AC #5 ("should feel fast") — no measurable criterion. Recommend: define latency SLO.
+
+## Risk Table
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Token collision in reset link | Critical | Low | Use crypto-random 256-bit token |
+| Race: two resets same user | Medium | Medium | Last-write-wins with DB constraint |
+```
+
+### 7.2 `qa-author` — Write Adversarial Tests
+
+**Trigger:** "write tests for this," "add tests for <file/feature>"
+
+**Input:** File path or diff. Optionally a TEST-PLAN.md from `qa-strategy`.
+
+**Process:**
+1. Read the implementation
+2. Read existing tests for the same module
+3. Walk the Break-It Checklist against the implementation
+4. Write test cases — prioritizing failure modes over happy paths
+5. Verify each new test **fails** against a known-bad state (Red-Before-Green rule)
+6. Group: unit → integration → e2e
+
+**Output:** Test files in the project's testing convention. No essays — code.
+
+**Stack dispatch:** Check the file extension and import patterns, then load the appropriate reference:
+- `.ts` + `@nestjs/*` → `references/nestjs.md`
+- `.tsx` + `react` → `references/react.md`
+- `.go` → `references/go.md`
+- `.ts` + `aws-cdk-lib` → `references/cdk.md`
+- `.ts` + `hx-` attributes in template strings → `references/htmx-lambda.md`
+
+### 7.3 `qa-critique` — Test Suite Quality Assessment
+
+**Trigger:** "review this PR before I merge" (from QA perspective), "are these tests good enough?"
+
+**Input:** Diff or file paths of test files. Optionally the implementation they test.
+
+**Process:**
+1. Read the test files
+2. Read the implementation under test
+3. Evaluate against:
+   - **Coverage gaps:** Which branches/paths have no test?
+   - **Assertion quality:** Are assertions specific enough? Would they catch a regression?
+   - **False confidence:** Tests that pass regardless of implementation correctness
+   - **Missing scenarios:** Walk the Break-It Checklist — what's not exercised?
+   - **Test isolation:** Shared mutable state, test ordering dependencies
+   - **Maintenance burden:** Overly brittle tests that break on refactors
+4. Produce a scored assessment
+
+**Output:** Critique report
+
+```markdown
+# Test Suite Critique — <file/module>
+
+## Score: 6/10
+
+## Coverage Gaps (Critical)
+- [ ] No test for unauthorized access to GET /users/:id with another user's token
+- [ ] No test for empty result set on paginated endpoint
+- [ ] No test for concurrent write conflict
+
+## Weak Assertions
+- `user.spec.ts:45` — `expect(result).toBeDefined()` proves nothing
+- `order.spec.ts:112` — catches error but doesn't assert the error *type*
+
+## False Confidence
+- `payment.spec.ts:78` — mocks the payment gateway AND the validation layer; tests only the orchestration glue, which is 3 lines
+
+## Missing from Break-It Checklist
+- [ ] Boundary: max pagination size
+- [ ] Auth: horizontal escalation
+- [ ] Time: token expiry at exact second
+- [ ] Encoding: unicode in user-supplied names
+
+## Recommendations (prioritized)
+1. (P0) Add authz tests — every endpoint, user A accessing user B's resources
+2. (P0) Replace `toBeDefined()` assertions with specific value/shape checks
+3. (P1) Add boundary tests for pagination
+4. (P2) Consider property-based testing for the validation layer
+```
+
+### 7.4 `qa-flake-triage` — Flaky Test Root-Cause Classification
+
+**Trigger:** "why is this test flaky?" "this test keeps failing randomly"
+
+**Input:** Test file + failure logs (from CI or local)
+
+**Process:**
+1. Read the test
+2. Read recent failure logs (CI history if available via `gh run view`)
+3. Classify the flake:
+
+| Class | Indicators | Fix pattern |
+|---|---|---|
+| **Race condition** | Passes with delay, fails under load | Add proper synchronization, not sleep |
+| **Shared state** | Fails only when run after specific other test | Isolate — teardown/setup per test |
+| **Non-deterministic ordering** | Fails on sorted assertions with ties | Make sort stable or assert without order |
+| **Clock sensitivity** | Fails near midnight, DST, or second boundaries | Mock time, use relative comparisons |
+| **External dependency** | Fails when network/service is slow | Mock or use test containers |
+| **Resource exhaustion** | Fails later in the suite | Connection/file handle leak |
+| **Platform-specific** | Fails on CI but not local (or vice versa) | OS, timezone, locale, file system differences |
+
+4. Propose a fix (not `sleep`, not `.skip`)
+
+**Output:** Classification + fix recommendation + confidence level
+
+### 7.5 `qa-bug-report` — Structured Reproduction
+
+**Trigger:** "file a bug for this," "this is broken, document it"
+
+**Input:** A failing scenario (test output, error log, user report, or observed behavior)
+
+**Process:**
+1. Identify the failure
+2. Determine minimal reproduction steps
+3. Classify severity and likely root cause
+4. Format as a structured bug report suitable for ticket creation
+
+**Output:**
+
+```markdown
+## Bug Report
+
+**Summary:** <one line>
+**Severity:** Critical / High / Medium / Low
+**Component:** <package/module>
+**Reproducibility:** Always / Intermittent / Rare
+
+### Steps to Reproduce
+1. ...
+2. ...
+3. ...
+
+### Expected Behavior
+...
+
+### Actual Behavior
+...
+
+### Environment
+- Branch: ...
+- Commit: ...
+- Relevant config: ...
+
+### Root Cause (suspected)
+...
+
+### Suggested Fix
+...
+```
+
+Optionally invoke `tkt create --type Bug --summary "..." --description "..."` if the user confirms.
+
+---
+
+## 8. Sub-Agent: `qa-engineer`
+
+### Identity
+
+```markdown
+---
+name: qa-engineer
+description: Adversarial QA analysis — finds what the developer missed. Read + write test files only.
+tools: [Read, Write, Bash]
+model: sonnet
+---
+```
+
+### Trust model
+
+- **Read:** Any file in the repo
+- **Write:** Only `**/*.test.*`, `**/*.spec.*`, `**/__tests__/**`, `**/TEST-PLAN.md`, `**/test/**`
+- **Bash (read-only):** `git diff`, `git log`, `tkt view`, `tkt cfg`, test runners (read output only)
+- **Bash (write):** Test runner execution only (to verify red-before-green)
+- **NEVER:** `tkt transition`, `tkt comment`, `git commit`, `git push`, file edits outside test directories
+
+### Persona
+
+You are a pessimist who has seen production burn. You assume:
+- The developer tested the happy path and nothing else
+- Every type annotation is a lie until a runtime check proves it
+- Every "this can't happen" comment is a prediction, not a fact
+- The existing test suite has gaps the developer doesn't know about
+
+Your job is NOT to prove the code works. Your job is to find where it doesn't.
+
+### Routing
+
+The `qa-engineer` agent acts as the primary entry point for QA requests and routes to the appropriate skill:
+
+```
+User request → qa-engineer
+  ├── "what could break?" → adversarial analysis (inline) → risk table
+  ├── "generate tests from spec" → qa-strategy → qa-author
+  ├── "write tests" → qa-author
+  ├── "review tests" / "are these tests good enough?" → qa-critique
+  ├── "flaky test" → qa-flake-triage
+  └── "file a bug" → qa-bug-report
+```
+
+---
+
+## 9. Stack-Specific References
+
+Progressive disclosure: SKILL.md stays as a router. Details pushed into `references/` so you're not burning context on Go table tests when debugging a React component.
+
+### `references/nestjs.md`
+- `Test.createTestingModule` patterns
+- Provider overrides for unit isolation
+- Supertest for e2e (assert response shape, status, headers)
+- Transactional test DB (setup/teardown per test)
+- Guard/interceptor testing in isolation
+
+### `references/react.md`
+- Testing Library philosophy: test behavior, not implementation
+- `userEvent` over `fireEvent` (simulates real interaction)
+- Never query by class name or test-id-less selectors
+- Async act() patterns for state updates
+- Accessibility assertions (`toBeAccessible`, role queries)
+
+### `references/go.md`
+- Table-driven tests (subtests with `t.Run`)
+- `t.Parallel()` for concurrency safety
+- No testify religion — stdlib `testing` + `cmp` is fine
+- Interface mocks via manual struct, not framework magic
+- `httptest.NewServer` for HTTP handler testing
+
+### `references/cdk.md`
+- `Template.fromStack()` assertions
+- Snapshot tests are a diff alarm, not a test (acknowledge their limits)
+- Resource property assertions for security (IAM, SGs, encryption)
+- `Aspects` for cross-stack policy validation
+
+### `references/htmx-lambda.md`
+- Responses are HTML fragments — assert with cheerio/jsdom, not JSON shape
+- Test `hx-*` attributes and swap targets explicitly
+- Assert `HX-Trigger` response headers for event-driven UI updates
+- Template rendering assertions (is the data bound correctly?)
+- Lambda handler integration tests with API Gateway event shapes
+- Most internet testing guidance has no idea this pattern exists — reference the actual request/response cycle
+
+---
+
+## 10. Integration with Existing Pipeline
+
+### Where QA skills plug into `automated-sdlc`
+
+```
+Phase 2 (Plan)
+  └── qa-strategy can expand the "Test Strategy" section into a full TEST-PLAN.md
+      (optional — triggered by user or by plan-ticket detecting complex AC)
+
+Phase 3 (Implement)
+  └── Developer/executor writes implementation + basic tests
+  
+Phase 4 (Self-Review)
+  └── sdlc-reviewer may flag "missing tests" → recommends invoking qa-author
+  
+[NEW] Phase 4.5 (QA Analysis) — OPTIONAL, human-triggered
+  └── qa-engineer runs adversarial analysis against the diff
+  └── qa-critique evaluates the test suite
+  └── qa-author fills coverage gaps
+  └── Produces risk table for human reviewer
+  
+Phase 5+ (PR, CI, Review...)
+  └── qa-flake-triage activates if ci-fix encounters non-deterministic failures
+```
+
+### Standalone invocations (outside the pipeline)
+
+The QA suite is equally useful outside the SDLC pipeline:
+- "Review this PR before I merge" → `qa-critique` + `qa-strategy` (gap analysis)
+- "Write tests for this module" → `qa-author`
+- "This test keeps flaking" → `qa-flake-triage`
+
+---
+
+## 11. Output Artifacts
+
+Every skill produces a concrete deliverable — no 2000-word essays about testing philosophy.
+
+| Skill | Primary artifact | Secondary |
+|---|---|---|
+| `qa-strategy` | `TEST-PLAN.md` (requirements → test matrix) | Risk table |
+| `qa-author` | Test files (`.test.ts`, `.spec.ts`, `_test.go`, etc.) | — |
+| `qa-critique` | Critique report (structured markdown) | Scored assessment |
+| `qa-flake-triage` | Classification + fix recommendation | — |
+| `qa-bug-report` | Structured bug report | Optionally creates ticket |
+
+---
+
+## 12. Evaluation Strategy
+
+### Known-bug fixture repo
+
+Plant bugs in a fixture and verify the suite finds them:
+
+| Bug type | Location | Expected detection |
+|---|---|---|
+| Off-by-one in pagination | `listUsers` returns n-1 items on last page | `qa-author` boundary tests |
+| Authz hole | `GET /users/:id` doesn't check ownership | `qa-author` or `qa-critique` flags missing authz test |
+| N+1 query | `getOrders` fires one query per order for items | `qa-critique` flags performance, `qa-author` writes load assertion |
+| Flaky test | Shared DB state between parallel tests | `qa-flake-triage` classifies as shared-state |
+| Weak assertion | `expect(response).toBeDefined()` on a critical endpoint | `qa-critique` flags false confidence |
+| Race condition | Counter increment without lock | `qa-author` concurrency test |
+
+### Eval criteria
+
+- **Detection rate:** Does the skill find the planted bug? (binary)
+- **False positive rate:** Does it flag non-issues? (< 20% acceptable)
+- **Artifact quality:** Is the output usable without human rewriting? (qualitative)
+- **Red-before-green compliance:** Does the authored test actually fail on buggy code? (binary)
+
+---
+
+## 13. Open Questions
+
+1. **Should `qa-author` auto-commit its test files?** Current inclination: no. It writes them, the user/executor reviews and commits. Same as how `sdlc-reviewer` doesn't fix.
+
+2. **How deep should `qa-critique` go on coverage?** Options:
+   - (a) AST-level branch coverage analysis (expensive, precise)
+   - (b) Heuristic based on reading test + implementation (cheaper, less precise)
+   - (c) Run coverage tool and analyze the report (requires toolchain support)
+   
+   Recommendation: (b) by default, (c) when coverage tooling is configured via `tkt cfg build.coverage`.
+
+3. **Should the QA suite have its own orchestrator skill?** Or does `qa-engineer` agent handle routing?
+   
+   Recommendation: `qa-engineer` agent is the entry point. No separate orchestrator skill — avoids another layer.
+
+4. **Integration with BDD / behavior specs?** The existing `behavior-specs.md` practice uses Gherkin-style scenarios. Should `qa-strategy` produce Gherkin as an optional output format?
+   
+   Recommendation: Yes, optional. If `build.bdd` is configured, `qa-strategy` can output `.feature` files alongside `TEST-PLAN.md`.
+
+5. **Model tier for each skill?**
+   
+   | Skill | Recommended tier | Rationale |
+   |---|---|---|
+   | `qa-strategy` | opus | Requires deep requirement analysis |
+   | `qa-author` | sonnet | Implementation work, benefits from speed |
+   | `qa-critique` | opus | Adversarial analysis is where models are weakest |
+   | `qa-flake-triage` | sonnet | Pattern matching against known categories |
+   | `qa-bug-report` | haiku | Structured formatting of known information |
+   | `qa-engineer` (agent) | opus | Routing + adversarial judgment calls |
+
+---
+
+## 14. Next Steps
+
+- [ ] Write `skills/qa-strategy/SKILL.md` (canonical)
+- [ ] Write `skills/qa-author/SKILL.md` (canonical)
+- [ ] Write `skills/qa-critique/SKILL.md` (canonical)
+- [ ] Write `skills/qa-flake-triage/SKILL.md` (canonical)
+- [ ] Write `skills/qa-bug-report/SKILL.md` (canonical)
+- [ ] Write `agents/qa-engineer.md` (sub-agent definition)
+- [ ] Write stack-specific references (`references/*.md`)
+- [ ] Create fixture repo for evals
+- [ ] Sync to all harness formats via `sync-skills`
+- [ ] Update `automated-sdlc/SKILL.md` to reference Phase 4.5
+- [ ] Update `self-review/SKILL.md` to delegate test-gap findings to QA suite
+- [ ] Update `ci-fix/SKILL.md` to delegate flake analysis to `qa-flake-triage`

--- a/examples/config.github.toml
+++ b/examples/config.github.toml
@@ -87,5 +87,13 @@ test      = "make test"
 typecheck = "true"
 lint      = "true"
 
+[models]                      # advisory model routing (see docs/model-routing.md).
+# Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
+# resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole
+# table and every phase runs on the harness's session default.
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+
 [timetracking]
 provider = "none"        # GitHub has no time tracking; worklog/lane-time are no-ops

--- a/examples/config.github.toml
+++ b/examples/config.github.toml
@@ -86,6 +86,10 @@ build     = "make build"
 test      = "make test"
 typecheck = "true"
 lint      = "true"
+# bdd (optional): the repo's behavior-spec runner. self-review runs it as a
+# non-blocking signal, mirroring the non-strict BDD posture. Omit when the repo
+# has no behavior specs. See docs/behavior-specs.md.
+# bdd     = "go test ./features/..."
 
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator

--- a/examples/config.github.toml
+++ b/examples/config.github.toml
@@ -91,6 +91,14 @@ lint      = "true"
 # has no behavior specs. See docs/behavior-specs.md.
 # bdd     = "go test ./features/..."
 
+[run]                         # external loop driver — `tkt run`. Optional.
+# harness_cmd is required to use `tkt run`; {prompt} is substituted with the
+# per-phase prompt. Use the least-privilege flags your harness offers.
+# harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+# max_iterations     = 30     # total phase invocations before the run gives up
+# max_phase_attempts = 3      # failed attempts on one phase -> transition blocked
+# invocation_timeout = 3600   # seconds per harness invocation
+
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
 # resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole

--- a/examples/config.jira.toml
+++ b/examples/config.jira.toml
@@ -68,6 +68,10 @@ build     = "pnpm turbo build --filter={pkg}"
 test      = "pnpm --filter {pkg} test -- --run"
 typecheck = "pnpm turbo typecheck"
 lint      = "pnpm turbo lint"
+# bdd (optional): the repo's behavior-spec runner. self-review runs it as a
+# non-blocking signal, mirroring the non-strict BDD posture. Omit when the repo
+# has no behavior specs. See docs/behavior-specs.md.
+# bdd     = "go test ./features/..."
 
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator

--- a/examples/config.jira.toml
+++ b/examples/config.jira.toml
@@ -73,6 +73,14 @@ lint      = "pnpm turbo lint"
 # has no behavior specs. See docs/behavior-specs.md.
 # bdd     = "go test ./features/..."
 
+[run]                         # external loop driver — `tkt run`. Optional.
+# harness_cmd is required to use `tkt run`; {prompt} is substituted with the
+# per-phase prompt. Use the least-privilege flags your harness offers.
+# harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+# max_iterations     = 30     # total phase invocations before the run gives up
+# max_phase_attempts = 3      # failed attempts on one phase -> transition blocked
+# invocation_timeout = 3600   # seconds per harness invocation
+
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
 # resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole

--- a/examples/config.jira.toml
+++ b/examples/config.jira.toml
@@ -69,6 +69,14 @@ test      = "pnpm --filter {pkg} test -- --run"
 typecheck = "pnpm turbo typecheck"
 lint      = "pnpm turbo lint"
 
+[models]                      # advisory model routing (see docs/model-routing.md).
+# Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
+# resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole
+# table and every phase runs on the harness's session default.
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+
 [timetracking]
 provider = "tempo"        # none | jira-worklog | tempo
 billable = false

--- a/examples/config.linear.toml
+++ b/examples/config.linear.toml
@@ -68,6 +68,10 @@ build     = "make build"
 test      = "make test"
 typecheck = "true"
 lint      = "true"
+# bdd (optional): the repo's behavior-spec runner. self-review runs it as a
+# non-blocking signal, mirroring the non-strict BDD posture. Omit when the repo
+# has no behavior specs. See docs/behavior-specs.md.
+# bdd     = "go test ./features/..."
 
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator

--- a/examples/config.linear.toml
+++ b/examples/config.linear.toml
@@ -69,5 +69,13 @@ test      = "make test"
 typecheck = "true"
 lint      = "true"
 
+[models]                      # advisory model routing (see docs/model-routing.md).
+# Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
+# resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole
+# table and every phase runs on the harness's session default.
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+
 [timetracking]
 provider = "none"        # Linear has no time tracking; worklog/lane-time are no-ops

--- a/examples/config.linear.toml
+++ b/examples/config.linear.toml
@@ -73,6 +73,14 @@ lint      = "true"
 # has no behavior specs. See docs/behavior-specs.md.
 # bdd     = "go test ./features/..."
 
+[run]                         # external loop driver — `tkt run`. Optional.
+# harness_cmd is required to use `tkt run`; {prompt} is substituted with the
+# per-phase prompt. Use the least-privilege flags your harness offers.
+# harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+# max_iterations     = 30     # total phase invocations before the run gives up
+# max_phase_attempts = 3      # failed attempts on one phase -> transition blocked
+# invocation_timeout = 3600   # seconds per harness invocation
+
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
 # resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole

--- a/examples/config.markdown.toml
+++ b/examples/config.markdown.toml
@@ -54,6 +54,14 @@ lint      = "true"
 # has no behavior specs. See docs/behavior-specs.md.
 # bdd     = "go test ./features/..."
 
+[run]                         # external loop driver — `tkt run`. Optional.
+# harness_cmd is required to use `tkt run`; {prompt} is substituted with the
+# per-phase prompt. Use the least-privilege flags your harness offers.
+# harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+# max_iterations     = 30     # total phase invocations before the run gives up
+# max_phase_attempts = 3      # failed attempts on one phase -> transition blocked
+# invocation_timeout = 3600   # seconds per harness invocation
+
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
 # resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole

--- a/examples/config.markdown.toml
+++ b/examples/config.markdown.toml
@@ -49,6 +49,10 @@ build     = "make build"
 test      = "make test"
 typecheck = "true"
 lint      = "true"
+# bdd (optional): the repo's behavior-spec runner. self-review runs it as a
+# non-blocking signal, mirroring the non-strict BDD posture. Omit when the repo
+# has no behavior specs. See docs/behavior-specs.md.
+# bdd     = "go test ./features/..."
 
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator

--- a/examples/config.markdown.toml
+++ b/examples/config.markdown.toml
@@ -50,5 +50,13 @@ test      = "make test"
 typecheck = "true"
 lint      = "true"
 
+[models]                      # advisory model routing (see docs/model-routing.md).
+# Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
+# resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole
+# table and every phase runs on the harness's session default.
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+
 [timetracking]
 provider = "local"            # none disables worklog; anything else -> local JSONL

--- a/examples/config.openkanban.toml
+++ b/examples/config.openkanban.toml
@@ -54,6 +54,10 @@ build     = "make build"
 test      = "make test"
 typecheck = "true"
 lint      = "true"
+# bdd (optional): the repo's behavior-spec runner. self-review runs it as a
+# non-blocking signal, mirroring the non-strict BDD posture. Omit when the repo
+# has no behavior specs. See docs/behavior-specs.md.
+# bdd     = "go test ./features/..."
 
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator

--- a/examples/config.openkanban.toml
+++ b/examples/config.openkanban.toml
@@ -55,5 +55,13 @@ test      = "make test"
 typecheck = "true"
 lint      = "true"
 
+[models]                      # advisory model routing (see docs/model-routing.md).
+# Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
+# resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole
+# table and every phase runs on the harness's session default.
+cheap    = "claude-haiku-4-5"
+standard = "claude-sonnet-5"
+deep     = "claude-opus-5"
+
 [timetracking]
 provider = "none"        # openkanban has no time tracking; worklog/lane-time are no-ops

--- a/examples/config.openkanban.toml
+++ b/examples/config.openkanban.toml
@@ -59,6 +59,14 @@ lint      = "true"
 # has no behavior specs. See docs/behavior-specs.md.
 # bdd     = "go test ./features/..."
 
+[run]                         # external loop driver — `tkt run`. Optional.
+# harness_cmd is required to use `tkt run`; {prompt} is substituted with the
+# per-phase prompt. Use the least-privilege flags your harness offers.
+# harness_cmd        = "claude -p {prompt} --permission-mode acceptEdits"
+# max_iterations     = 30     # total phase invocations before the run gives up
+# max_phase_attempts = 3      # failed attempts on one phase -> transition blocked
+# invocation_timeout = 3600   # seconds per harness invocation
+
 [models]                      # advisory model routing (see docs/model-routing.md).
 # Skills declare `model_tier: cheap|standard|deep` in frontmatter; the orchestrator
 # resolves the tier here via `tkt cfg models.<tier>`. Optional — omit the whole

--- a/scripts/smoke-sync-pack.sh
+++ b/scripts/smoke-sync-pack.sh
@@ -22,17 +22,29 @@ C="$(mktemp -d)"
 trap 'rm -rf "$C" "${C2:-}" "${C3:-}" "${C4:-}"' EXIT
 
 # ---- case 1: fresh install --------------------------------------------------
+# Expected counts are derived from the pack, not hardcoded, so adding a skill
+# does not require editing this file. sync-pack never ships `sync-skills`.
+want_skills=$(find "$PACK/skills" -maxdepth 1 -mindepth 1 -type d ! -name sync-skills | wc -l | tr -d ' ')
+want_prompts=$(find "$PACK/.github/prompts" -maxdepth 1 -type f | wc -l | tr -d ' ')
+want_kiro=$(find "$PACK/.kiro/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
+want_agents=$(find "$PACK/agents" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+want_steer=$(find "$PACK/.kiro/steering" -maxdepth 1 -type f | wc -l | tr -d ' ')
+
 "$TKT" sync-pack --dir "$C" >/dev/null
 skills_n=$(find "$C/.claude/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
 prompts_n=$(find "$C/.github/prompts" -maxdepth 1 -type f | wc -l | tr -d ' ')
 kiro_n=$(find "$C/.kiro/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
+agents_n=$(find "$C/.claude/agents" -maxdepth 1 -type f | wc -l | tr -d ' ')
+steer_n=$(find "$C/.kiro/steering" -maxdepth 1 -type f | wc -l | tr -d ' ')
 ok=1
-[ "$skills_n" = "14" ] || { ok=0; echo "  .claude/skills=$skills_n (want 14)"; }
-[ "$prompts_n" = "14" ] || { ok=0; echo "  .github/prompts=$prompts_n (want 14)"; }
-[ "$kiro_n" = "14" ] || { ok=0; echo "  .kiro/skills=$kiro_n (want 14)"; }
+[ "$skills_n" = "$want_skills" ] || { ok=0; echo "  .claude/skills=$skills_n (want $want_skills)"; }
+[ "$prompts_n" = "$want_prompts" ] || { ok=0; echo "  .github/prompts=$prompts_n (want $want_prompts)"; }
+[ "$kiro_n" = "$want_kiro" ] || { ok=0; echo "  .kiro/skills=$kiro_n (want $want_kiro)"; }
+[ "$agents_n" = "$want_agents" ] || { ok=0; echo "  .claude/agents=$agents_n (want $want_agents)"; }
+[ "$steer_n" = "$want_steer" ] || { ok=0; echo "  .kiro/steering=$steer_n (want $want_steer)"; }
 [ -f "$C/.sdlc/pack-manifest.json" ] || { ok=0; echo "  manifest missing"; }
 grep -q "tkt-pack:begin" "$C/AGENTS.md" || { ok=0; echo "  AGENTS.md markers missing"; }
-[ "$ok" = "1" ] && pass "case1 fresh install (skills=14 prompts=14 kiro=14 manifest+markers)" \
+[ "$ok" = "1" ] && pass "case1 fresh install (skills=$want_skills prompts=$want_prompts kiro=$want_kiro agents=$want_agents steering=$want_steer manifest+markers)" \
                 || fail "case1 fresh install"
 
 # ---- case 2: idempotent second run leaves git clean -------------------------

--- a/skills/automated-sdlc/SKILL.md
+++ b/skills/automated-sdlc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: automated-sdlc
 description: 'Automated SDLC pipeline: ticket selection, intake, plan, implement, self-review, PR, review, CI, preview, human QA gate, deploy. Provider-agnostic via tkt — configure ticketing + board in .sdlc/config.toml. Orchestrates sub-skills with explicit human gates and lane-time annotation.'
+model_tier: standard
 ---
 
 # Automated SDLC
@@ -10,6 +11,32 @@ sub-skills with explicit human gates and per-lane time annotation. **Every
 ticketing/board operation goes through `tkt`**, so the same pipeline runs on Jira,
 GitHub Issues+Projects, Linear, qi, or a markdown board — the backend and board
 shape are declared in `.sdlc/config.toml`.
+
+## Model routing
+
+Each sub-skill declares a `model_tier` (`cheap` | `standard` | `deep`) in its
+frontmatter. Resolve the tier to a concrete model from project config before
+invoking a phase:
+
+```shell
+tkt cfg models.deep         # exit 4 = no [models] table -> skip routing entirely
+```
+
+| Tier | Phases |
+|------|--------|
+| cheap | `select-ticket`, `check-blockers`, `triage-ticket` |
+| deep | `plan-ticket` |
+| standard | everything else |
+
+**Escalate on failure, never start high.** A cheap-tier phase that returns a wrong
+or ambiguous result gets retried once at standard. If `self-review` cycles 3+ times
+without converging, re-plan at deep and resume the review at standard. Escalation
+is per-invocation — subsequent phases resume at their assigned tier.
+
+**Never block on routing.** If the harness cannot select a model, or `[models]` is
+unset, proceed on the session default. No phase requires a specific model to
+produce correct output — routing is a cost optimization. Full policy and the
+per-harness support matrix: [docs/model-routing.md](../../docs/model-routing.md).
 
 ## Prerequisites
 

--- a/skills/automated-sdlc/SKILL.md
+++ b/skills/automated-sdlc/SKILL.md
@@ -135,15 +135,20 @@ esac
 Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 `deliverable` sets are defined in `[issue_types]`.
 
-### Phase 2: Plan
+### Phase 2: Plan (→ `sdlc-planner`)
 
-**Invoke `plan-ticket`.** Output: files, test strategy, risks. External dep missing
-→ see "External blocker handling".
+**Delegate to `sdlc-planner`** with the ticket JSON (`tkt view "$KEY" --json`) as
+context. It returns files to touch, ordered steps, risks, test strategy, and
+parallelism hints. External dep missing → see "External blocker handling".
 
-### Phase 3: Implement + test
+**Fallback:** invoke `plan-ticket` inline. Same output, same context — acceptable
+here because planning is not adversarial.
+
+### Phase 3: Implement + test (→ `sdlc-executor`)
 
 1. Branch: `git checkout -b "$(tkt cfg vcs.branch_fmt --ticket "$KEY" --slug "<slug>")"`
-2. Implement per plan.
+2. Implement per plan. **Delegate to `sdlc-executor`**, which is scoped to the repo
+   worktree and cannot transition tickets or push. Fallback: implement inline.
 3. After each logical unit, run the configured toolchain:
 
    ```shell
@@ -156,7 +161,10 @@ Spike) → **invoke `complete-deliverable`, then stop**. The `full_sdlc` /
 
 ### Phase 4: Self-review (adversarial)
 
-**Invoke `self-review`** in a loop until clean.
+**Invoke `self-review`** in a loop until clean. Its review pass delegates to
+`sdlc-reviewer` (read-only, findings only) and its check pass to `sdlc-verifier`
+(PASS/FAIL with command output as evidence) — both fresh contexts that did not
+write the code.
 
 ### Phase 5: Open PR
 

--- a/skills/automated-sdlc/SKILL.md
+++ b/skills/automated-sdlc/SKILL.md
@@ -166,6 +166,20 @@ here because planning is not adversarial.
 (PASS/FAIL with command output as evidence) — both fresh contexts that did not
 write the code.
 
+### Phase 4.5: Adversarial QA (optional, → `qa-engineer`)
+
+Run when the change carries real failure risk — new endpoints, auth, money, data
+migrations, concurrency — or when Phase 4 flagged a test gap. Skip for docs-only
+and trivial changes; say which and why.
+
+**Delegate to `qa-engineer`**, which routes to the QA skills: `qa-strategy` (test
+plan from acceptance criteria), `qa-author` (adversarial tests, red-before-green),
+`qa-critique` (existing-suite assessment). See
+[docs/qa-suite-design.md](../../docs/qa-suite-design.md).
+
+A P0 finding sends the ticket back to Phase 3. **Fallback:** invoke `qa-author`
+inline against the modules Phase 4 flagged.
+
 ### Phase 5: Open PR
 
 **Invoke `open-pr`** — pushes, opens the PR, requests reviewers, and (for

--- a/skills/check-blockers/SKILL.md
+++ b/skills/check-blockers/SKILL.md
@@ -3,6 +3,7 @@ name: check-blockers
 description: 'Review tickets in the blocked lane, classify each blocker, and recommend unblock actions. Ad-hoc or standup-driven. Provider-agnostic via tkt.'
 model: claude-haiku-4-5
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Check Blockers

--- a/skills/ci-fix/SKILL.md
+++ b/skills/ci-fix/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-fix
 description: 'Monitor CI status on a PR, diagnose failures from logs, fix, and re-push. Loop until green. VCS via gh; build commands + ticket comments via tkt config.'
+model_tier: standard
 ---
 
 # CI Fix

--- a/skills/ci-fix/SKILL.md
+++ b/skills/ci-fix/SKILL.md
@@ -86,10 +86,27 @@ tkt comment "$KEY" "CI failing after 3 attempts on PR #$PR — needs human inves
 ### 9. Flaky tests
 
 Non-deterministic failure (passes locally, random timeout): `gh run rerun <run-id> --failed`
-**once**. If it fails again, treat as real.
+**once**. If it fails again on the same assertion but with a different value or
+timing, it is a flake, not a regression.
+
+Hand the root cause to **`qa-flake-triage`** rather than patching around it:
+
+```
+⚠️ FLAKE DETECTED: <test name> in <file>
+  - Failed with: <assertion/error>
+  - Passed on rerun: yes/no
+  → Recommend: invoke `qa-flake-triage` for root-cause classification and fix.
+```
+
+`ci-fix` must **not**: add `sleep()` or raise timeouts, skip or disable the test,
+or rerun more than once. Each of those turns a real race condition into a silent
+one. If the flake still blocks CI after one rerun, flag it and stop — the QA suite
+classifies the cause (race, shared state, clock sensitivity, test ordering) and
+proposes a real fix.
 
 ## Output
 
 - CI status: green / still failing
 - Fixes applied (commits)
+- Flake findings (handed to `qa-flake-triage`)
 - If stuck: the unresolved failure

--- a/skills/complete-deliverable/SKILL.md
+++ b/skills/complete-deliverable/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: complete-deliverable
 description: 'Short-circuit flow for non-PR ticket types (Task, Sub-task, Epic, Chore, Spike). Produces the deliverable, comments with the artifact link, logs lane time, and transitions straight to Done. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Complete Deliverable

--- a/skills/deploy-preview/SKILL.md
+++ b/skills/deploy-preview/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deploy-preview
 description: 'Confirm the preview environment for a PR, extract its URL, and post it back to the ticket and PR. Provider-agnostic ticketing via tkt; VCS via gh. URL extraction is project-specific.'
+model_tier: standard
 ---
 
 # Deploy Preview

--- a/skills/deploy-ready/SKILL.md
+++ b/skills/deploy-ready/SKILL.md
@@ -2,6 +2,7 @@
 name: deploy-ready
 description: 'Pick up tickets in the deploy_ready lane: annotate QA lane times, merge the PR, watch the staging workflow for the merge commit, gate manual production deploy, comment status. Provider-agnostic ticketing via tkt; VCS via gh.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Deploy Ready

--- a/skills/hotfix-revert/SKILL.md
+++ b/skills/hotfix-revert/SKILL.md
@@ -2,6 +2,7 @@
 name: hotfix-revert
 description: 'Revert a bad change in production, create a highest-priority hotfix ticket, and fast-track through PR → staging → prod with a single human signoff. Skips most automation gates. Provider-agnostic ticketing via tkt.'
 disable-model-invocation: true
+model_tier: standard
 ---
 
 # Hotfix Revert

--- a/skills/open-pr/SKILL.md
+++ b/skills/open-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: open-pr
 description: 'Commit changes, push the branch, open a PR, request reviewers, and transition the ticket to the review lane with lane-time annotation. Provider-agnostic ticketing via tkt; VCS via gh.'
+model_tier: standard
 ---
 
 # Open PR

--- a/skills/plan-ticket/SKILL.md
+++ b/skills/plan-ticket/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-ticket
 description: 'Analyze a triaged ticket and produce a structured implementation plan before coding begins. Provider-agnostic via tkt.'
+model_tier: deep
 ---
 
 # Plan Ticket

--- a/skills/qa-author/SKILL.md
+++ b/skills/qa-author/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: qa-author
+description: 'Write adversarial tests focused on failure modes, edge cases, and the Break-It Checklist. Produces test files — not essays. Enforces red-before-green rule.'
+model_tier: standard
+---
+
+# QA Author — Write Adversarial Tests
+
+Write tests that find where code breaks. Prioritize failure modes over happy
+paths. The developer already tested the happy path — we exist to find what they
+missed.
+
+## Input
+
+- File path or diff of the implementation under test
+- Optionally: a `TEST-PLAN.md` from `qa-strategy` (if available, implement its
+  test cases rather than re-deriving them)
+
+## Steps
+
+### 1. Read the implementation
+
+Read the file(s) being tested. Identify:
+- Public API surface (exports, endpoints, handlers)
+- Internal branching logic
+- External dependencies (DB, APIs, file system)
+- Error handling paths
+
+### 2. Read existing tests
+
+Find and read existing test files for the same module. Identify what's already
+covered to avoid duplication.
+
+### 3. Detect stack and load reference
+
+Check the file extension and import patterns, then load the appropriate reference
+for framework-specific testing patterns:
+
+| Pattern | Reference |
+| --- | --- |
+| `.ts` + `@nestjs/*` imports | `references/nestjs.md` |
+| `.tsx` + `react` imports | `references/react.md` |
+| `.go` files | `references/go.md` |
+| `.ts` + `aws-cdk-lib` imports | `references/cdk.md` |
+| `.ts` + `hx-` attributes in templates | `references/htmx-lambda.md` |
+
+If no reference matches, use the project's existing test conventions (infer from
+neighboring test files).
+
+### 4. Walk the Break-It Checklist
+
+For the implementation under test, enumerate failure scenarios:
+
+**Boundary Analysis**
+- 0, 1, n, n+1 for every numeric input
+- Empty array, empty string, empty object, null, undefined
+- Single-element collections
+- At configured limits, at integer overflow, at payload size limits
+- Negative numbers, negative indexes
+
+**Null / Undefined / Missing**
+- null vs undefined vs empty string
+- Missing key vs key-present-with-null-value
+- Optional chaining paths that produce undefined mid-chain
+- JSON.parse of responses that omit fields
+
+**Authorization**
+- User A reading/writing user B's resources
+- Horizontal and vertical privilege escalation
+- Resource enumeration via sequential IDs
+- Token expiry mid-operation
+
+**Concurrency**
+- Two writes, same row, same millisecond
+- Read-then-write races (TOCTOU)
+- Connection pool exhaustion
+
+**Idempotency & Retries**
+- Client sends request twice
+- Network timeout → retry → original succeeded
+- Partial retry after partial success
+
+**Partial Failure**
+- DB write succeeds, external API doesn't — state consistency
+- Multi-step transaction: step N fails — what's left behind
+
+**Time**
+- Timezone handling (UTC vs local)
+- DST transitions
+- Token/session expiry at exact boundary
+
+**Pagination & Ordering**
+- Unstable sort with ties
+- Cursor drift during writes
+- Page size = 0, page = -1, page beyond total
+
+**Encoding & Input**
+- Unicode (emoji, combining characters, zero-width joiners)
+- 10k-character inputs
+- Script injection in user-writable fields
+- Path traversal in filenames
+
+**Error Propagation**
+- Error messages don't leak internals
+- Correct HTTP status codes
+- Error response matches documented schema
+
+### 5. Write tests
+
+Write test files following the project's conventions:
+- Group: unit → integration → e2e
+- Each test has a descriptive name stating the scenario and expected outcome
+- Assertions are specific — never `toBeDefined()` alone
+- Tests are isolated — no shared mutable state between tests
+
+### 6. Verify red-before-green (mandatory)
+
+**A new test MUST fail first against the unfixed/unmocked code path it exercises.**
+
+For each test written:
+1. Identify what makes it fail (the bug or missing behavior it catches)
+2. Document how to verify the red state
+3. If a test passes immediately, investigate:
+   - The bug doesn't exist → remove the test
+   - The test doesn't exercise the failure path → fix the test
+   - The assertion is too weak → strengthen it
+
+## Forbidden Cheats
+
+These are explicitly forbidden. Violation means the test is worthless:
+
+| Cheat | Why forbidden |
+| --- | --- |
+| `.skip()` or delete a failing test | Deleting evidence is not fixing |
+| Weaken assertion to match wrong output | You encoded the bug as a spec |
+| `sleep(5000)` to paper over a flake | Hidden race condition behind a prayer |
+| Mock the unit under test | You're testing your mock, not your code |
+| `expect(result).toBeDefined()` alone | Proves nothing except it didn't throw |
+| Catch-all try/catch that swallows errors | Makes the test unfailable |
+| Test that passes regardless of implementation | Tautological — delete it |
+
+## Output
+
+Test files in the project's testing convention. No essays — working test code.
+
+Each file includes a header comment:
+
+```
+// QA Author — adversarial tests
+// Break-It dimensions covered: [list]
+// See TEST-PLAN.md TC-X.Y for requirements mapping (if applicable)
+```
+
+## Guardrails
+
+- **Write only test files.** Only create/modify files matching `**/*.test.*`,
+  `**/*.spec.*`, `**/__tests__/**`, or `**/test/**`.
+- **Never modify implementation code.** If the implementation is buggy, write a
+  test that proves it — don't fix the bug.
+- **Never transition tickets.** No `tkt transition`, `tkt comment`,
+  or `tkt create`.
+- **Never commit or push.** Write files only. The user/executor reviews and commits.
+- **No git mutations.** Never `git commit`, `git push`, `git add`.

--- a/skills/qa-bug-report/SKILL.md
+++ b/skills/qa-bug-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: qa-bug-report
+description: 'Produce a structured bug report with minimal reproduction steps from a failing scenario. Optionally creates a ticket via tkt create.'
+model_tier: cheap
+---
+
+# QA Bug Report — Structured Reproduction
+
+Produce a structured, actionable bug report from a failing scenario. Distills
+test output, error logs, or user reports into minimal reproduction steps with
+clear expected/actual behavior.
+
+## Input
+
+- A failing scenario: test output, error log, user report, or observed behavior
+- Optionally: the code path involved
+
+## Steps
+
+### 1. Identify the failure
+
+From the input, extract:
+- What operation was attempted
+- What went wrong (error message, wrong output, crash, hang)
+- Under what conditions (specific inputs, timing, environment)
+
+### 2. Determine minimal reproduction steps
+
+Strip away everything that isn't required to trigger the failure:
+- What's the minimum setup?
+- What's the fewest steps to reproduce?
+- Can it be triggered from a test? From a curl command? From the UI?
+
+### 3. Classify severity
+
+| Severity | Criteria |
+| --- | --- |
+| **Critical** | Data loss, security breach, complete service outage |
+| **High** | Core feature broken, no workaround, affects many users |
+| **Medium** | Feature degraded, workaround exists, affects some users |
+| **Low** | Cosmetic, rare edge case, minimal user impact |
+
+### 4. Classify reproducibility
+
+| Reproducibility | Meaning |
+| --- | --- |
+| **Always** | Reproduces 100% of the time with given steps |
+| **Often** | Reproduces >50% of attempts |
+| **Intermittent** | Reproduces <50% — timing/state dependent |
+| **Rare** | Hard to reproduce — specific conditions required |
+
+### 5. Identify suspected root cause
+
+From reading the code path and error:
+- What function/module is likely at fault?
+- Is this a logic error, data issue, race condition, or configuration problem?
+- What would a fix likely involve?
+
+### 6. Format the report
+
+## Output
+
+```markdown
+## Bug Report
+
+**Summary:** <one-line description of the bug>
+**Severity:** Critical / High / Medium / Low
+**Component:** <package/module/service>
+**Reproducibility:** Always / Often / Intermittent / Rare
+
+### Steps to Reproduce
+1. <precondition or setup>
+2. <action>
+3. <action>
+4. Observe: <what goes wrong>
+
+### Expected Behavior
+<what should happen>
+
+### Actual Behavior
+<what actually happens, including error messages>
+
+### Environment
+- Branch: <branch name>
+- Commit: <short sha>
+- OS/Runtime: <if relevant>
+- Relevant config: <if relevant>
+
+### Evidence
+```
+<error log, stack trace, or test output — trimmed to relevant portion>
+```
+
+### Root Cause (suspected)
+<brief analysis of what's likely wrong>
+
+### Suggested Fix
+<what the fix would involve, if known>
+
+### Regression?
+- [ ] Yes — worked in <commit/version>, broken since <commit/version>
+- [ ] No — appears to be a pre-existing issue
+- [ ] Unknown — needs bisection
+```
+
+### 7. Optional: Create ticket
+
+If the user confirms, create a ticket:
+
+```shell
+tkt create \
+  --type Bug \
+  --summary "<one-line summary>" \
+  --description "<full report body>" \
+  --priority "<severity-mapped-priority>"
+```
+
+Do NOT create the ticket automatically — always ask first.
+
+## Guardrails
+
+- **Read-only by default.** Only create tickets when explicitly confirmed by user.
+- **No code modifications.** Document the bug, don't fix it.
+- **No ticket transitions.** Never `tkt transition` on existing tickets.
+- **No git mutations.** Never commit or push.
+- **Minimal, precise reports.** Every field must be specific and actionable.
+  "Something is broken" is not a bug report.
+- **No speculation without marking it.** If the root cause is uncertain, say
+  "suspected" — don't present guesses as facts.

--- a/skills/qa-critique/SKILL.md
+++ b/skills/qa-critique/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: qa-critique
+description: 'Evaluate existing test suite quality: coverage gaps, assertion strength, false confidence detection, Break-It Checklist compliance. Produces a scored assessment.'
+model_tier: deep
+---
+
+# QA Critique — Test Suite Quality Assessment
+
+Evaluate an existing test suite for adequacy. Finds coverage gaps, weak
+assertions, false confidence, and missing adversarial scenarios. Produces a
+scored assessment with prioritized recommendations.
+
+This skill does NOT write tests — it identifies what's missing so `qa-author`
+can fill the gaps.
+
+## Input
+
+- Test file paths (or a diff containing test changes)
+- Optionally: the implementation files they test
+
+## Steps
+
+### 1. Read the test files
+
+Read all test files in scope. Understand:
+- What modules/functions are under test
+- What scenarios are exercised
+- What assertions are made
+- How tests are structured (setup/teardown, isolation)
+
+### 2. Read the implementation under test
+
+Read the implementation code. Identify:
+- All branches and code paths
+- External dependencies and failure modes
+- Authorization checks (or their absence)
+- Error handling paths
+- Edge cases in business logic
+
+### 3. Evaluate coverage gaps
+
+For each public function / endpoint / handler in the implementation:
+- Is it tested at all?
+- Which branches have no test?
+- Which error paths are unexercised?
+
+### 4. Evaluate assertion quality
+
+For each assertion in the test suite:
+
+| Quality level | Example | Verdict |
+| --- | --- | --- |
+| **Strong** | `expect(result.amount).toBe(150.00)` | Good |
+| **Adequate** | `expect(result).toMatchObject({...})` | Acceptable |
+| **Weak** | `expect(result).toBeDefined()` | Flag |
+| **Meaningless** | `expect(true).toBe(true)` | Critical flag |
+| **Tautological** | Tests that pass regardless of implementation | Critical flag |
+
+### 5. Detect false confidence
+
+Tests that give a feeling of safety without providing it:
+
+- **Mock-heavy tests:** If the mock covers 80% of the code path, you're testing
+  the remaining 20% plus your mock setup. The integration gap is where bugs hide.
+- **Overly specific mocks:** Mock returns exactly what the code expects — proves
+  only that the code works when given perfect inputs.
+- **Assertion on mock calls only:** Verifying a function was called doesn't verify
+  the *result* is correct.
+- **Try/catch swallowing:** Test catches errors without asserting on them.
+
+### 6. Walk the Break-It Checklist
+
+Check which dimensions from the checklist are exercised:
+
+| Dimension | Exercised? | Missing scenarios |
+| --- | --- | --- |
+| Boundary (0, 1, n, n+1, max, negative, empty) | | |
+| Null / Undefined / Missing | | |
+| Authorization (horizontal, vertical, expiry) | | |
+| Concurrency (races, TOCTOU, pool exhaustion) | | |
+| Idempotency (double-submit, retry) | | |
+| Partial failure (DB + API mismatch) | | |
+| Time (timezone, DST, expiry boundary) | | |
+| Pagination (unstable sort, cursor drift) | | |
+| Encoding (unicode, injection, path traversal) | | |
+| Performance (N+1, unbounded, missing index) | | |
+| Error propagation (safe messages, correct codes) | | |
+
+### 7. Evaluate test isolation
+
+- Shared mutable state between tests?
+- Test ordering dependencies?
+- Global setup that hides individual test requirements?
+- Tests that only pass when run in a specific order?
+
+### 8. Evaluate maintenance burden
+
+- Overly brittle tests that break on refactors (testing implementation details)?
+- Snapshot tests without targeted assertions?
+- Deep mock hierarchies that mirror implementation structure?
+
+### 9. Score and produce report
+
+Score on a 1–10 scale:
+
+| Score | Meaning |
+| --- | --- |
+| 9–10 | Adversarial-quality suite, covers failure modes |
+| 7–8 | Good coverage, some gaps in edge cases |
+| 5–6 | Happy-path coverage, missing adversarial scenarios |
+| 3–4 | Sparse, weak assertions, significant gaps |
+| 1–2 | Cosmetic tests only, false confidence |
+
+## Output
+
+```markdown
+# Test Suite Critique — <file/module>
+
+## Score: N/10
+
+## Coverage Gaps (Critical)
+- [ ] <missing test scenario>
+- [ ] <untested branch/path>
+
+## Weak Assertions
+- `<file>:<line>` — <what's wrong with the assertion>
+
+## False Confidence
+- `<file>:<line>` — <why this test provides false safety>
+
+## Missing from Break-It Checklist
+- [ ] <dimension>: <specific missing scenario>
+
+## Test Isolation Issues
+- <shared state, ordering dependencies>
+
+## Maintenance Concerns
+- <brittle tests, over-mocking>
+
+## Recommendations (prioritized)
+1. (P0) <critical gap to fill>
+2. (P0) <security test to add>
+3. (P1) <important edge case>
+4. (P2) <nice-to-have improvement>
+
+## Dimensions Assessed
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Boundary | Partial | Missing n+1 for pagination |
+| Authorization | None | No authz tests at all |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only.** Do not modify any files.
+- **No ticket operations.** Never `tkt transition`, `tkt comment`,
+  `tkt create`.
+- **No git mutations.** Never commit, push, or modify history.
+- **Concrete over vague.** Every finding must reference a specific file:line and
+  explain what's wrong and what should be there instead.
+- **No false positives from ignorance.** If you can't determine whether a test is
+  adequate without reading more context, say so rather than guessing.

--- a/skills/qa-flake-triage/SKILL.md
+++ b/skills/qa-flake-triage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: qa-flake-triage
+description: 'Classify flaky test root causes and recommend fixes. Never papers over flakes with sleep or skip — finds the actual race condition, shared state, or timing issue.'
+model_tier: standard
+---
+
+# QA Flake Triage — Flaky Test Root-Cause Classification
+
+Diagnose non-deterministic test failures. Classify the flake, identify root cause,
+and propose a real fix — never `sleep()`, never `.skip()`.
+
+## Input
+
+- Test file path
+- Failure logs (from CI or local — `gh run view <id> --log-failed` if available)
+- Optionally: recent CI history showing the pattern
+
+## Steps
+
+### 1. Read the failing test
+
+Read the test code. Understand:
+- What it exercises
+- What assertions it makes
+- What setup/teardown it performs
+- What external resources it touches
+
+### 2. Read failure logs
+
+Gather evidence:
+- Error messages and stack traces
+- Timing information (how long did it take?)
+- Which specific assertion failed?
+- What was the actual vs expected value?
+
+If CI history is available:
+
+```shell
+# Recent runs of this test
+gh run list --workflow=<workflow> --limit=20 --json conclusion,startedAt,databaseId
+```
+
+### 3. Classify the flake
+
+| Class | Indicators | Root cause |
+| --- | --- | --- |
+| **Race condition** | Passes with delay, fails under load; timing-dependent assertions; async operations without proper synchronization | Missing await, no mutex, optimistic read |
+| **Shared state** | Fails only when run after specific other test; passes in isolation (`-run TestX`); order-dependent | Tests mutating shared DB/file/global without cleanup |
+| **Non-deterministic ordering** | Sorted assertions fail on ties; map iteration order; DB results without ORDER BY | Unstable sort, relying on insertion order |
+| **Clock sensitivity** | Fails near midnight, DST transitions, or second boundaries; token expiry assertions | Using `Date.now()` / `time.Now()` without mocking |
+| **External dependency** | Fails when network/service is slow or unavailable; timeout errors; connection refused | Real HTTP calls in tests, no retry/circuit-breaker |
+| **Resource exhaustion** | Fails later in the suite; connection pool errors; "too many open files" | Leaked connections, file handles, goroutines |
+| **Platform-specific** | Fails on CI but not local (or vice versa); OS, locale, timezone differences | Hardcoded paths, locale assumptions, Docker differences |
+
+### 4. Gather supporting evidence
+
+For the classified category, look for corroborating signals:
+
+**Race condition:**
+- Are there `async` operations without `await`?
+- Is there shared mutable state accessed from multiple execution paths?
+- Does the test use `setTimeout`/`time.Sleep` for synchronization?
+
+**Shared state:**
+- Is there a `beforeAll` without corresponding `afterAll` cleanup?
+- Do tests share a database table without per-test transactions?
+- Are there global variables mutated in tests?
+
+**Non-deterministic ordering:**
+- Does the assertion use strict equality on an array?
+- Is the data source a Map/object with non-guaranteed key order?
+- Is the DB query missing `ORDER BY`?
+
+**Clock sensitivity:**
+- Does the test compare timestamps with exact equality?
+- Is there a "created X seconds ago" assertion?
+- Does the test rely on `Date.now()` being stable across execution?
+
+**External dependency:**
+- Are there real HTTP calls (not mocked)?
+- Is there a database/service startup race on CI?
+- Are there DNS lookups that could timeout?
+
+**Resource exhaustion:**
+- Is the test suite run with connection pool limits?
+- Are streams/readers properly closed in tests?
+- Does `go test -race` detect goroutine leaks?
+
+**Platform-specific:**
+- Are file paths hardcoded with `/` or `\`?
+- Does the test assume a specific timezone?
+- Are there locale-dependent string comparisons?
+
+### 5. Propose a fix
+
+The fix must be a **real solution**, not a workaround:
+
+| Class | Correct fix | FORBIDDEN fix |
+| --- | --- | --- |
+| Race condition | Add proper synchronization (mutex, channel, await) | `sleep(5000)` |
+| Shared state | Per-test isolation (transaction, temp dir, fresh instance) | Running tests sequentially |
+| Non-deterministic ordering | Remove order dependency from assertion, add stable sort | `.skip()` |
+| Clock sensitivity | Mock time, use relative comparisons | Widening tolerance to minutes |
+| External dependency | Mock the external service, use test containers | Adding retry loops with backoff |
+| Resource exhaustion | Fix the leak (close connections, cancel contexts) | Increasing pool size |
+| Platform-specific | Use path.join, normalize TZ, use t.TempDir() | Skipping on specific platforms |
+
+### 6. Confidence assessment
+
+| Level | Meaning |
+| --- | --- |
+| **High** | Root cause identified with strong evidence (reproducer exists) |
+| **Medium** | Classification is likely, evidence is circumstantial |
+| **Low** | Multiple possible causes, need more data to confirm |
+
+## Output
+
+```markdown
+# Flake Triage — <test name>
+
+## Classification: <class>
+**Confidence:** High / Medium / Low
+
+## Evidence
+- <observation 1>
+- <observation 2>
+- <CI history pattern>
+
+## Root Cause
+<explanation of why this test is non-deterministic>
+
+## Proposed Fix
+```<language>
+// Before (flaky)
+<current code>
+
+// After (stable)
+<fixed code>
+```
+
+## Verification
+- Run `<command>` N times to confirm stability
+- Expected: 0 failures in N runs
+
+## If Fix Doesn't Work
+- Alternative hypothesis: <other possible cause>
+- Additional investigation: <what to check next>
+```
+
+## Guardrails
+
+- **Never paper over the flake.** `sleep()`, `.skip()`, widening tolerances,
+  increasing timeouts — all forbidden. These hide the problem.
+- **Never weaken assertions.** If the assertion is correct, the code or test
+  setup is wrong — fix that.
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only.
+- **May modify test files.** This skill can write fixes to test files (same
+  scope as `qa-author`: `**/*.test.*`, `**/*.spec.*`, `**/__tests__/**`,
+  `**/test/**`).
+- **Never modify implementation code.** If the implementation has a race
+  condition, document it and recommend a fix — don't apply it.
+- **No git mutations.** Never commit or push.

--- a/skills/qa-strategy/SKILL.md
+++ b/skills/qa-strategy/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: qa-strategy
+description: 'Generate a structured test plan from ticket requirements or a spec document. Maps acceptance criteria to test cases with priority, risk analysis, and coverage gaps. Provider-agnostic via tkt.'
+model_tier: deep
+---
+
+# QA Strategy — Test Plan from Spec
+
+Produce a structured test plan that maps requirements to concrete test cases.
+Prioritizes failure modes over happy paths. Operates under the assumption that
+the code is wrong until proven otherwise.
+
+This skill does NOT write test files — it produces the plan that `qa-author`
+executes against.
+
+## Input
+
+- Ticket key (`$KEY`) — requirements read via `tkt view "$KEY" --json`
+- OR a spec/requirements document path
+
+## Steps
+
+### 1. Extract acceptance criteria
+
+```shell
+tkt view "$KEY" --json | jq -r '.acceptance[]'
+```
+
+If input is a document rather than a ticket, extract testable assertions from
+the spec text.
+
+### 2. Walk the Break-It Checklist per criterion
+
+For each acceptance criterion, enumerate test cases across these dimensions:
+
+| Dimension | What to enumerate |
+| --- | --- |
+| **Boundary** | 0, 1, n, n+1, max, negative, empty, single-element |
+| **Null/Missing** | null vs undefined vs empty, missing keys, optional chaining traps |
+| **Authorization** | Horizontal escalation, vertical escalation, token expiry, resource enumeration |
+| **Concurrency** | Two writes same row, TOCTOU, pool exhaustion, deadlocks |
+| **Idempotency** | Double-submit, retry after timeout, partial retry |
+| **Partial failure** | DB write + API call mismatch, multi-step rollback |
+| **Time** | Timezones, DST, clock skew, expiry at boundary |
+| **Pagination** | Unstable sort, cursor drift, page=0, page beyond total |
+| **Encoding** | Unicode, RTL, 10k-char inputs, injection, path traversal, null bytes |
+| **Performance** | N+1 queries, over-fetching, unbounded loops, missing indexes |
+| **Error propagation** | Safe error messages, correct status codes, retry-after headers |
+
+Not every dimension applies to every criterion. Skip irrelevant ones — but
+explicitly state which were considered and dismissed.
+
+### 3. Assign priority
+
+| Priority | Meaning |
+| --- | --- |
+| P0 | Blocks release — security, data loss, core functionality broken |
+| P1 | Should fix before ship — important edge cases, degraded UX |
+| P2 | Nice to have — unlikely scenarios, cosmetic |
+
+### 4. Flag untested and untestable requirements
+
+- **Untested:** Acceptance criterion with no test case mapped to it
+- **Untestable:** Vague, subjective, or missing definition of done (e.g. "should
+  feel fast" — recommend: define latency SLO)
+
+### 5. Produce risk table
+
+For each identified risk:
+- What can break
+- Severity (Critical / High / Medium / Low)
+- Likelihood (High / Medium / Low)
+- Mitigation (what the implementation should do)
+
+### 6. Optional: BDD output
+
+If BDD is configured (`tkt cfg build.bdd` resolves without error), produce
+`.feature` files in Gherkin format alongside `TEST-PLAN.md`.
+
+## Output
+
+`TEST-PLAN.md` in the following structure:
+
+```markdown
+# Test Plan — <KEY>: <summary>
+
+## Requirements Coverage Matrix
+
+| # | Requirement (from AC) | Test cases | Priority | Status |
+|---|---|---|---|---|
+| 1 | <requirement text> | TC-1.1, TC-1.2, TC-1.3 | P0 | Planned |
+
+## Test Cases
+
+### TC-1.1: <descriptive name>
+- **Type:** Unit / Integration / E2E
+- **Priority:** P0 / P1 / P2
+- **Dimension:** Boundary / Auth / Concurrency / ...
+- **Preconditions:** ...
+- **Steps:** ...
+- **Expected:** ...
+- **Red-before-green:** How to verify this fails against buggy code
+
+### TC-1.2: ...
+
+## Untested Requirements
+- AC #N (<text>) — <reason it has no test>
+
+## Untestable Requirements
+- AC #N (<text>) — <why it's untestable> — <recommendation>
+
+## Risk Table
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| <what can break> | Critical | Medium | <what to do> |
+
+## Checklist Dimensions Considered
+
+| Dimension | Applicable | Test cases |
+|---|---|---|
+| Boundary | Yes | TC-1.2, TC-1.3 |
+| Authorization | No (no user-facing auth in this feature) | — |
+| ... | ... | ... |
+```
+
+## Guardrails
+
+- **Read-only ticketing.** Use `tkt view` and `tkt cfg` only. Never
+  transition, comment, or create tickets.
+- **No code changes.** This skill produces a plan document, not code.
+- **No happy-path padding.** Do not enumerate obvious happy-path tests that any
+  developer would write. Focus on what they'll miss.
+- **Concrete over vague.** Every test case must have specific inputs and expected
+  outputs. "Test that it handles errors" is not a test case.

--- a/skills/respond-to-review/SKILL.md
+++ b/skills/respond-to-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: respond-to-review
 description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+model_tier: standard
 ---
 
 # Respond to Review

--- a/skills/respond-to-review/SKILL.md
+++ b/skills/respond-to-review/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: respond-to-review
-description: 'Read PR review comments, address each with code changes or replies, push fixes, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
+description: 'Read PR review comments, address each with code changes or replies, push fixes, auto-resolve addressed threads with fix summaries, loop until approved. VCS via gh; ticketing (revise/review transitions + lane time) via tkt.'
 model_tier: standard
 ---
 
 # Respond to Review
 
-Read PR review comments (bot + human), address each, push fixes, loop until
-approved. Git host via `gh`; all ticketing via `tkt`. Repo/reviewers from
-`.sdlc/config.toml`.
+Read PR review comments (bot + human), address each, push fixes, auto-resolve the
+threads you actually addressed, loop until approved. Git host via `gh`; all
+ticketing via `tkt`. Repo/reviewers from `.sdlc/config.toml`.
 
 ## Input
 
@@ -53,7 +53,9 @@ gh api --paginate "repos/$OWNER/$NAME/pulls/$PR/comments?per_page=100" \
 Identify automated-reviewer comments by `user.login` (e.g. `*copilot*[bot]`, or
 whatever your `vcs.reviewers` lists). Track unresolved ones separately.
 
-Resolved-thread state (paginate via `pageInfo.hasNextPage`):
+Thread state — fetch thread IDs, resolution status, file path, and comment bodies
+(paginate via `pageInfo.hasNextPage`). The thread ID and path are what step 6 needs
+to resolve, so collect them now:
 
 ```shell
 CURSOR=null
@@ -63,7 +65,12 @@ while : ; do
       repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
         reviewThreads(first:100, after:$after) {
           pageInfo { hasNextPage endCursor }
-          nodes { id isResolved comments(first:1){ nodes { author{login} body } } }
+          nodes {
+            id isResolved path line
+            comments(first:100) {
+              nodes { id databaseId author{login} body }
+            }
+          }
         } } } }' \
     -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CURSOR")
   echo "$RESP" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
@@ -72,21 +79,28 @@ while : ; do
 done
 ```
 
+Build a mapping of unresolved threads:
+`thread_id → {path, line, comment_id, body, author}`. Step 6 drives resolution off
+it, so a thread you can't map is a thread you must not resolve.
+
 ### 2. Categorize each comment
 
 Change request → make the change. Question → reply. Suggestion → apply if valid,
 else explain. Nit → apply. Blocker → must fix. Out of scope → acknowledge, create
 a follow-up with `tkt create` if warranted.
 
+Record the outcome per thread — this decides what gets resolved:
+
+- `addressed` — change fully implemented (**will** resolve)
+- `question` — answered (**will** resolve after reply)
+- `partial` — change only partly implemented (will **not** resolve)
+- `skipped` — out of scope, won't-fix, or ambiguous (will **not** resolve)
+
 ### 3. Address change requests
 
-For each: make the change, verify it builds/tests (`tkt cfg build.*`), reply on the
-thread:
-
-```shell
-gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
-  -f body="Fixed in <sha>. <brief explanation>"
-```
+For each `addressed` thread: make the code change and verify it builds/tests
+(`tkt cfg build.*`). **Do not reply yet** — fix-summary replies cite the commit
+SHA, which doesn't exist until step 5.
 
 ### 4. Reply to questions
 
@@ -98,9 +112,76 @@ gh pr comment "$PR" --repo "$REPO" --body "Re: <question> — <answer>"
 
 ```shell
 git add -A && git commit -m "fix(<scope>): address review feedback" && git push
+SHA=$(git rev-parse --short HEAD)
 ```
 
-### 6. Re-request review + move back to review lane
+### 6. Resolve addressed threads + post fix summaries
+
+For each thread categorized `addressed` or `question`:
+
+1. **Verify the fix is actually in the diff.** A thread whose file was never
+   touched must not be marked resolved:
+
+   ```shell
+   git diff --name-only HEAD~1 HEAD | grep -Fxq "<path>"
+   ```
+
+   Not in the diff → re-categorize as `partial` and skip.
+
+2. **Post a fix-summary reply** on the thread:
+
+   ```shell
+   gh api "repos/$OWNER/$NAME/pulls/$PR/comments/<comment-id>/replies" \
+     -f body="Fixed in \`$SHA\`: updated \`<file>\` — <one-line change summary>"
+   ```
+
+   Questions were already answered in step 4; go straight to resolving.
+
+3. **Resolve the thread:**
+
+   ```shell
+   gh api graphql -f query='
+     mutation($threadId: ID!) {
+       resolveReviewThread(input: {threadId: $threadId}) {
+         thread { id isResolved }
+       }
+     }' -F threadId="$THREAD_ID"
+   ```
+
+4. **Accumulate a resolution log entry** for step 7:
+
+   ```
+   • [`<file>:<line>`](https://github.com/$OWNER/$NAME/blob/$SHA/<file>#L<line>): <summary>
+   ```
+
+**Never resolve when:** the fix is partial; the comment is ambiguous and needs
+reviewer confirmation; the thread bundles several requests and only some are done;
+or the path isn't in the commit diff. Leave those threads open **without** a
+fix-summary reply — a summary on an unresolved thread misleads the reviewer.
+
+### 7. Post the consolidated resolution log
+
+One PR comment as the audit trail:
+
+```shell
+BODY="## Review thread resolution
+
+**Commit:** \`$SHA\`
+**Resolved:** $RESOLVED_COUNT thread(s)
+**Left open:** $OPEN_COUNT thread(s)
+
+### Resolved
+$(printf '%s\n' "${RESOLVED_LOG[@]}")
+
+### Left open (needs reviewer)
+$(printf '%s\n' "${OPEN_LOG[@]}")"
+
+gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+```
+
+Each resolved entry links its file path to the line in the pushed commit.
+
+### 8. Re-request review + move back to review lane
 
 ```shell
 for R in $(tkt cfg vcs.reviewers --json | jq -r '.[]'); do
@@ -111,10 +192,11 @@ WL=$(tkt worklog "$KEY" --from-role in_progress --note "Revise cycle — fixes p
 tkt transition "$KEY" review
 tkt edit "$KEY" --agent-status waiting
 tkt comment "$KEY" "Pushed fixes, re-requested review. Time in In Progress (revise cycle): \
-$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
+$(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id)). \
+Resolved $RESOLVED_COUNT review thread(s); $OPEN_COUNT left open for the reviewer."
 ```
 
-### 7. Loop until clean
+### 9. Loop until clean
 
 Re-fetch after each push. Exit only when **all** hold:
 
@@ -125,7 +207,7 @@ Re-fetch after each push. Exit only when **all** hold:
 Cap at **5** cycles. If a bot repeats the same nit after 2 attempts, reply with a
 one-line "won't fix" justification and resolve the thread.
 
-### 8. If stuck after 5 cycles
+### 10. If stuck after 5 cycles
 
 ```shell
 gh pr comment "$PR" --repo "$REPO" --body "5 review cycles complete. Remaining items need human judgment — requesting sync review."
@@ -137,7 +219,7 @@ Time in review so far: $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -
 (`$KEY` is the ticket; `$PR` is the PR number — unrelated. Always pass `$PR`
 explicitly to `gh pr comment`.)
 
-### 9. On loop exit, annotate review lane time
+### 11. On loop exit, annotate review lane time
 
 ```shell
 WL=$(tkt worklog "$KEY" --from-role review --note "Review loop complete. Cycles: <N>" --json)
@@ -149,4 +231,5 @@ $(echo "$WL" | jq -r .human) (worklog $(echo "$WL" | jq -r .worklog_id))."
 
 - Review status: approved / changes requested / stuck
 - Comments addressed (count)
+- Threads resolved vs. left open (count)
 - Outstanding items

--- a/skills/resume-from-revise/SKILL.md
+++ b/skills/resume-from-revise/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resume-from-revise
 description: 'Resume the SDLC after a human dev fixed a revise-state ticket. Annotates revise time, re-runs CI/review automation, promotes back to qa_ready. Provider-agnostic via tkt.'
+model_tier: standard
 ---
 
 # Resume From Revise

--- a/skills/select-ticket/SKILL.md
+++ b/skills/select-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: select-ticket
 description: 'Discover and select the next ticket to work on, respecting priority, assignee, and blockers. Provider-agnostic via tkt. Auto-selects when the candidate is unambiguous; otherwise returns recommendations for human pick.'
 allowed-tools: [Bash, Read]
+model_tier: cheap
 ---
 
 # Select Ticket

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -18,7 +18,15 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
-### 2. Review as adversary
+### 2. Review as adversary (→ `sdlc-reviewer`)
+
+**Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The
+point is separation: the reviewer is a fresh context that did not write the code,
+so it judges the evidence rather than recalling the intent.
+
+**Fallback** (no subagent support): run this pass yourself, but explicitly — re-read
+the diff from scratch and argue against it before approving. Pretend it is a
+stranger's PR. Do not rubber-stamp your own code.
 
 Hostile-reviewer mindset. Check every changed file for:
 
@@ -39,13 +47,22 @@ project's own conventions doc — read them and apply.
 ### 3. List findings
 
 Per issue: file+line, severity (**blocker** / **warning** / **nit**), description,
-suggested fix.
+suggested fix. Plus an overall verdict — PASS (zero blockers, zero warnings) skips
+straight to the final check.
+
+The reviewer produces findings only; the author context fixes them in step 4.
 
 ### 4. Fix blockers and warnings
 
 Fix all blocker + warning items. Don't skip.
 
-### 5. Rebuild and re-test (config toolchain)
+### 5. Rebuild and re-test (→ `sdlc-verifier`)
+
+**Delegate to `sdlc-verifier`**, which runs the configured checks and returns a
+binary PASS/FAIL with the exact commands and their output as evidence. It never
+fixes anything — a FAIL comes back here.
+
+**Fallback:** run them yourself.
 
 ```shell
 eval "$(tkt cfg build.build --pkg "<pkg>")"

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -70,6 +70,25 @@ eval "$(tkt cfg build.test --pkg "<pkg>")"
 eval "$(tkt cfg build.typecheck)"
 ```
 
+### 5b. Run behavior specs — non-blocking (if configured)
+
+If the repo binds a behavior-spec runner, run it as a **reported, non-blocking**
+signal, mirroring the non-strict BDD posture: pending scenarios inform the author
+but never block the flow. Skip cleanly when `build.bdd` is unset. See
+[docs/behavior-specs.md](../../docs/behavior-specs.md).
+
+```shell
+# Only a missing key (tkt cfg exit 4 = NotFoundError) is a clean skip.
+# Surface any other failure (e.g. exit 2 = bad/missing config) instead of
+# silently swallowing it. On success stderr is empty, so 2>&1 is safe to eval.
+out="$(tkt cfg build.bdd --pkg "<pkg>" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+  eval "$out" || echo "bdd: behavior-spec runner exited non-zero (non-blocking)"
+elif [ "$rc" -ne 4 ]; then
+  echo "bdd: could not resolve build.bdd (tkt cfg exit $rc): $out" >&2
+fi
+```
+
 ### 6. Loop
 
 Repeat until a pass yields **zero blockers and zero warnings**. Max 3 passes; if

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -56,6 +56,19 @@ The reviewer produces findings only; the author context fixes them in step 4.
 
 Fix all blocker + warning items. Don't skip.
 
+**Test gaps are not fixed here.** If the reviewer flags "new code without tests" or
+"tests that assert nothing meaningful," do **not** write tests inline — a fix-pass
+test written to close a finding tends to assert whatever the code already does.
+Note the gap and hand it to `qa-author` (or the `qa-engineer` agent) after this
+loop completes, which writes adversarial tests with red-before-green verification.
+
+Format the flag as:
+
+```
+⚠️ TEST GAP: <file:line> — <description>
+→ Recommend: invoke `qa-author` targeting <file/module> after self-review passes.
+```
+
 ### 5. Rebuild and re-test (→ `sdlc-verifier`)
 
 **Delegate to `sdlc-verifier`**, which runs the configured checks and returns a

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-review
 description: 'Adversarial self-review of changes before PR. Reviews diff, finds issues, fixes them, loops until clean. Build commands via tkt config; no ticketing.'
+model_tier: standard
 ---
 
 # Self-Review

--- a/skills/sync-skills/SKILL.md
+++ b/skills/sync-skills/SKILL.md
@@ -60,6 +60,8 @@ policy change.
 | `.continue/rules/*.md` | YAML + MD (`globs:`) | Continue.dev |
 | `.augment/rules/*.md` | YAML + MD (`type:`) | Augment Code |
 | `.agents/rules/*.md` | YAML + MD (`trigger:`) | Antigravity |
+| `.kiro/steering/*.md` | Steering MD (optional YAML frontmatter) | AWS Kiro |
+| `.kiro/agents/*.md` + `*.json` | Kiro sub-agent definitions (IDE reads MD, CLI reads JSON) | AWS Kiro |
 
 Root `AGENTS.md` is the universal fallback. Sub-`AGENTS.md` cascading is honored by
 Codex, Kilo, Amp, Factory, and Windsurf; other tools fall back gracefully to root.
@@ -199,6 +201,68 @@ e.g. `!git status --short`.>
 
 Markdown body is the prompt template. Optional frontmatter keys: `agent`, `model`,
 `subtask`. Guardrails are enforced separately by project config — not per-command.
+
+### 9. Kiro Steering (`.kiro/steering/*.md`)
+
+Project-wide conventions. Three inclusion modes control when a file loads:
+
+```markdown
+# always (the default — no frontmatter needed)
+```
+
+```markdown
+---
+inclusion: fileMatch
+fileMatchPattern: '.sdlc/config.toml'
+---
+```
+
+```markdown
+---
+inclusion: manual        # opt in from chat via a # context key
+---
+```
+
+Steering supports `#[[file:<relative_path>]]` to pull in another file by reference
+instead of duplicating it.
+
+**Kiro does not read `AGENTS.md`** — steering is its only project-convention
+surface. `tech.md` bridges that gap: an always-included file whose entire job is
+`#[[file:../../AGENTS.md]]`, so Kiro sees the same rules as every other harness
+with nothing duplicated to drift.
+
+| File | Inclusion | Purpose |
+|------|-----------|---------|
+| `tech.md` | always | Pulls the repo's `AGENTS.md` in by reference |
+| `tkt.md` | always | Core portability rules + verb contract |
+| `sdlc-config.md` | fileMatch (`.sdlc/config.toml`) | Config schema reference |
+| `ticket-workflow.md` | manual | Ticket lifecycle, lane-time, decision points |
+
+### 10. Kiro Agent (`.kiro/agents/<name>.md` + `<name>.json`)
+
+Generated from the canonical `agents/<name>.md`. The `.md` mirrors the source; the
+`.json` is what `kiro-cli chat --agent <name>` reads:
+
+```json
+{
+  "name": "<agent-name>",
+  "description": "<one-line description>",
+  "model": "claude-sonnet-4.6",
+  "prompt": "<system prompt — a single string>",
+  "tools": ["fs_read", "execute_bash"],
+  "allowedTools": ["fs_read", "read"],
+  "toolsSettings": {}
+}
+```
+
+Kiro CLI model IDs must be the exact dotted form (`claude-haiku-4.5`,
+`claude-sonnet-4.6`, `claude-opus-4.8`); bare aliases fail. Resolve the agent's
+`model_tier` against `[models]` and spell the result in that form. `allowedTools`
+restricts what the agent can actually invoke; `toolsSettings` adds write-scoping or
+deny-lists — defense in depth, not a security boundary.
+
+Kiro agents inherit the same portability rules as skills: no backend specifics, no
+hardcoded repo or toolchain values.
 
 ## Steps to Sync
 

--- a/skills/triage-ticket/SKILL.md
+++ b/skills/triage-ticket/SKILL.md
@@ -2,6 +2,7 @@
 name: triage-ticket
 description: 'Read a ticket, extract requirements, move it to In Progress, and start time tracking. Provider-agnostic via tkt.'
 allowed-tools: [Bash, Read, Edit]
+model_tier: cheap
 ---
 
 # Triage Ticket

--- a/tests/test_jira_adf.py
+++ b/tests/test_jira_adf.py
@@ -1,0 +1,194 @@
+"""Unit tests for the Jira Markdown -> ADF converter (adapters/jira.py).
+
+Pure, offline, stdlib-only — no backend needed. Run from the repo root:
+
+    python3 -m unittest tests.test_jira_adf
+    python3 tests/test_jira_adf.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from adapters.jira import _md_to_adf, _inline  # noqa: E402
+
+
+def types(nodes):
+    return [n.get("type") for n in nodes]
+
+
+def marks(node):
+    return sorted(m["type"] for m in node.get("marks", []))
+
+
+def flatten_text(node):
+    if node.get("type") == "text":
+        return node.get("text", "")
+    return "".join(flatten_text(c) for c in node.get("content", []) or [])
+
+
+class DocShape(unittest.TestCase):
+    def test_always_returns_a_doc(self):
+        doc = _md_to_adf("")
+        self.assertEqual(doc["type"], "doc")
+        self.assertEqual(doc["version"], 1)
+        # Empty input still yields a valid (empty) paragraph.
+        self.assertEqual(types(doc["content"]), ["paragraph"])
+
+    def test_plain_paragraph(self):
+        doc = _md_to_adf("Just some prose.")
+        self.assertEqual(types(doc["content"]), ["paragraph"])
+        self.assertEqual(flatten_text(doc["content"][0]), "Just some prose.")
+
+    def test_soft_wrapped_lines_join_into_one_paragraph(self):
+        doc = _md_to_adf("line one\nline two")
+        self.assertEqual(types(doc["content"]), ["paragraph"])
+        self.assertEqual(flatten_text(doc["content"][0]), "line one line two")
+
+
+class Blocks(unittest.TestCase):
+    def test_headings_levels(self):
+        doc = _md_to_adf("# H1\n\n### H3")
+        h1, h3 = doc["content"]
+        self.assertEqual((h1["type"], h1["attrs"]["level"]), ("heading", 1))
+        self.assertEqual((h3["type"], h3["attrs"]["level"]), ("heading", 3))
+
+    def test_hash_without_space_is_not_a_heading(self):
+        doc = _md_to_adf("#nothashtag")
+        self.assertEqual(types(doc["content"]), ["paragraph"])
+
+    def test_bullet_list(self):
+        doc = _md_to_adf("- a\n- b\n- c")
+        self.assertEqual(types(doc["content"]), ["bulletList"])
+        self.assertEqual(len(doc["content"][0]["content"]), 3)
+
+    def test_ordered_list(self):
+        doc = _md_to_adf("1. first\n2. second")
+        self.assertEqual(types(doc["content"]), ["orderedList"])
+
+    def test_nested_list_becomes_sublist(self):
+        doc = _md_to_adf("- top\n  - child\n- top2")
+        lst = doc["content"][0]
+        first_item = lst["content"][0]
+        # listItem holds a paragraph plus a nested list.
+        self.assertIn("bulletList", types(first_item["content"]))
+
+    def test_blockquote(self):
+        doc = _md_to_adf("> quoted line")
+        self.assertEqual(types(doc["content"]), ["blockquote"])
+        self.assertEqual(flatten_text(doc["content"][0]), "quoted line")
+
+    def test_blockquote_degrades_disallowed_children(self):
+        # ADF blockquotes may only hold paragraph/list/codeBlock. Heading/rule/
+        # nested-quote inside `>` must be coerced, never emitted verbatim (Jira
+        # 400s on an invalid blockquote content model).
+        allowed = {"paragraph", "bulletList", "orderedList", "codeBlock"}
+        for src in ("> # Heading", "> ---", "> > nested"):
+            bq = _md_to_adf(src)["content"][0]
+            self.assertEqual(bq["type"], "blockquote")
+            child_types = {c.get("type") for c in bq["content"]}
+            self.assertTrue(child_types <= allowed, f"{src} -> {child_types}")
+        # The heading's text survives as a paragraph.
+        bq = _md_to_adf("> # Heading")["content"][0]
+        self.assertEqual(flatten_text(bq), "Heading")
+
+    def test_horizontal_rule(self):
+        doc = _md_to_adf("above\n\n---\n\nbelow")
+        self.assertEqual(types(doc["content"]), ["paragraph", "rule", "paragraph"])
+
+    def test_fenced_code_block_keeps_language_and_literal_body(self):
+        doc = _md_to_adf("```go\nfmt.Println(\"*not bold*\")\n```")
+        cb = doc["content"][0]
+        self.assertEqual(cb["type"], "codeBlock")
+        self.assertEqual(cb["attrs"]["language"], "go")
+        self.assertEqual(cb["content"][0]["text"], 'fmt.Println("*not bold*")')
+
+    def test_list_does_not_swallow_following_paragraph(self):
+        doc = _md_to_adf("- a\n- b\n\nAfter the list.")
+        self.assertEqual(types(doc["content"]), ["bulletList", "paragraph"])
+
+    def test_empty_list_item_is_skipped(self):
+        # Middle line is a bare marker + space ("- ") = an empty item.
+        doc = _md_to_adf("- a\n- \n- c")
+        items = doc["content"][0]["content"]
+        self.assertEqual(len(items), 2)
+        self.assertEqual([flatten_text(i) for i in items], ["a", "c"])
+
+    def test_all_empty_list_emits_no_list(self):
+        # A list whose every item is empty must not emit an empty bulletList/
+        # orderedList (content: []) — that is invalid ADF and Jira 400s on it.
+        for src in ("- ", "1. ", "- \n- \n- "):
+            doc = _md_to_adf(src)
+            all_types = {n.get("type") for n in doc["content"]}
+            self.assertNotIn("bulletList", all_types, src)
+            self.assertNotIn("orderedList", all_types, src)
+        # Same guard inside a blockquote.
+        bq = _md_to_adf("> - ")["content"][0]
+        self.assertEqual(bq["type"], "blockquote")
+        self.assertNotIn("bulletList", {c.get("type") for c in bq["content"]})
+
+
+class Inline(unittest.TestCase):
+    def test_bold_and_italic(self):
+        nodes = _inline("**bold** and *italic*")
+        bold = next(n for n in nodes if n["text"] == "bold")
+        ital = next(n for n in nodes if n["text"] == "italic")
+        self.assertEqual(marks(bold), ["strong"])
+        self.assertEqual(marks(ital), ["em"])
+
+    def test_inline_code(self):
+        nodes = _inline("call `doThing()` now")
+        code = next(n for n in nodes if n["text"] == "doThing()")
+        self.assertEqual(marks(code), ["code"])
+
+    def test_strikethrough(self):
+        nodes = _inline("~~gone~~")
+        self.assertEqual(marks(nodes[0]), ["strike"])
+
+    def test_link_becomes_link_mark(self):
+        nodes = _inline("see [docs](https://example.com/x)")
+        link = next(n for n in nodes if n["text"] == "docs")
+        self.assertEqual(marks(link), ["link"])
+        href = link["marks"][0]["attrs"]["href"]
+        self.assertEqual(href, "https://example.com/x")
+
+    def test_bold_link_keeps_both_marks(self):
+        nodes = _inline("[**bold link**](https://e.co)")
+        node = nodes[0]
+        self.assertEqual(marks(node), ["link", "strong"])
+
+    def test_unsafe_link_scheme_stays_plain_text(self):
+        # javascript:/data:/protocol-relative must not become a link mark; the
+        # text is preserved.
+        for src in ("[x](javascript:alert(1))", "[y](data:text/html,<script>)",
+                    "[z](//evil.com)"):
+            nodes = _inline(src)
+            self.assertTrue(all("link" not in marks(n) for n in nodes), src)
+        # http/https/mailto plus schemeless relative/anchor links still render.
+        for href in ("https://e.co", "mailto:a@b.co", "/rel", "#anchor",
+                     "page.md", "../up"):
+            nodes = _inline(f"[t]({href})")
+            self.assertEqual(marks(nodes[0]), ["link"], href)
+            self.assertEqual(nodes[0]["marks"][0]["attrs"]["href"], href)
+
+    def test_double_star_is_strong_not_two_ems(self):
+        nodes = _inline("**x**")
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(marks(nodes[0]), ["strong"])
+
+    def test_unmatched_asterisk_stays_literal(self):
+        # A lone glob star (services/*, go:*) must not start emphasis.
+        for src in ("build services/* now", "run go:* tasks", "a * b"):
+            nodes = _inline(src)
+            self.assertEqual("".join(n["text"] for n in nodes), src)
+            self.assertTrue(all(not n.get("marks") for n in nodes), src)
+
+    def test_snake_case_underscores_stay_literal(self):
+        nodes = _inline("field some_snake_case name")
+        self.assertEqual("".join(n["text"] for n in nodes), "field some_snake_case name")
+        self.assertTrue(all(not n.get("marks") for n in nodes))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,714 @@
+"""Unit tests for core/run.py — the external loop driver.
+
+Fully offline: uses the markdown adapter with temp dirs and a stub harness
+script that writes scripted result.json sequences. No real model turns.
+
+Run from repo root:
+    python3 -m unittest tests.test_run
+"""
+import json
+import os
+import stat
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.config import Config
+from core.run import (
+    RunConfig, RunDriver, PHASES, PHASE_NAMES,
+    read_ticket_marker, write_ticket_marker,
+    check_stop_file, create_stop_file, ensure_state_dir,
+    read_result_file, delete_result_file, append_run_log,
+    build_phase_prompt, invoke_harness, _build_marker,
+    is_gate_phase, is_production_phase, is_human_owned_transition,
+)
+from core.registry import get_adapter
+
+
+
+# ---- Test helpers ------------------------------------------------------------
+
+def _write_config(tmp: Path, extra_toml: str = "") -> Path:
+    """Write a minimal markdown config and return its path."""
+    sdlc = tmp / ".sdlc"
+    sdlc.mkdir(parents=True, exist_ok=True)
+    board = sdlc / "board"
+    board.mkdir(exist_ok=True)
+    state = sdlc / "state"
+    state.mkdir(exist_ok=True)
+
+    config_path = sdlc / "config.toml"
+    config_path.write_text(textwrap.dedent(f"""\
+        [ticketing]
+        provider = "markdown"
+        project  = "TKT"
+
+        [markdown]
+        board_dir = "{board}"
+        state_dir = "{state}"
+        me        = "testbot"
+
+        [board.roles]
+        backlog     = "Backlog"
+        todo        = "To Do"
+        in_progress = "In Progress"
+        review      = "In Review"
+        qa_ready    = "QA Ready"
+        done        = "Done"
+        blocked     = "Blocked"
+
+        [board.ownership]
+        "todo->in_progress"   = "agent"
+        "in_progress->review" = "agent"
+        "review->qa_ready"    = "agent"
+        "qa_ready->qa"        = "human"
+        "deploy_ready->done"  = "human"
+
+        [issue_types]
+        full_sdlc   = ["Story", "Bug"]
+        deliverable = ["Task", "Chore"]
+
+        [queries]
+        tier1 = 'status = "To Do" ORDER BY priority DESC'
+
+        [vcs]
+        repo           = "test/repo"
+        default_branch = "main"
+
+        [build]
+        build = "true"
+        test  = "true"
+
+        [timetracking]
+        provider = "none"
+
+        [run]
+        harness_cmd = "{tmp}/stub.sh {{prompt}}"
+        max_iterations = 30
+        max_phase_attempts = 3
+        invocation_timeout = 10
+
+        {extra_toml}
+    """))
+    return config_path
+
+
+
+def _create_ticket(board_dir: Path, key: str, status: str = "To Do",
+                   issue_type: str = "Story") -> None:
+    """Create a minimal ticket markdown file."""
+    board_dir.mkdir(parents=True, exist_ok=True)
+    (board_dir / f"{key}.md").write_text(textwrap.dedent(f"""\
+        ---
+        type: {issue_type}
+        status: {status}
+        priority: High
+        assignee: testbot
+        blocked_by: []
+        blocks: []
+        ---
+        # Test ticket {key}
+
+        Description for testing.
+    """))
+
+
+def _write_stub_script(tmp: Path, results: list[dict]) -> Path:
+    """Write a stub harness that writes scripted result.json per call.
+
+    Each invocation pops the next result from a sequence file.
+    """
+    seq_file = tmp / "stub_sequence.json"
+    seq_file.write_text(json.dumps(results))
+
+    stub = tmp / "stub.sh"
+    stub.write_text(textwrap.dedent(f"""\
+        #!/bin/sh
+        # Stub harness: reads next result from sequence, writes to result.json
+        SEQ="{seq_file}"
+        # Find the state dir from the prompt (look for .sdlc/state/run)
+        PROMPT="$*"
+        # Extract result path from the prompt
+        RESULT_PATH=$(echo "$PROMPT" | grep -oE '[^ ]*result\\.json' | head -1)
+        if [ -z "$RESULT_PATH" ]; then
+            # Fallback: find result.json path in any .sdlc/state/run dir
+            exit 1
+        fi
+        # Pop first element from sequence
+        RESULT=$(python3 -c "
+import json, sys
+seq = json.loads(open('$SEQ').read())
+if not seq:
+    sys.exit(1)
+print(json.dumps(seq[0]))
+open('$SEQ', 'w').write(json.dumps(seq[1:]))
+")
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
+        # Ensure parent dir exists
+        mkdir -p "$(dirname "$RESULT_PATH")"
+        echo "$RESULT" > "$RESULT_PATH"
+    """))
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return stub
+
+
+
+# ---- Test cases --------------------------------------------------------------
+
+class TestRunConfig(unittest.TestCase):
+    def test_loads_from_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            rc = RunConfig(config)
+            self.assertIn("stub.sh", rc.harness_cmd)
+            self.assertEqual(rc.max_iterations, 30)
+            self.assertEqual(rc.max_phase_attempts, 3)
+            self.assertEqual(rc.invocation_timeout, 10)
+
+    def test_missing_harness_cmd_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            sdlc = tmp / ".sdlc"
+            sdlc.mkdir()
+            (sdlc / "board").mkdir()
+            (sdlc / "state").mkdir()
+            cfg = sdlc / "config.toml"
+            cfg.write_text(textwrap.dedent("""\
+                [ticketing]
+                provider = "markdown"
+                [markdown]
+                board_dir = ".sdlc/board"
+                state_dir = ".sdlc/state"
+                [board.roles]
+                done = "Done"
+                [run]
+                max_iterations = 5
+            """))
+            config = Config.load(str(cfg))
+            with self.assertRaises(Exception) as ctx:
+                RunConfig(config)
+            self.assertIn("harness_cmd", str(ctx.exception))
+
+
+class TestTicketMarker(unittest.TestCase):
+    def test_write_and_read_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            adapter = get_adapter(config)
+            board_dir = Path(config.provider_cfg["board_dir"])
+            _create_ticket(board_dir, "TKT-1")
+
+            state = {"phase": "P3", "attempt": 1, "outcome": "advance",
+                     "next": "P4", "updated": "2026-01-01T00:00:00Z"}
+            write_ticket_marker(adapter, "TKT-1", state)
+
+            marker = read_ticket_marker(adapter, "TKT-1")
+            self.assertIsNotNone(marker)
+            self.assertEqual(marker["phase"], "P3")
+            self.assertEqual(marker["outcome"], "advance")
+
+    def test_read_nonexistent_ticket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            adapter = get_adapter(config)
+            marker = read_ticket_marker(adapter, "NOPE-99")
+            self.assertIsNone(marker)
+
+    def test_local_mirror_resumes_when_comments_are_unreadable(self):
+        """Only the markdown adapter exposes raw comment bodies. Every other
+        backend has to recover the marker from the local mirror, or a resume
+        silently restarts the pipeline at P1."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            adapter = get_adapter(config)
+            board_dir = Path(config.provider_cfg["board_dir"])
+            _create_ticket(board_dir, "TKT-1")
+            state_dir = ensure_state_dir(config, "TKT-1")
+
+            state = {"phase": "P6", "attempt": 2, "outcome": "retry",
+                     "updated": "2026-01-01T00:00:00Z"}
+            write_ticket_marker(adapter, "TKT-1", state, state_dir)
+
+            # Stand in for a backend whose comments cannot be read back.
+            class NoRawComments:
+                def __getattr__(self, name):
+                    if name == "_read_raw":
+                        raise AttributeError(name)
+                    return getattr(adapter, name)
+
+            blind = NoRawComments()
+            self.assertIsNone(read_ticket_marker(blind, "TKT-1"))
+
+            marker = read_ticket_marker(blind, "TKT-1", state_dir)
+            self.assertIsNotNone(marker)
+            self.assertEqual(marker["phase"], "P6")
+            self.assertEqual(marker["attempt"], 2)
+            self.assertEqual(marker["outcome"], "retry")
+
+    def test_local_mirror_ignores_corrupt_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            adapter = get_adapter(config)
+            state_dir = ensure_state_dir(config, "TKT-1")
+            (state_dir / "marker.json").write_text("{not json")
+
+            class NoRawComments:
+                def __getattr__(self, name):
+                    if name == "_read_raw":
+                        raise AttributeError(name)
+                    return getattr(adapter, name)
+
+            self.assertIsNone(read_ticket_marker(NoRawComments(), "TKT-1", state_dir))
+
+
+
+class TestLocalState(unittest.TestCase):
+    def test_ensure_state_dir_creates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            d = ensure_state_dir(config, "TKT-1")
+            self.assertTrue(d.is_dir())
+            self.assertTrue(str(d).endswith("run/TKT-1"))
+
+    def test_stop_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            d = ensure_state_dir(config, "TKT-1")
+            self.assertFalse(check_stop_file(d))
+            create_stop_file(config, "TKT-1")
+            self.assertTrue(check_stop_file(d))
+
+    def test_result_file_valid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            d = tmp / "state"
+            d.mkdir()
+            result = {"phase": "P3", "outcome": "advance",
+                      "next": "P4", "reason": "tests pass"}
+            (d / "result.json").write_text(json.dumps(result))
+            read = read_result_file(d)
+            self.assertEqual(read["outcome"], "advance")
+            delete_result_file(d)
+            self.assertIsNone(read_result_file(d))
+
+    def test_result_file_invalid_outcome(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            d = tmp / "state"
+            d.mkdir()
+            (d / "result.json").write_text('{"phase":"P3","outcome":"bogus"}')
+            self.assertIsNone(read_result_file(d))
+
+    def test_result_file_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(read_result_file(Path(tmp)))
+
+    def test_result_file_corrupt_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            d = tmp / "state"
+            d.mkdir()
+            (d / "result.json").write_text("not json at all")
+            self.assertIsNone(read_result_file(d))
+
+    def test_run_log_append(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            d = tmp / "state"
+            d.mkdir()
+            append_run_log(d, {"iteration": 1, "phase": "P1"})
+            append_run_log(d, {"iteration": 2, "phase": "P2"})
+            lines = (d / "run.log").read_text().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["phase"], "P1")
+
+
+
+class TestGateLogic(unittest.TestCase):
+    def test_p9_is_gate(self):
+        self.assertTrue(is_gate_phase("P9"))
+        self.assertFalse(is_gate_phase("P8"))
+        self.assertFalse(is_gate_phase("P3"))
+
+    def test_production_phase_default_human(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            # deploy_ready->done is human-owned in our test config
+            self.assertTrue(is_production_phase("P10", config))
+            self.assertFalse(is_production_phase("P5", config))
+
+    def test_production_phase_agent_owned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            # Override ownership in memory to grant agent deploy.
+            config.ownership["deploy_ready->done"] = "agent"
+            self.assertFalse(is_production_phase("P10", config))
+
+    def test_human_owned_transition(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            self.assertTrue(
+                is_human_owned_transition(config, "qa_ready", "qa"))
+            self.assertFalse(
+                is_human_owned_transition(config, "todo", "in_progress"))
+
+
+class TestPhasePrompt(unittest.TestCase):
+    def test_prompt_contains_key_and_phase(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            prompt = build_phase_prompt("TKT-5", "P3", 2, d)
+            self.assertIn("TKT-5", prompt)
+            self.assertIn("P3", prompt)
+            self.assertIn("Attempt: 2", prompt)
+            self.assertIn("result.json", prompt)
+            self.assertIn("advance|retry|blocked|gate", prompt)
+
+
+
+class TestInvokeHarness(unittest.TestCase):
+    def test_dry_run_does_not_execute(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            rc, out = invoke_harness(
+                "echo should_not_run", "test prompt", 10, d, dry_run=True)
+            self.assertEqual(rc, 0)
+            self.assertIn("dry-run", out)
+
+    def test_successful_invocation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            rc, out = invoke_harness("echo hello", "ignored", 10, d)
+            self.assertEqual(rc, 0)
+            self.assertIn("hello", out)
+
+    def test_timeout_counts_as_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            rc, out = invoke_harness("sleep 30", "ignored", 1, d)
+            self.assertEqual(rc, 1)
+            self.assertIn("timeout", out.lower())
+
+    def test_nonzero_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            rc, out = invoke_harness("exit 42", "ignored", 10, d)
+            self.assertEqual(rc, 42)
+
+
+
+class TestDriverLoop(unittest.TestCase):
+    """Integration tests running the full driver with a stub harness."""
+
+    def _setup_env(self, results, ticket_status="In Progress",
+                   extra_toml="", ownership_override=None):
+        """Set up a temp env with config, ticket, and stub harness."""
+        self.tmp = tempfile.mkdtemp()
+        tmp = Path(self.tmp)
+        cfg_path = _write_config(tmp, extra_toml)
+        self.config = Config.load(str(cfg_path))
+        board_dir = Path(self.config.provider_cfg["board_dir"])
+        _create_ticket(board_dir, "TKT-1", status=ticket_status)
+        _write_stub_script(tmp, results)
+        return self.config
+
+    def tearDown(self):
+        import shutil
+        if hasattr(self, 'tmp') and os.path.isdir(self.tmp):
+            shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_advance_through_phases(self):
+        """Stub returns advance for P1->P4, driver advances each time."""
+        results = [
+            {"phase": "P1", "outcome": "advance", "next": "P1.5",
+             "reason": "triaged"},
+            {"phase": "P1.5", "outcome": "advance", "next": "P2",
+             "reason": "full_sdlc"},
+            {"phase": "P2", "outcome": "advance", "next": "P3",
+             "reason": "planned"},
+            {"phase": "P3", "outcome": "advance", "next": "P4",
+             "reason": "implemented"},
+            {"phase": "P4", "outcome": "advance", "next": "P5",
+             "reason": "review clean"},
+            {"phase": "P5", "outcome": "advance", "next": "P6",
+             "reason": "PR opened"},
+            {"phase": "P6", "outcome": "advance", "next": "P7",
+             "reason": "CI green"},
+            {"phase": "P7", "outcome": "advance", "next": "P8",
+             "reason": "approved"},
+            {"phase": "P8", "outcome": "advance", "next": "P9",
+             "reason": "preview live"},
+        ]
+        config = self._setup_env(results)
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        # Start from P1 since ticket exists already.
+        driver.phase = "P1"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        # Should halt at P9 (qa_ready gate)
+        self.assertEqual(rc, 0)
+        self.assertEqual(driver.phase, "P9")
+
+
+    def test_retry_then_advance(self):
+        """First attempt fails (retry), second succeeds (advance)."""
+        results = [
+            {"phase": "P1", "outcome": "retry", "next": "P1",
+             "reason": "flaky"},
+            {"phase": "P1", "outcome": "advance", "next": "P1.5",
+             "reason": "ok now"},
+            {"phase": "P1.5", "outcome": "gate", "next": "P2",
+             "reason": "stop for test"},
+        ]
+        config = self._setup_env(results)
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.phase = "P1"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 0)  # gate stops cleanly
+
+    def test_three_attempts_transitions_blocked(self):
+        """3 failed attempts on one phase -> blocked transition + comment."""
+        results = [
+            {"phase": "P3", "outcome": "retry", "next": "P3",
+             "reason": "test fail 1"},
+            {"phase": "P3", "outcome": "retry", "next": "P3",
+             "reason": "test fail 2"},
+            {"phase": "P3", "outcome": "retry", "next": "P3",
+             "reason": "test fail 3"},
+        ]
+        config = self._setup_env(results)
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.phase = "P3"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 1)
+        # Verify ticket was transitioned to Blocked.
+        adapter = get_adapter(config)
+        ticket = adapter.view("TKT-1")
+        self.assertEqual(ticket.status, "Blocked")
+
+
+    def test_stop_file_honored_mid_run(self):
+        """STOP file present before iteration -> exits cleanly."""
+        results = [
+            {"phase": "P1", "outcome": "advance", "next": "P1.5",
+             "reason": "ok"},
+        ]
+        config = self._setup_env(results)
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.phase = "P1"
+        driver.attempt = 1
+        driver._init_state()
+        # Drop STOP file before first iteration.
+        create_stop_file(config, "TKT-1")
+
+        rc = driver._loop()
+        self.assertEqual(rc, 0)
+        # Should not have run any iterations.
+        self.assertEqual(driver.iteration, 0)
+
+    def test_qa_ready_gate_halt(self):
+        """Driver halts when it reaches P9 (qa_ready) regardless of agent."""
+        config = self._setup_env([])
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.phase = "P9"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 0)
+        self.assertEqual(driver.iteration, 0)
+
+    def test_human_owned_transition_refused(self):
+        """Driver refuses to run phase whose transition is human-owned."""
+        config = self._setup_env([])
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        # P9's transition is qa_ready->qa which is human-owned
+        driver.phase = "P9"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 0)
+
+
+    def test_missing_result_json_treated_as_retry(self):
+        """If harness doesn't write result.json, counts as failed attempt."""
+        # Empty results list means stub will exit without writing anything.
+        config = self._setup_env([])
+        rc_cfg = RunConfig(config)
+        # Override max_phase_attempts to 2 for faster test.
+        rc_cfg.max_phase_attempts = 2
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.max_phase_attempts = 2
+        driver.phase = "P3"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 1)  # blocked after 2 attempts
+        # Should have run 2 iterations.
+        self.assertEqual(driver.iteration, 2)
+
+    def test_timeout_counts_as_attempt(self):
+        """Timeout on harness invocation counts as a failed attempt."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            board_dir = Path(config.provider_cfg["board_dir"])
+            _create_ticket(board_dir, "TKT-1")
+            # Write a stub that sleeps forever.
+            stub = tmp / "stub.sh"
+            stub.write_text("#!/bin/sh\nsleep 60\n")
+            stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+            # Patch harness_cmd to use sleep stub, with 1s timeout.
+            rc_cfg = RunConfig(config)
+            rc_cfg.harness_cmd = f"{stub} {{prompt}}"
+            rc_cfg.invocation_timeout = 1
+            rc_cfg.max_phase_attempts = 2
+
+            driver = RunDriver(config, rc_cfg, key="TKT-1")
+            driver.max_phase_attempts = 2
+            driver.timeout = 1
+            driver.phase = "P3"
+            driver.attempt = 1
+            driver._init_state()
+
+            rc = driver._loop()
+            self.assertEqual(rc, 1)
+            self.assertEqual(driver.iteration, 2)
+
+
+    def test_resume_from_ticket_marker(self):
+        """Kill the driver, rerun — resumes from the ticket marker."""
+        results_first = [
+            {"phase": "P1", "outcome": "advance", "next": "P1.5",
+             "reason": "triaged"},
+            {"phase": "P1.5", "outcome": "advance", "next": "P2",
+             "reason": "routed"},
+        ]
+        config = self._setup_env(results_first)
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1")
+        driver.phase = "P1"
+        driver.attempt = 1
+        driver._init_state()
+        # Limit iterations so we stop after 2 phases.
+        driver.max_iterations = 2
+        rc = driver._loop()
+        self.assertEqual(rc, 1)  # max iterations
+
+        # Now resume. The marker should show P2 as the halted phase.
+        adapter = get_adapter(config)
+        marker = read_ticket_marker(adapter, "TKT-1")
+        self.assertIsNotNone(marker)
+        self.assertEqual(marker["phase"], "P2")
+
+        # Write new results for the resumed run.
+        tmp = Path(self.tmp)
+        seq_file = tmp / "stub_sequence.json"
+        new_results = [
+            {"phase": "P2", "outcome": "advance", "next": "P3",
+             "reason": "planned"},
+            {"phase": "P3", "outcome": "gate", "next": "P4",
+             "reason": "testing stop"},
+        ]
+        seq_file.write_text(json.dumps(new_results))
+
+        # Create a new driver that resumes.
+        driver2 = RunDriver(config, rc_cfg, key="TKT-1")
+        driver2._init_state()
+        driver2._resume_from_marker()
+        self.assertEqual(driver2.phase, "P2")
+        rc2 = driver2._loop()
+        self.assertEqual(rc2, 0)  # gate
+
+    def test_dry_run_invokes_nothing(self):
+        """--dry-run prints the prompt but does not invoke."""
+        config = self._setup_env([])
+        rc_cfg = RunConfig(config)
+        driver = RunDriver(config, rc_cfg, key="TKT-1", dry_run=True)
+        driver.phase = "P3"
+        driver.attempt = 1
+        driver._init_state()
+
+        rc = driver._loop()
+        self.assertEqual(rc, 0)
+        # No iterations beyond the dry-run check.
+        self.assertEqual(driver.iteration, 1)
+
+
+class TestDriverStatus(unittest.TestCase):
+    def test_status_no_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            board_dir = Path(config.provider_cfg["board_dir"])
+            _create_ticket(board_dir, "TKT-1")
+            rc_cfg = RunConfig(config)
+            driver = RunDriver(config, rc_cfg, key="TKT-1")
+            status = driver.status()
+            self.assertIsNone(status.get("phase"))
+
+    def test_status_with_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            cfg_path = _write_config(tmp)
+            config = Config.load(str(cfg_path))
+            board_dir = Path(config.provider_cfg["board_dir"])
+            _create_ticket(board_dir, "TKT-1")
+            adapter = get_adapter(config)
+            write_ticket_marker(adapter, "TKT-1", {
+                "phase": "P5", "attempt": 1, "outcome": "advance",
+                "next": "P6", "updated": "2026-01-01T00:00:00Z",
+            })
+            rc_cfg = RunConfig(config)
+            driver = RunDriver(config, rc_cfg, key="TKT-1")
+            status = driver.status()
+            self.assertEqual(status["phase"], "P5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What landed

| Commit | Cluster |
|---|---|
| `694807c` | Jira Markdown→ADF on all write paths (24 tests) |
| `b2213e4` | Windows install + platform notes |
| `8b6ce8c` | Three-tier model routing via config |
| `b53d8fe` | Trust-scoped SDLC agent catalog |
| `32d96ee` | respond-to-review auto-resolves threads |
| `7a72337` | Optional `build.bdd` behavior-spec hook |
| `79517db` | `tkt run` external loop driver (34 tests) |
| `704dd49` | Adversarial QA suite |
| `7af1c23` | Kiro steering shipped by sync-pack + mirror resync |
| `5db3b17` | Smoke test derives pack counts |

### Highlights

**Jira ADF.** REST v3 stores rich text as ADF, so Markdown authored by skills
was landing literal (`## Heading`, `- item` shown verbatim). A dependency-free
CommonMark subset now converts every write path. Link hrefs are restricted to
http/https/mailto plus schemeless relative paths, so `javascript:`/`data:`/
protocol-relative never reach the ADF.

**Model routing.** Skills declare `model_tier: cheap|standard|deep`; a new
optional `[models]` table maps tier→model, resolved at invocation time via
`tkt cfg models.<tier>`. This is the deliberate divergence from the downstream
version, which pinned model IDs in every skill's frontmatter — that would mean
editing 20 files per model generation across every consumer repo. Same rule the
pack already applies to `build.*` and `vcs.*`: the skill names what it needs,
config names what it is. Absent `[models]`, `tkt cfg` exits 4 and routing is
skipped; no phase requires a specific model.

**Agent catalog.** Plan, implement, and review previously ran in one context, so
the review pass judged code it had just written. Four least-privilege agents fix
the separation; every delegating phase states an inline fallback, so harnesses
without subagent support run the pipeline unchanged.

**`tkt run`.** Every loop in the pipeline existed only as prose inside whichever
session ran the skill, dying when that session ended or compacted. The driver
moves the loop outside the harness: one phase per invocation, structured
`result.json`, repeat until a gate, STOP, or cap. P9 (`qa_ready`) always halts;
`[board.ownership]` still gates every human-owned transition.

## Two defects fixed beyond the straight port

**`run.py` resume was markdown-only.** `read_ticket_marker` depends on
`_read_raw`, which only the markdown adapter has, so on Jira/GitHub/Linear/
openkanban it always returned `None` — `tkt run KEY` silently restarted at P1
and re-triaged a ticket already in review, and `--status` never found a marker.
The marker is now mirrored to `.sdlc/state/run/<key>/marker.json` and recovered
from there, with two regression tests. Cross-machine resume stays markdown-only
and is documented as such.

**Tier-A harness mirrors had drifted.** `.kiro/skills` and `.agents/skills` were
missing the 5 QA skills and had not picked up `model_tier`; `check-blockers` was
already stale before this branch. All resynced byte-identical.

## Verification

- 58 unit tests pass (`python3 -m unittest discover -s tests`)
- All 7 `scripts/smoke-sync-pack.sh` cases pass
- `sync-pack --check` clean in both default and `--all-harnesses` modes
- Every adapter imports; all modules compile
- End-to-end verb run against a markdown board (`init`, `doctor`, `view --json`,
  `transition`, `comment`, `cfg`), plus `tkt run` dry-run, live loop, resume,
  and `--stop`

No live Jira board was available, so the ADF converter is covered by its unit
tests rather than against a real backend.

## Deliberately left out

- **`.github/prompts` still has 14 entries, not 19.** Those are condensed
  translations, not byte-identical copies, so the 5 QA prompts need an authoring
  pass rather than a mechanical mirror.
- **`.kiro/agents/*.json` + `.md` not hand-committed.** They duplicate
  `agents/*.md` with dotted model IDs that rot; `sync-skills` is the documented
  generator, and `pack.py` ships the tree if it is ever generated.
- Downstream-specific values were not ported, and tkt's `toolchain.py` / `--no-detect-build` /
  `qi` provider mentions are preserved where the downstream copy had dropped them.
