### PR TITLE
feat(prompts): add Copilot translations for the QA skills

### DIFF
--- a/.agents/skills/qa-author/references/cdk.md
+++ b/.agents/skills/qa-author/references/cdk.md
@@ -1,0 +1,267 @@
+# AWS CDK Testing Reference
+
+Stack-specific patterns for adversarial testing of AWS CDK infrastructure code.
+
+## Template Assertions
+
+### Basic resource property assertions
+
+```typescript
+import { Template, Match } from 'aws-cdk-lib/assertions';
+
+const template = Template.fromStack(stack);
+
+// Verify a resource exists with specific properties
+template.hasResourceProperties('AWS::Lambda::Function', {
+  Runtime: 'nodejs20.x',
+  Timeout: 30,
+  MemorySize: 256,
+  Environment: {
+    Variables: {
+      NODE_ENV: 'production',
+    },
+  },
+});
+
+// Verify resource COUNT (catches accidental duplicates or missing resources)
+template.resourceCountIs('AWS::Lambda::Function', 3);
+```
+
+### Security-focused assertions
+
+```typescript
+// S3 bucket encryption
+template.hasResourceProperties('AWS::S3::Bucket', {
+  BucketEncryption: {
+    ServerSideEncryptionConfiguration: [
+      {
+        ServerSideEncryptionByDefault: {
+          SSEAlgorithm: 'aws:kms',
+        },
+      },
+    ],
+  },
+  PublicAccessBlockConfiguration: {
+    BlockPublicAcls: true,
+    BlockPublicPolicy: true,
+    IgnorePublicAcls: true,
+    RestrictPublicBuckets: true,
+  },
+});
+
+// No public S3 buckets
+template.hasResourceProperties('AWS::S3::BucketPolicy', {
+  PolicyDocument: Match.not(
+    Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Principal: '*',
+          Effect: 'Allow',
+        }),
+      ]),
+    })
+  ),
+});
+
+// RDS encryption at rest
+template.hasResourceProperties('AWS::RDS::DBInstance', {
+  StorageEncrypted: true,
+  DeletionProtection: true,
+});
+
+// Security group — no 0.0.0.0/0 ingress on sensitive ports
+template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+  SecurityGroupIngress: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        CidrIp: '0.0.0.0/0',
+        FromPort: 5432, // postgres
+      }),
+    ])
+  ),
+});
+```
+
+### IAM least-privilege assertions
+
+```typescript
+// Lambda role should NOT have wildcard actions
+const roles = template.findResources('AWS::IAM::Role');
+for (const [logicalId, role] of Object.entries(roles)) {
+  const policies = role.Properties?.Policies ?? [];
+  for (const policy of policies) {
+    const statements = policy.PolicyDocument?.Statement ?? [];
+    for (const stmt of statements) {
+      if (stmt.Effect === 'Allow') {
+        expect(stmt.Action).not.toContain('*');
+        expect(stmt.Resource).not.toBe('*');
+      }
+    }
+  }
+}
+
+// Verify no inline policies with admin access
+template.hasResourceProperties('AWS::IAM::Role', {
+  Policies: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: '*',
+              Resource: '*',
+            }),
+          ]),
+        }),
+      }),
+    ])
+  ),
+});
+```
+
+## Snapshot Tests — Acknowledge Limits
+
+Snapshot tests are a **diff alarm**, not a test. They tell you "something changed"
+— not whether the change is correct or incorrect.
+
+```typescript
+// Snapshot: useful as a change-detection alarm
+// BUT: reviewing a 5000-line JSON diff is meaningless
+// Use targeted assertions for actual correctness guarantees
+test('stack matches snapshot', () => {
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
+});
+```
+
+**When snapshots are useful:**
+- Catching unintended resource deletions during refactors
+- Detecting drift from expected resource counts
+
+**When snapshots are harmful:**
+- As the sole test (proves nothing about correctness)
+- When they get auto-updated without review (`-u` is dangerous)
+- When the snapshot is too large to meaningfully review
+
+## Aspects for Cross-Stack Policy
+
+```typescript
+import { Annotations, IAspect, Stack } from 'aws-cdk-lib';
+import { CfnBucket } from 'aws-cdk-lib/aws-s3';
+
+class BucketEncryptionAspect implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof CfnBucket) {
+      if (!node.bucketEncryption) {
+        Annotations.of(node).addError('All S3 buckets must have encryption enabled');
+      }
+    }
+  }
+}
+
+// In test:
+test('all buckets are encrypted', () => {
+  Aspects.of(stack).add(new BucketEncryptionAspect());
+  const annotations = Annotations.fromStack(stack);
+  annotations.hasNoError('/MyStack/*', Match.anyValue());
+});
+```
+
+## Adversarial Patterns for CDK
+
+### Removal protection
+
+```typescript
+// DynamoDB tables should have deletion protection
+template.hasResource('AWS::DynamoDB::Table', {
+  DeletionPolicy: 'Retain',
+  UpdateReplacePolicy: 'Retain',
+});
+
+// Critical resources should not be replaceable on update
+template.hasResource('AWS::RDS::DBInstance', {
+  UpdateReplacePolicy: Match.not('Delete'),
+});
+```
+
+### Environment separation
+
+```typescript
+// Production stack should NOT reference dev account IDs
+const templateJson = JSON.stringify(template.toJSON());
+expect(templateJson).not.toContain('123456789012'); // dev account
+expect(templateJson).not.toContain('dev-');
+
+// Production stack should have higher resource limits
+template.hasResourceProperties('AWS::Lambda::Function', {
+  MemorySize: Match.not(128), // 128 = default = probably not tuned for prod
+  Timeout: Match.not(3),      // 3s = default = probably not tuned for prod
+});
+```
+
+### VPC / Network isolation
+
+```typescript
+// Lambda in VPC should have both private subnets
+template.hasResourceProperties('AWS::Lambda::Function', {
+  VpcConfig: {
+    SubnetIds: Match.not(Match.arrayWith([])), // not empty
+    SecurityGroupIds: Match.not(Match.arrayWith([])),
+  },
+});
+
+// No resources in public subnets that shouldn't be
+const publicSubnetRefs = findPublicSubnetRefs(template);
+const lambdas = template.findResources('AWS::Lambda::Function');
+for (const [id, lambda] of Object.entries(lambdas)) {
+  const subnets = lambda.Properties?.VpcConfig?.SubnetIds ?? [];
+  for (const subnet of subnets) {
+    expect(publicSubnetRefs).not.toContainEqual(subnet);
+  }
+}
+```
+
+### Cost traps
+
+```typescript
+// NAT Gateways are expensive — verify they're intentional
+const natCount = Object.keys(
+  template.findResources('AWS::EC2::NatGateway')
+).length;
+expect(natCount).toBeLessThanOrEqual(expectedNatCount);
+
+// On-demand instances when spot would suffice
+template.hasResourceProperties('AWS::ECS::Service', {
+  CapacityProviderStrategy: Match.arrayWith([
+    Match.objectLike({
+      CapacityProvider: Match.stringLikeRegexp('FARGATE_SPOT'),
+    }),
+  ]),
+});
+```
+
+### Cross-stack reference integrity
+
+```typescript
+// When stacks export values, verify consumers actually use them
+// (orphaned exports are tech debt and can't be removed without deploy coordination)
+const exports = template.findOutputs('*');
+for (const [name, output] of Object.entries(exports)) {
+  if (output.Export) {
+    // Document why this export exists
+    expect(output.Description).toBeDefined();
+  }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot-only testing (no targeted assertions on security/permissions)
+- Testing synthesized template but not the construct inputs (garbage-in verification)
+- Missing `DeletionPolicy: Retain` on stateful resources (databases, buckets)
+- Wildcard IAM permissions (`*` on Action or Resource)
+- Hardcoded account IDs or region strings in constructs
+- No assertions on security group rules (default allows all egress)
+- Missing encryption on data-at-rest resources
+- Lambda functions with default 3s timeout and 128MB memory in production

--- a/.agents/skills/qa-author/references/go.md
+++ b/.agents/skills/qa-author/references/go.md
@@ -1,0 +1,295 @@
+# Go Testing Reference
+
+Stack-specific patterns for adversarial testing of Go applications.
+
+## Table-Driven Tests
+
+The standard Go pattern. Every test function should start here.
+
+```go
+func TestParseUserID(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int64
+        wantErr bool
+    }{
+        {"valid", "123", 123, false},
+        {"zero", "0", 0, false},
+        {"negative", "-1", 0, true},
+        {"empty string", "", 0, true},
+        {"whitespace", "  42  ", 0, true},    // or 42 if trimming is expected
+        {"overflow", "9223372036854775808", 0, true},
+        {"non-numeric", "abc", 0, true},
+        {"float", "3.14", 0, true},
+        {"leading zero", "007", 7, false},    // verify octal isn't assumed
+        {"max int64", "9223372036854775807", 9223372036854775807, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ParseUserID(tt.input)
+            if tt.wantErr {
+                if err == nil {
+                    t.Errorf("ParseUserID(%q) = %d, want error", tt.input, got)
+                }
+                return
+            }
+            if err != nil {
+                t.Fatalf("ParseUserID(%q) unexpected error: %v", tt.input, err)
+            }
+            if got != tt.want {
+                t.Errorf("ParseUserID(%q) = %d, want %d", tt.input, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Parallel Tests
+
+```go
+func TestConcurrentAccess(t *testing.T) {
+    t.Parallel() // marks this test as safe to run in parallel
+
+    tests := []struct{ name, input string }{...}
+    for _, tt := range tests {
+        tt := tt // capture range variable (required pre-Go 1.22)
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel() // subtests run in parallel with each other
+            // ...
+        })
+    }
+}
+```
+
+Use `t.Parallel()` aggressively to surface race conditions. Run with
+`-race` flag: `go test -race ./...`
+
+## Interface Mocks
+
+Prefer hand-written mocks over framework magic. A mock is just a struct that
+implements the interface.
+
+```go
+type mockStore struct {
+    getUserFunc func(ctx context.Context, id string) (*User, error)
+    calls       []string // track what was called
+}
+
+func (m *mockStore) GetUser(ctx context.Context, id string) (*User, error) {
+    m.calls = append(m.calls, "GetUser:"+id)
+    if m.getUserFunc != nil {
+        return m.getUserFunc(ctx, id)
+    }
+    return nil, errors.New("not configured")
+}
+```
+
+This makes test behavior explicit and avoids mock framework DSL overhead.
+
+## HTTP Handler Testing
+
+```go
+func TestGetUserHandler(t *testing.T) {
+    // Setup
+    store := &mockStore{
+        getUserFunc: func(ctx context.Context, id string) (*User, error) {
+            if id == "existing" {
+                return &User{ID: "existing", Name: "Alice"}, nil
+            }
+            return nil, ErrNotFound
+        },
+    }
+    handler := NewUserHandler(store)
+
+    tests := []struct {
+        name       string
+        method     string
+        path       string
+        wantStatus int
+        wantBody   string
+    }{
+        {"happy path", "GET", "/users/existing", 200, `"name":"Alice"`},
+        {"not found", "GET", "/users/missing", 404, `"error"`},
+        {"wrong method", "POST", "/users/existing", 405, ""},
+        {"empty id", "GET", "/users/", 400, ""},
+        {"path traversal", "GET", "/users/../admin", 400, ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            req := httptest.NewRequest(tt.method, tt.path, nil)
+            rec := httptest.NewRecorder()
+
+            handler.ServeHTTP(rec, req)
+
+            if rec.Code != tt.wantStatus {
+                t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+            }
+            if tt.wantBody != "" && !strings.Contains(rec.Body.String(), tt.wantBody) {
+                t.Errorf("body = %q, want substring %q", rec.Body.String(), tt.wantBody)
+            }
+        })
+    }
+}
+```
+
+### Test server for integration tests
+
+```go
+func TestClientIntegration(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        switch {
+        case r.URL.Path == "/api/users" && r.Method == "GET":
+            w.Header().Set("Content-Type", "application/json")
+            json.NewEncoder(w).Encode([]User{{ID: "1", Name: "Alice"}})
+        default:
+            w.WriteHeader(404)
+        }
+    }))
+    defer srv.Close()
+
+    client := NewAPIClient(srv.URL)
+    users, err := client.ListUsers(context.Background())
+    // ...
+}
+```
+
+## Context & Cancellation
+
+```go
+func TestOperationRespectsContext(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel() // already cancelled
+
+    _, err := service.DoExpensiveThing(ctx)
+    if !errors.Is(err, context.Canceled) {
+        t.Errorf("expected context.Canceled, got %v", err)
+    }
+}
+
+func TestOperationTimeout(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+    defer cancel()
+
+    time.Sleep(5 * time.Millisecond) // ensure timeout fires
+    _, err := service.DoThing(ctx)
+    if !errors.Is(err, context.DeadlineExceeded) {
+        t.Errorf("expected DeadlineExceeded, got %v", err)
+    }
+}
+```
+
+## Error Wrapping & Sentinel Checks
+
+```go
+// Verify errors are properly wrapped for caller inspection
+func TestErrorWrapping(t *testing.T) {
+    _, err := repo.GetUser(ctx, "nonexistent")
+
+    // Caller should be able to check the sentinel
+    if !errors.Is(err, ErrNotFound) {
+        t.Errorf("expected ErrNotFound, got %v", err)
+    }
+
+    // Verify context is preserved in the chain
+    var notFoundErr *NotFoundError
+    if !errors.As(err, &notFoundErr) {
+        t.Fatalf("expected *NotFoundError in chain, got %T", err)
+    }
+    if notFoundErr.Resource != "user" {
+        t.Errorf("resource = %q, want %q", notFoundErr.Resource, "user")
+    }
+}
+```
+
+## Adversarial Patterns for Go
+
+### Race condition detection
+
+```go
+// Run with: go test -race -count=100 ./...
+func TestConcurrentMapAccess(t *testing.T) {
+    cache := NewCache()
+    var wg sync.WaitGroup
+    for i := 0; i < 100; i++ {
+        wg.Add(2)
+        go func(n int) {
+            defer wg.Done()
+            cache.Set(fmt.Sprintf("key-%d", n), n)
+        }(i)
+        go func(n int) {
+            defer wg.Done()
+            cache.Get(fmt.Sprintf("key-%d", n))
+        }(i)
+    }
+    wg.Wait()
+}
+```
+
+### Goroutine leak detection
+
+```go
+import "go.uber.org/goleak"
+
+func TestMain(m *testing.M) {
+    goleak.VerifyTestMain(m)
+}
+```
+
+### Nil receiver
+
+```go
+func TestNilReceiver(t *testing.T) {
+    var s *Service // nil
+    // Should panic or return error, not silently misbehave
+    defer func() {
+        if r := recover(); r == nil {
+            t.Error("expected panic on nil receiver, got none")
+        }
+    }()
+    s.DoThing()
+}
+```
+
+### JSON marshaling edge cases
+
+```go
+func TestJSONRoundTrip(t *testing.T) {
+    cases := []struct {
+        name  string
+        input User
+    }{
+        {"zero value", User{}},
+        {"unicode name", User{Name: ""}},
+        {"null-byte in string", User{Name: "foo\x00bar"}},
+        {"max-length name", User{Name: strings.Repeat("a", 10000)}},
+    }
+    for _, tt := range cases {
+        t.Run(tt.name, func(t *testing.T) {
+            data, err := json.Marshal(tt.input)
+            if err != nil {
+                t.Fatalf("marshal: %v", err)
+            }
+            var got User
+            if err := json.Unmarshal(data, &got); err != nil {
+                t.Fatalf("unmarshal: %v", err)
+            }
+            if diff := cmp.Diff(tt.input, got); diff != "" {
+                t.Errorf("roundtrip mismatch (-want +got):\n%s", diff)
+            }
+        })
+    }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Tests without `t.Run` subtests (can't identify which case failed)
+- Missing `t.Parallel()` on independent tests (hides race conditions)
+- Using `t.Fatal` in goroutines (panics, doesn't fail the test properly)
+- Asserting on string representations of errors instead of `errors.Is`/`errors.As`
+- Tests that depend on file system state without `t.TempDir()`
+- Using `time.Sleep` instead of channels/contexts for synchronization
+- Not running with `-race` flag in CI

--- a/.agents/skills/qa-author/references/htmx-lambda.md
+++ b/.agents/skills/qa-author/references/htmx-lambda.md
@@ -1,0 +1,312 @@
+# HTMX + Lambda Testing Reference
+
+Stack-specific patterns for adversarial testing of HTMX applications served by
+AWS Lambda handlers. This pattern is uncommon — most internet testing guidance
+doesn't cover it. Reference the actual request/response cycle.
+
+## Architecture
+
+```
+Browser → API Gateway → Lambda Handler → HTML Fragment Response
+         (hx-get/post)                    (not JSON, not full page)
+```
+
+Key differences from typical API testing:
+- Responses are **HTML fragments**, not JSON
+- `hx-*` attributes drive client behavior — they ARE the API contract
+- `HX-Trigger` response headers drive event-driven UI updates
+- No SPA router — server decides what HTML to swap
+
+## HTML Fragment Assertions
+
+Use cheerio (Node.js) or jsdom to parse and assert on HTML responses.
+
+```typescript
+import * as cheerio from 'cheerio';
+
+test('GET /users returns user list fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+
+  // Assert structure, not exact HTML string
+  expect($('ul#user-list li')).toHaveLength(3);
+  expect($('li').first().text()).toContain('Alice');
+
+  // Verify hx-* attributes — these are the API contract
+  expect($('li').first().attr('hx-get')).toBe('/users/1');
+  expect($('li').first().attr('hx-target')).toBe('#user-detail');
+  expect($('li').first().attr('hx-swap')).toBe('innerHTML');
+});
+```
+
+## HX-Trigger Header Assertions
+
+`HX-Trigger` response headers tell the client to fire events. These are part of
+the contract — test them explicitly.
+
+```typescript
+test('POST /users triggers userAdded event', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Bob', email: 'bob@example.com' }),
+    headers: {
+      'HX-Request': 'true',
+      'Content-Type': 'application/json',
+    },
+  }));
+
+  expect(response.statusCode).toBe(201);
+
+  // HX-Trigger can be a string (event name) or JSON (event + data)
+  const trigger = JSON.parse(response.headers['HX-Trigger']);
+  expect(trigger).toHaveProperty('userAdded');
+  expect(trigger.userAdded).toMatchObject({ id: expect.any(String) });
+});
+
+test('DELETE /users/:id triggers userList refresh', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'DELETE',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  // After delete, the response should trigger a list refresh
+  expect(response.headers['HX-Trigger']).toContain('refreshUserList');
+});
+```
+
+## hx-* Attribute Testing
+
+The `hx-*` attributes in rendered HTML ARE the client-side routing. Test them
+like you'd test API routes.
+
+```typescript
+test('edit form has correct hx-put target', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123/edit',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  const form = $('form');
+
+  // These attributes define the mutation contract
+  expect(form.attr('hx-put')).toBe('/users/123');
+  expect(form.attr('hx-target')).toBe('#user-detail');
+  expect(form.attr('hx-swap')).toBe('outerHTML');
+
+  // Verify form inputs exist for all required fields
+  expect($('input[name="name"]')).toHaveLength(1);
+  expect($('input[name="email"]')).toHaveLength(1);
+
+  // Verify CSRF token is present if applicable
+  expect($('input[name="_csrf"]').val()).toBeTruthy();
+});
+```
+
+## Template Rendering Assertions
+
+Verify that data is actually bound into templates correctly.
+
+```typescript
+test('user detail renders all fields', async () => {
+  // Setup: user exists in DB
+  await createUser({ id: '123', name: 'Alice', email: 'alice@example.com', role: 'admin' });
+
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+
+  // Verify data binding — not just that it rendered, but the RIGHT data
+  expect($('[data-field="name"]').text()).toBe('Alice');
+  expect($('[data-field="email"]').text()).toBe('alice@example.com');
+  expect($('[data-field="role"]').text()).toBe('admin');
+
+  // XSS: verify HTML entities are escaped in user content
+  await updateUser('123', { name: '<script>alert("xss")</script>' });
+  const xssResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+  expect(xssResponse.body).not.toContain('<script>');
+  expect(xssResponse.body).toContain('&lt;script&gt;');
+});
+```
+
+## Lambda Handler Integration Tests
+
+Use the API Gateway event shape directly — no HTTP framework abstractions.
+
+```typescript
+// Helper to construct API Gateway proxy events
+function apiGatewayEvent(opts: {
+  method: string;
+  path: string;
+  body?: string;
+  headers?: Record<string, string>;
+  pathParameters?: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+}): APIGatewayProxyEvent {
+  return {
+    httpMethod: opts.method,
+    path: opts.path,
+    body: opts.body ?? null,
+    headers: { 'HX-Request': 'true', ...opts.headers },
+    pathParameters: opts.pathParameters ?? null,
+    queryStringParameters: opts.queryStringParameters ?? null,
+    // ... other required fields with defaults
+  } as APIGatewayProxyEvent;
+}
+```
+
+### Non-HTMX requests (progressive enhancement)
+
+```typescript
+test('non-HTMX request returns full page', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: {}, // No HX-Request header
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Full page should have html/head/body
+  expect($('html')).toHaveLength(1);
+  expect($('head title').text()).toBeTruthy();
+  expect($('body #user-list')).toHaveLength(1);
+});
+
+test('HTMX request returns fragment only', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Fragment should NOT have html/head/body wrappers
+  expect($('html')).toHaveLength(0);
+  expect($('head')).toHaveLength(0);
+});
+```
+
+## Adversarial Patterns for HTMX + Lambda
+
+### Swap target integrity
+
+```typescript
+// If hx-target references an element ID, that element must exist in the
+// page context. A missing target = silent failure (no visible error).
+test('all hx-target references resolve', async () => {
+  // Get the full page first
+  const pageResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/dashboard',
+    headers: {},
+  }));
+  const $page = cheerio.load(pageResponse.body);
+
+  // Find all hx-target attributes in fragment responses
+  const fragmentResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const $fragment = cheerio.load(fragmentResponse.body);
+
+  $fragment('[hx-target]').each((_, el) => {
+    const target = $fragment(el).attr('hx-target');
+    if (target && target.startsWith('#')) {
+      expect($page(target).length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+### Error responses as HTML
+
+```typescript
+// Errors must return HTML fragments (not JSON) for HTMX to display
+test('validation error returns HTML error fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: '', email: 'not-an-email' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  // Should be 422, not 400 (HTMX doesn't swap on non-2xx by default unless
+  // hx-target-error is set)
+  expect(response.statusCode).toBe(422);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+  expect($('.error-message')).toHaveLength(2); // name + email
+  expect($('.error-message').first().text()).toContain('required');
+});
+```
+
+### Out-of-band swaps (hx-swap-oob)
+
+```typescript
+test('response includes OOB update for notification area', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // OOB element should target the toast area
+  const oob = $('[hx-swap-oob="true"]');
+  expect(oob).toHaveLength(1);
+  expect(oob.attr('id')).toBe('notifications');
+  expect(oob.text()).toContain('User created');
+});
+```
+
+### Cold start / timeout behavior
+
+```typescript
+test('handler responds within API Gateway timeout', async () => {
+  const start = Date.now();
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const elapsed = Date.now() - start;
+
+  // API Gateway default timeout is 29s; Lambda should be well under
+  expect(elapsed).toBeLessThan(5000);
+  expect(response.statusCode).toBe(200);
+});
+```
+
+## Anti-Patterns to Catch
+
+- Asserting on HTML string equality (brittle — whitespace, attribute order)
+- Not testing the `HX-Request` header presence/absence fork
+- Returning JSON error responses to HTMX requests (won't render)
+- Missing `HX-Trigger` headers after mutations (client doesn't know to refresh)
+- `hx-target` pointing to IDs that don't exist in the page context
+- Not escaping user content in templates (XSS via HTML injection)
+- Testing with framework abstractions instead of raw API Gateway events
+- Ignoring `hx-swap` strategy in assertions (innerHTML vs outerHTML matters)

--- a/.agents/skills/qa-author/references/nestjs.md
+++ b/.agents/skills/qa-author/references/nestjs.md
@@ -1,0 +1,182 @@
+# NestJS Testing Reference
+
+Stack-specific patterns for adversarial testing of NestJS applications.
+
+## Unit Tests
+
+### Module setup
+
+```typescript
+const module = await Test.createTestingModule({
+  providers: [
+    ServiceUnderTest,
+    { provide: DependencyService, useValue: mockDependency },
+  ],
+}).compile();
+
+const service = module.get<ServiceUnderTest>(ServiceUnderTest);
+```
+
+### Provider override patterns
+
+```typescript
+// Override a single provider for isolation
+const module = await Test.createTestingModule({
+  imports: [AppModule],
+})
+  .overrideProvider(DatabaseService)
+  .useValue(mockDb)
+  .compile();
+```
+
+### Guard testing in isolation
+
+```typescript
+// Test guards independently from controllers
+const guard = new AuthGuard(mockReflector, mockAuthService);
+const context = createMockExecutionContext({ user: null });
+await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+```
+
+### Interceptor testing
+
+```typescript
+const interceptor = new TransformInterceptor();
+const context = createMockExecutionContext();
+const next = { handle: () => of(rawData) };
+const result = await lastValueFrom(interceptor.intercept(context, next));
+expect(result).toEqual(expectedTransformedShape);
+```
+
+## Integration / E2E Tests
+
+### Supertest patterns
+
+```typescript
+const app = moduleFixture.createNestApplication();
+// Apply the same pipes/guards as production
+app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+await app.init();
+
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send(payload)
+  .expect(201);
+
+// Assert response SHAPE, not just status
+expect(response.body).toMatchObject({
+  id: expect.any(String),
+  email: payload.email,
+  createdAt: expect.any(String),
+});
+
+// Assert headers when relevant
+expect(response.headers['content-type']).toMatch(/application\/json/);
+```
+
+### Transactional test DB
+
+```typescript
+// Per-test transaction rollback for isolation
+beforeEach(async () => {
+  queryRunner = dataSource.createQueryRunner();
+  await queryRunner.startTransaction();
+});
+
+afterEach(async () => {
+  await queryRunner.rollbackTransaction();
+  await queryRunner.release();
+});
+```
+
+### Testing error responses
+
+```typescript
+// Don't just check status — verify the error shape
+const response = await request(app.getHttpServer())
+  .get('/users/nonexistent-id')
+  .expect(404);
+
+expect(response.body).toMatchObject({
+  statusCode: 404,
+  message: expect.any(String),
+  // Should NOT contain stack traces or internal paths
+});
+expect(response.body.message).not.toMatch(/\/src\//);
+expect(response.body.message).not.toMatch(/Error:/);
+```
+
+## Adversarial Patterns for NestJS
+
+### DTO validation bypass
+
+```typescript
+// ValidationPipe with whitelist:true should strip unknown properties
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send({ ...validPayload, isAdmin: true, __proto__: { admin: true } })
+  .expect(201);
+
+// Verify the extra fields did NOT persist
+const user = await userRepo.findOne({ where: { id: response.body.id } });
+expect(user.isAdmin).toBeFalsy();
+```
+
+### Authorization boundary tests
+
+```typescript
+// User A accessing User B's resource
+const tokenA = await getToken(userA);
+const response = await request(app.getHttpServer())
+  .get(`/users/${userB.id}/settings`)
+  .set('Authorization', `Bearer ${tokenA}`)
+  .expect(403); // or 404 — don't reveal existence
+
+// Expired token
+const expiredToken = generateExpiredToken(userA);
+await request(app.getHttpServer())
+  .get('/protected')
+  .set('Authorization', `Bearer ${expiredToken}`)
+  .expect(401);
+```
+
+### Pipe/guard ordering
+
+NestJS applies guards before pipes before interceptors. Test that auth rejection
+happens BEFORE validation (don't leak validation errors to unauthenticated users):
+
+```typescript
+// Invalid body + no auth = should get 401, not 400
+await request(app.getHttpServer())
+  .post('/protected')
+  .send({ invalid: 'payload' })
+  // No auth header
+  .expect(401);
+```
+
+### Exception filter coverage
+
+```typescript
+// Verify custom exception filters handle all expected error types
+// and don't leak internal errors on unexpected ones
+const unknownError = new Error('unexpected internal failure');
+// Trigger via a mocked provider that throws
+mockService.doThing.mockRejectedValue(unknownError);
+
+const response = await request(app.getHttpServer())
+  .get('/endpoint-using-service')
+  .expect(500);
+
+// Generic message, no stack trace
+expect(response.body.message).toBe('Internal server error');
+expect(JSON.stringify(response.body)).not.toContain('unexpected internal failure');
+```
+
+## Anti-Patterns to Catch
+
+- Testing with `any` typed mocks that silently accept anything
+- Supertest assertions on status only (no body/header checks)
+- Tests that import and call the controller method directly (bypasses pipes/guards)
+- Mocking the repository inside a service test AND the service inside a
+  controller test — the integration gap is where bugs hide
+- Not testing validation pipe behavior (assuming DTOs "just work")

--- a/.agents/skills/qa-author/references/react.md
+++ b/.agents/skills/qa-author/references/react.md
@@ -1,0 +1,219 @@
+# React Testing Reference
+
+Stack-specific patterns for adversarial testing of React applications.
+
+## Philosophy
+
+Test behavior, not implementation. Users don't know about state variables,
+effect hooks, or component hierarchies — they know about clicking buttons and
+seeing results.
+
+## Rendering & Queries
+
+### Prefer accessible queries
+
+```typescript
+// Good — queries the way a screen reader does
+screen.getByRole('button', { name: /submit/i });
+screen.getByLabelText(/email address/i);
+screen.getByText(/no results found/i);
+
+// Bad — brittle, tests implementation
+container.querySelector('.submit-btn');
+screen.getByTestId('submit-button'); // last resort only
+```
+
+### Query priority (Testing Library)
+
+1. `getByRole` — accessible name/role (best)
+2. `getByLabelText` — form fields
+3. `getByPlaceholderText` — when no label exists
+4. `getByText` — non-interactive content
+5. `getByDisplayValue` — filled-in form fields
+6. `getByAltText` — images
+7. `getByTitle` — title attribute
+8. `getByTestId` — last resort (no semantic meaning)
+
+## User Interaction
+
+### Always use `userEvent` over `fireEvent`
+
+```typescript
+import userEvent from '@testing-library/user-event';
+
+const user = userEvent.setup();
+
+// Good — simulates real user behavior (focus, keydown, keyup, input, change)
+await user.click(screen.getByRole('button', { name: /save/i }));
+await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+await user.selectOptions(screen.getByRole('combobox'), 'option-value');
+
+// Bad — only fires a single synthetic event
+fireEvent.click(button);
+fireEvent.change(input, { target: { value: 'text' } });
+```
+
+### Keyboard navigation
+
+```typescript
+// Tab order matters for accessibility
+await user.tab();
+expect(screen.getByLabelText(/first name/i)).toHaveFocus();
+await user.tab();
+expect(screen.getByLabelText(/last name/i)).toHaveFocus();
+
+// Escape to close
+await user.keyboard('{Escape}');
+expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+```
+
+## Async Patterns
+
+### Waiting for state updates
+
+```typescript
+// Good — waits for the element to appear
+await waitFor(() => {
+  expect(screen.getByText(/success/i)).toBeInTheDocument();
+});
+
+// Good — for elements that appear after async operations
+const successMessage = await screen.findByText(/saved successfully/i);
+expect(successMessage).toBeInTheDocument();
+
+// Bad — arbitrary timeouts
+await new Promise(resolve => setTimeout(resolve, 1000));
+```
+
+### Act warnings
+
+If you see "act() warnings," the component is updating state outside of the
+test's awareness. Fix by:
+1. Using `waitFor` / `findBy` for async updates
+2. Ensuring all promises resolve before assertions
+
+```typescript
+// If a component fetches on mount:
+render(<UserProfile userId="123" />);
+// Wait for loading to finish
+await waitFor(() => {
+  expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+});
+// Now assert on the loaded state
+expect(screen.getByText(/John Doe/i)).toBeInTheDocument();
+```
+
+## Adversarial Patterns for React
+
+### Error boundary testing
+
+```typescript
+// Verify error boundaries catch and display fallback UI
+const ThrowingChild = () => { throw new Error('render failure'); };
+
+render(
+  <ErrorBoundary fallback={<div>Something went wrong</div>}>
+    <ThrowingChild />
+  </ErrorBoundary>
+);
+
+expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+// Verify the error didn't propagate to the whole page
+expect(screen.queryByText(/unhandled/i)).not.toBeInTheDocument();
+```
+
+### Loading / error / empty states
+
+```typescript
+// Every data-fetching component has three states — test all three
+// 1. Loading
+render(<UserList />);
+expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+// 2. Error
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.status(500))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+});
+
+// 3. Empty
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.json([]))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+});
+```
+
+### Form validation edge cases
+
+```typescript
+// Rapid submission (double-click prevention)
+const submitButton = screen.getByRole('button', { name: /submit/i });
+await user.click(submitButton);
+await user.click(submitButton); // immediate second click
+// Should only submit once
+expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+// Paste into validated field
+await user.click(screen.getByLabelText(/phone/i));
+await user.paste('not-a-phone-number');
+await user.click(submitButton);
+expect(screen.getByText(/invalid phone/i)).toBeInTheDocument();
+
+// Unicode in text inputs
+await user.type(screen.getByLabelText(/name/i), '');
+// Verify it renders correctly, doesn't crash, doesn't truncate
+expect(screen.getByLabelText(/name/i)).toHaveValue('');
+```
+
+### Accessibility assertions
+
+```typescript
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+const { container } = render(<MyComponent />);
+const results = await axe(container);
+expect(results).toHaveNoViolations();
+
+// Also verify ARIA states update correctly
+const expandButton = screen.getByRole('button', { name: /show details/i });
+expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+await user.click(expandButton);
+expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+```
+
+### Responsive / conditional rendering
+
+```typescript
+// Test that mobile-only elements aren't rendered on desktop viewport
+// (if using media queries that affect DOM structure)
+Object.defineProperty(window, 'innerWidth', { value: 1024 });
+window.dispatchEvent(new Event('resize'));
+render(<Navigation />);
+expect(screen.queryByRole('button', { name: /menu/i })).not.toBeInTheDocument();
+```
+
+### Unmount / cleanup
+
+```typescript
+// Verify no memory leaks: subscriptions, timers, listeners cleaned up
+const { unmount } = render(<RealTimeComponent />);
+unmount();
+// Advance timers — should not throw "setState on unmounted component"
+jest.advanceTimersByTime(5000);
+// No console.error about unmounted state updates
+expect(consoleSpy).not.toHaveBeenCalled();
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot tests as the sole assertion (they prove nothing broke, not that
+  anything works)
+- Testing state directly via component internals (e.g., accessing `.state`)
+- Querying by class name or CSS selector
+- `fireEvent` when `userEvent` is available
+- Missing `await` on async interactions (tests pass but are non-deterministic)
+- Testing that a mock was called instead of testing the visible effect
+- Not testing disabled/loading states of buttons during async operations

--- a/.agents/skills/qa-bug-report/SKILL.md
+++ b/.agents/skills/qa-bug-report/SKILL.md
@@ -111,7 +111,7 @@ If the user confirms, create a ticket:
 tkt create \
   --type Bug \
   --summary "<one-line summary>" \
-  --description "<full report body>" \
+  --body "<full report body>" \
   --priority "<severity-mapped-priority>"
 ```
 

--- a/.github/prompts/qa-author.prompt.md
+++ b/.github/prompts/qa-author.prompt.md
@@ -1,0 +1,33 @@
+---
+mode: agent
+description: 'Write adversarial tests focused on failure modes and edge cases, red-before-green enforced.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# QA Author
+
+Write tests that find where code breaks. The developer already tested the happy path — you exist to find what they missed. Produce working test code, not essays.
+
+## Steps
+
+1. Read the implementation under test: public API surface, branching logic, external dependencies, error paths.
+2. Read existing tests for the same module so you don't duplicate coverage.
+3. Detect the stack and load the matching reference from `skills/qa-author/references/`: `nestjs.md`, `react.md`, `go.md`, `cdk.md`, or `htmx-lambda.md`. No match → infer conventions from neighboring test files.
+4. If a `TEST-PLAN.md` from `qa-strategy` exists, implement its cases rather than re-deriving them.
+5. Walk the Break-It Checklist and enumerate failure scenarios: boundary (0, 1, n, n+1, max, negative, empty), null vs undefined vs missing, authorization (cross-user access, privilege escalation, token expiry mid-operation), concurrency (same-row writes, TOCTOU, pool exhaustion), idempotency (double-submit, retry after timeout), partial failure (DB write succeeds but API call doesn't), time (timezone, DST, expiry boundary), pagination (unstable sort, cursor drift, page beyond total), encoding (unicode, 10k inputs, injection, path traversal), error propagation (no leaked internals, correct status codes).
+6. Write the tests. Descriptive names stating scenario and expected outcome; specific assertions; no shared mutable state between tests.
+7. **Verify red-before-green (mandatory).** Every new test must fail first against the code path it exercises. If one passes immediately: either the bug doesn't exist (remove it), it doesn't exercise the failure path (fix it), or the assertion is too weak (strengthen it).
+
+## Forbidden cheats
+
+`.skip()` or deleting a failing test · weakening an assertion to match wrong output · `sleep()` to paper over a flake · mocking the unit under test · `toBeDefined()` alone · catch-all try/catch that swallows errors · any test that passes regardless of implementation.
+
+## Output
+
+Test files in the project's convention, each with a header comment listing the Break-It dimensions covered and the `TEST-PLAN.md` cases mapped.
+
+## Rules
+
+- Write **only** test files (`**/*.test.*`, `**/*.spec.*`, `**/__tests__/**`, `**/test/**`).
+- Never modify implementation code. If it's buggy, write a test proving it.
+- No ticket operations, no commits, no pushes.

--- a/.github/prompts/qa-bug-report.prompt.md
+++ b/.github/prompts/qa-bug-report.prompt.md
@@ -1,0 +1,50 @@
+---
+mode: agent
+description: 'Produce a structured bug report with minimal reproduction steps; optionally file it via tkt.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# QA Bug Report
+
+Distill a failing scenario — test output, error log, user report, or observed behavior — into a minimal, actionable bug report.
+
+## Steps
+
+1. Identify the failure: what was attempted, what went wrong (error, wrong output, crash, hang), under what conditions.
+2. Reduce to minimal reproduction: the fewest steps and least setup that still trigger it. Prefer a test or a `curl` over UI steps.
+3. Classify severity: **Critical** (data loss, security breach, outage) · **High** (core feature broken, no workaround) · **Medium** (degraded, workaround exists) · **Low** (cosmetic, rare edge case).
+4. Classify reproducibility: **Always** (100%) · **Often** (>50%) · **Intermittent** (<50%, timing or state dependent) · **Rare**.
+5. Read the code path and identify the suspected root cause — which module is at fault, and whether it's logic, data, a race, or configuration.
+6. Format the report (below).
+7. **Optional, only on explicit confirmation** — file it:
+   ```shell
+   tkt create --type Bug --summary "<one-line summary>" \
+     --body "<full report body>" --priority "<mapped priority>"
+   ```
+   Never create the ticket automatically. Ask first.
+
+## Output
+
+```markdown
+## Bug Report
+
+**Summary:** <one line>   **Severity:** ...   **Component:** ...   **Reproducibility:** ...
+
+### Steps to Reproduce
+1. <setup>  2. <action>  3. Observe: <what goes wrong>
+
+### Expected / Actual Behavior
+### Environment          (branch, commit, runtime, relevant config)
+### Evidence             (trimmed log, stack trace, or test output)
+### Root Cause (suspected)
+### Suggested Fix
+### Regression?          (yes — worked in X / no / unknown — needs bisection)
+```
+
+## Rules
+
+- Read-only by default; create a ticket only when the user confirms.
+- Document the bug, don't fix it. No code changes.
+- Never `tkt transition` an existing ticket. No commits or pushes.
+- Every field must be specific. "Something is broken" is not a bug report.
+- Mark uncertainty as "suspected" — never present a guess as fact.

--- a/.github/prompts/qa-critique.prompt.md
+++ b/.github/prompts/qa-critique.prompt.md
@@ -1,0 +1,32 @@
+---
+mode: agent
+description: 'Score an existing test suite for coverage gaps, assertion strength, and false confidence.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# QA Critique
+
+Evaluate an existing test suite for adequacy. Identifies what's missing so `qa-author` can fill it. Does NOT write tests.
+
+## Steps
+
+1. Read the test files in scope: what's under test, what scenarios run, what's asserted, how isolation is handled.
+2. Read the implementation: every branch, external dependency, authorization check (or its absence), error path.
+3. **Coverage gaps** — per public function/endpoint/handler: tested at all? which branches have no test? which error paths are unexercised?
+4. **Assertion quality** — strong (`expect(result.amount).toBe(150.00)`) → adequate (`toMatchObject`) → weak (`toBeDefined()` alone, flag) → meaningless (`expect(true).toBe(true)`, critical) → tautological (passes regardless of implementation, critical).
+5. **False confidence** — mock-heavy tests where the mock covers most of the path; mocks returning exactly what the code expects; assertions on mock calls rather than results; try/catch that swallows without asserting.
+6. **Break-It Checklist** — mark each dimension exercised or missing: boundary, null/missing, authorization, concurrency, idempotency, partial failure, time, pagination, encoding, performance, error propagation.
+7. **Isolation** — shared mutable state, ordering dependencies, global setup hiding per-test requirements.
+8. **Maintenance burden** — brittle tests coupled to implementation details, snapshots without targeted assertions, deep mock hierarchies.
+9. Score 1–10: 9–10 adversarial quality · 7–8 good with edge-case gaps · 5–6 happy-path only · 3–4 sparse and weak · 1–2 cosmetic, false confidence.
+
+## Output
+
+Markdown critique with the score, coverage gaps, weak assertions (file:line), false-confidence findings, missing Break-It dimensions, isolation and maintenance concerns, and prioritized P0/P1/P2 recommendations.
+
+## Rules
+
+- Read-only. Modify nothing.
+- No ticket operations, no git mutations.
+- Every finding cites a specific file:line and says what should be there instead.
+- If you can't judge adequacy without more context, say so rather than guessing.

--- a/.github/prompts/qa-flake-triage.prompt.md
+++ b/.github/prompts/qa-flake-triage.prompt.md
@@ -1,0 +1,51 @@
+---
+mode: agent
+description: 'Classify a flaky test root cause and propose a real fix — never sleep, never skip.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# QA Flake Triage
+
+Diagnose a non-deterministic test failure. Classify it, find the root cause, propose a real fix.
+
+## Steps
+
+1. Read the failing test: what it exercises, what it asserts, its setup/teardown, what external resources it touches.
+2. Gather failure evidence — error and stack trace, timing, which assertion failed, actual vs expected. CI history if available:
+   ```shell
+   gh run view <id> --log-failed
+   gh run list --workflow=<workflow> --limit=20 --json conclusion,startedAt,databaseId
+   ```
+3. Classify:
+   - **Race condition** — passes with delay, fails under load; async without proper synchronization
+   - **Shared state** — passes in isolation, fails after a specific other test; order-dependent
+   - **Non-deterministic ordering** — assertions on ties, map iteration order, query missing `ORDER BY`
+   - **Clock sensitivity** — fails near midnight, DST, or second boundaries; unmocked `Date.now()`/`time.Now()`
+   - **External dependency** — timeouts, connection refused, real network calls in tests
+   - **Resource exhaustion** — fails later in the suite; pool errors, leaked handles or goroutines
+   - **Platform-specific** — CI vs local; hardcoded paths, locale or timezone assumptions
+4. Corroborate the classification with specific signals in the code before committing to it.
+5. Propose the **real** fix, never the workaround:
+
+   | Class | Correct fix | Forbidden |
+   |---|---|---|
+   | Race | proper synchronization (mutex, channel, await) | `sleep(5000)` |
+   | Shared state | per-test isolation (transaction, temp dir, fresh instance) | forcing sequential runs |
+   | Ordering | remove order dependency, add stable sort | `.skip()` |
+   | Clock | mock time, use relative comparisons | widening tolerance |
+   | External dep | mock the service, use test containers | retry loops |
+   | Resource | fix the leak (close, cancel contexts) | raising pool size |
+   | Platform | `path.join`, normalized TZ, `t.TempDir()` | skipping on a platform |
+
+6. State confidence: high (reproducer exists), medium (circumstantial), low (needs more data).
+
+## Output
+
+Classification + confidence, evidence, root cause, before/after fix diff, a verification command with expected 0 failures over N runs, and an alternative hypothesis if the fix doesn't hold.
+
+## Rules
+
+- Never paper over the flake — no `sleep()`, `.skip()`, widened tolerances, or raised timeouts.
+- Never weaken a correct assertion; fix the code or the setup instead.
+- May modify test files only. Never modify implementation code — document the race and recommend the fix.
+- Read-only ticketing. No commits or pushes.

--- a/.github/prompts/qa-strategy.prompt.md
+++ b/.github/prompts/qa-strategy.prompt.md
@@ -1,0 +1,34 @@
+---
+mode: agent
+description: 'Generate a structured test plan from ticket requirements or a spec via tkt.'
+tools: ['search/codebase', 'terminal', 'file']
+---
+
+# QA Strategy
+
+Map requirements to concrete test cases. Prioritize failure modes over happy paths — assume the code is wrong until proven otherwise. This produces the plan that `qa-author` implements; it does NOT write test files.
+
+## Steps
+
+1. Extract acceptance criteria:
+   ```shell
+   tkt view "$KEY" --json | jq -r '.acceptance[]'
+   ```
+   If the input is a spec document instead, extract testable assertions from its text.
+2. For each criterion, walk the Break-It Checklist and enumerate cases across: boundary (0, 1, n, n+1, max, negative, empty), null/missing, authorization (horizontal, vertical, expiry), concurrency (TOCTOU, pool exhaustion), idempotency, partial failure, time (timezone, DST, expiry boundary), pagination (unstable sort, cursor drift), encoding (unicode, injection, path traversal), performance (N+1, unbounded), error propagation.
+3. Skip dimensions that don't apply — but state which you considered and dismissed.
+4. Assign priority: P0 blocks release (security, data loss, core broken), P1 fix before ship, P2 nice to have.
+5. Flag **untested** criteria (no case mapped) and **untestable** ones (vague or no definition of done — recommend how to make them testable).
+6. Produce a risk table: what breaks, severity, likelihood, mitigation.
+7. If BDD is configured (`tkt cfg build.bdd` exits 0), also emit `.feature` files in Gherkin.
+
+## Output
+
+`TEST-PLAN.md` with: requirements coverage matrix, test cases (each with type, priority, dimension, preconditions, steps, expected, and how to verify it fails against buggy code), untested/untestable requirements, risk table, and dimensions considered.
+
+## Rules
+
+- Read-only ticketing — `tkt view` and `tkt cfg` only. Never transition, comment, or create.
+- No code changes. This produces a plan, not tests.
+- No happy-path padding. Focus on what the developer will miss.
+- Every case needs specific inputs and expected outputs. "Test that it handles errors" is not a test case.

--- a/.kiro/skills/qa-author/references/cdk.md
+++ b/.kiro/skills/qa-author/references/cdk.md
@@ -1,0 +1,267 @@
+# AWS CDK Testing Reference
+
+Stack-specific patterns for adversarial testing of AWS CDK infrastructure code.
+
+## Template Assertions
+
+### Basic resource property assertions
+
+```typescript
+import { Template, Match } from 'aws-cdk-lib/assertions';
+
+const template = Template.fromStack(stack);
+
+// Verify a resource exists with specific properties
+template.hasResourceProperties('AWS::Lambda::Function', {
+  Runtime: 'nodejs20.x',
+  Timeout: 30,
+  MemorySize: 256,
+  Environment: {
+    Variables: {
+      NODE_ENV: 'production',
+    },
+  },
+});
+
+// Verify resource COUNT (catches accidental duplicates or missing resources)
+template.resourceCountIs('AWS::Lambda::Function', 3);
+```
+
+### Security-focused assertions
+
+```typescript
+// S3 bucket encryption
+template.hasResourceProperties('AWS::S3::Bucket', {
+  BucketEncryption: {
+    ServerSideEncryptionConfiguration: [
+      {
+        ServerSideEncryptionByDefault: {
+          SSEAlgorithm: 'aws:kms',
+        },
+      },
+    ],
+  },
+  PublicAccessBlockConfiguration: {
+    BlockPublicAcls: true,
+    BlockPublicPolicy: true,
+    IgnorePublicAcls: true,
+    RestrictPublicBuckets: true,
+  },
+});
+
+// No public S3 buckets
+template.hasResourceProperties('AWS::S3::BucketPolicy', {
+  PolicyDocument: Match.not(
+    Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Principal: '*',
+          Effect: 'Allow',
+        }),
+      ]),
+    })
+  ),
+});
+
+// RDS encryption at rest
+template.hasResourceProperties('AWS::RDS::DBInstance', {
+  StorageEncrypted: true,
+  DeletionProtection: true,
+});
+
+// Security group — no 0.0.0.0/0 ingress on sensitive ports
+template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+  SecurityGroupIngress: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        CidrIp: '0.0.0.0/0',
+        FromPort: 5432, // postgres
+      }),
+    ])
+  ),
+});
+```
+
+### IAM least-privilege assertions
+
+```typescript
+// Lambda role should NOT have wildcard actions
+const roles = template.findResources('AWS::IAM::Role');
+for (const [logicalId, role] of Object.entries(roles)) {
+  const policies = role.Properties?.Policies ?? [];
+  for (const policy of policies) {
+    const statements = policy.PolicyDocument?.Statement ?? [];
+    for (const stmt of statements) {
+      if (stmt.Effect === 'Allow') {
+        expect(stmt.Action).not.toContain('*');
+        expect(stmt.Resource).not.toBe('*');
+      }
+    }
+  }
+}
+
+// Verify no inline policies with admin access
+template.hasResourceProperties('AWS::IAM::Role', {
+  Policies: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: '*',
+              Resource: '*',
+            }),
+          ]),
+        }),
+      }),
+    ])
+  ),
+});
+```
+
+## Snapshot Tests — Acknowledge Limits
+
+Snapshot tests are a **diff alarm**, not a test. They tell you "something changed"
+— not whether the change is correct or incorrect.
+
+```typescript
+// Snapshot: useful as a change-detection alarm
+// BUT: reviewing a 5000-line JSON diff is meaningless
+// Use targeted assertions for actual correctness guarantees
+test('stack matches snapshot', () => {
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
+});
+```
+
+**When snapshots are useful:**
+- Catching unintended resource deletions during refactors
+- Detecting drift from expected resource counts
+
+**When snapshots are harmful:**
+- As the sole test (proves nothing about correctness)
+- When they get auto-updated without review (`-u` is dangerous)
+- When the snapshot is too large to meaningfully review
+
+## Aspects for Cross-Stack Policy
+
+```typescript
+import { Annotations, IAspect, Stack } from 'aws-cdk-lib';
+import { CfnBucket } from 'aws-cdk-lib/aws-s3';
+
+class BucketEncryptionAspect implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof CfnBucket) {
+      if (!node.bucketEncryption) {
+        Annotations.of(node).addError('All S3 buckets must have encryption enabled');
+      }
+    }
+  }
+}
+
+// In test:
+test('all buckets are encrypted', () => {
+  Aspects.of(stack).add(new BucketEncryptionAspect());
+  const annotations = Annotations.fromStack(stack);
+  annotations.hasNoError('/MyStack/*', Match.anyValue());
+});
+```
+
+## Adversarial Patterns for CDK
+
+### Removal protection
+
+```typescript
+// DynamoDB tables should have deletion protection
+template.hasResource('AWS::DynamoDB::Table', {
+  DeletionPolicy: 'Retain',
+  UpdateReplacePolicy: 'Retain',
+});
+
+// Critical resources should not be replaceable on update
+template.hasResource('AWS::RDS::DBInstance', {
+  UpdateReplacePolicy: Match.not('Delete'),
+});
+```
+
+### Environment separation
+
+```typescript
+// Production stack should NOT reference dev account IDs
+const templateJson = JSON.stringify(template.toJSON());
+expect(templateJson).not.toContain('123456789012'); // dev account
+expect(templateJson).not.toContain('dev-');
+
+// Production stack should have higher resource limits
+template.hasResourceProperties('AWS::Lambda::Function', {
+  MemorySize: Match.not(128), // 128 = default = probably not tuned for prod
+  Timeout: Match.not(3),      // 3s = default = probably not tuned for prod
+});
+```
+
+### VPC / Network isolation
+
+```typescript
+// Lambda in VPC should have both private subnets
+template.hasResourceProperties('AWS::Lambda::Function', {
+  VpcConfig: {
+    SubnetIds: Match.not(Match.arrayWith([])), // not empty
+    SecurityGroupIds: Match.not(Match.arrayWith([])),
+  },
+});
+
+// No resources in public subnets that shouldn't be
+const publicSubnetRefs = findPublicSubnetRefs(template);
+const lambdas = template.findResources('AWS::Lambda::Function');
+for (const [id, lambda] of Object.entries(lambdas)) {
+  const subnets = lambda.Properties?.VpcConfig?.SubnetIds ?? [];
+  for (const subnet of subnets) {
+    expect(publicSubnetRefs).not.toContainEqual(subnet);
+  }
+}
+```
+
+### Cost traps
+
+```typescript
+// NAT Gateways are expensive — verify they're intentional
+const natCount = Object.keys(
+  template.findResources('AWS::EC2::NatGateway')
+).length;
+expect(natCount).toBeLessThanOrEqual(expectedNatCount);
+
+// On-demand instances when spot would suffice
+template.hasResourceProperties('AWS::ECS::Service', {
+  CapacityProviderStrategy: Match.arrayWith([
+    Match.objectLike({
+      CapacityProvider: Match.stringLikeRegexp('FARGATE_SPOT'),
+    }),
+  ]),
+});
+```
+
+### Cross-stack reference integrity
+
+```typescript
+// When stacks export values, verify consumers actually use them
+// (orphaned exports are tech debt and can't be removed without deploy coordination)
+const exports = template.findOutputs('*');
+for (const [name, output] of Object.entries(exports)) {
+  if (output.Export) {
+    // Document why this export exists
+    expect(output.Description).toBeDefined();
+  }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot-only testing (no targeted assertions on security/permissions)
+- Testing synthesized template but not the construct inputs (garbage-in verification)
+- Missing `DeletionPolicy: Retain` on stateful resources (databases, buckets)
+- Wildcard IAM permissions (`*` on Action or Resource)
+- Hardcoded account IDs or region strings in constructs
+- No assertions on security group rules (default allows all egress)
+- Missing encryption on data-at-rest resources
+- Lambda functions with default 3s timeout and 128MB memory in production

--- a/.kiro/skills/qa-author/references/go.md
+++ b/.kiro/skills/qa-author/references/go.md
@@ -1,0 +1,295 @@
+# Go Testing Reference
+
+Stack-specific patterns for adversarial testing of Go applications.
+
+## Table-Driven Tests
+
+The standard Go pattern. Every test function should start here.
+
+```go
+func TestParseUserID(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int64
+        wantErr bool
+    }{
+        {"valid", "123", 123, false},
+        {"zero", "0", 0, false},
+        {"negative", "-1", 0, true},
+        {"empty string", "", 0, true},
+        {"whitespace", "  42  ", 0, true},    // or 42 if trimming is expected
+        {"overflow", "9223372036854775808", 0, true},
+        {"non-numeric", "abc", 0, true},
+        {"float", "3.14", 0, true},
+        {"leading zero", "007", 7, false},    // verify octal isn't assumed
+        {"max int64", "9223372036854775807", 9223372036854775807, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ParseUserID(tt.input)
+            if tt.wantErr {
+                if err == nil {
+                    t.Errorf("ParseUserID(%q) = %d, want error", tt.input, got)
+                }
+                return
+            }
+            if err != nil {
+                t.Fatalf("ParseUserID(%q) unexpected error: %v", tt.input, err)
+            }
+            if got != tt.want {
+                t.Errorf("ParseUserID(%q) = %d, want %d", tt.input, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Parallel Tests
+
+```go
+func TestConcurrentAccess(t *testing.T) {
+    t.Parallel() // marks this test as safe to run in parallel
+
+    tests := []struct{ name, input string }{...}
+    for _, tt := range tests {
+        tt := tt // capture range variable (required pre-Go 1.22)
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel() // subtests run in parallel with each other
+            // ...
+        })
+    }
+}
+```
+
+Use `t.Parallel()` aggressively to surface race conditions. Run with
+`-race` flag: `go test -race ./...`
+
+## Interface Mocks
+
+Prefer hand-written mocks over framework magic. A mock is just a struct that
+implements the interface.
+
+```go
+type mockStore struct {
+    getUserFunc func(ctx context.Context, id string) (*User, error)
+    calls       []string // track what was called
+}
+
+func (m *mockStore) GetUser(ctx context.Context, id string) (*User, error) {
+    m.calls = append(m.calls, "GetUser:"+id)
+    if m.getUserFunc != nil {
+        return m.getUserFunc(ctx, id)
+    }
+    return nil, errors.New("not configured")
+}
+```
+
+This makes test behavior explicit and avoids mock framework DSL overhead.
+
+## HTTP Handler Testing
+
+```go
+func TestGetUserHandler(t *testing.T) {
+    // Setup
+    store := &mockStore{
+        getUserFunc: func(ctx context.Context, id string) (*User, error) {
+            if id == "existing" {
+                return &User{ID: "existing", Name: "Alice"}, nil
+            }
+            return nil, ErrNotFound
+        },
+    }
+    handler := NewUserHandler(store)
+
+    tests := []struct {
+        name       string
+        method     string
+        path       string
+        wantStatus int
+        wantBody   string
+    }{
+        {"happy path", "GET", "/users/existing", 200, `"name":"Alice"`},
+        {"not found", "GET", "/users/missing", 404, `"error"`},
+        {"wrong method", "POST", "/users/existing", 405, ""},
+        {"empty id", "GET", "/users/", 400, ""},
+        {"path traversal", "GET", "/users/../admin", 400, ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            req := httptest.NewRequest(tt.method, tt.path, nil)
+            rec := httptest.NewRecorder()
+
+            handler.ServeHTTP(rec, req)
+
+            if rec.Code != tt.wantStatus {
+                t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+            }
+            if tt.wantBody != "" && !strings.Contains(rec.Body.String(), tt.wantBody) {
+                t.Errorf("body = %q, want substring %q", rec.Body.String(), tt.wantBody)
+            }
+        })
+    }
+}
+```
+
+### Test server for integration tests
+
+```go
+func TestClientIntegration(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        switch {
+        case r.URL.Path == "/api/users" && r.Method == "GET":
+            w.Header().Set("Content-Type", "application/json")
+            json.NewEncoder(w).Encode([]User{{ID: "1", Name: "Alice"}})
+        default:
+            w.WriteHeader(404)
+        }
+    }))
+    defer srv.Close()
+
+    client := NewAPIClient(srv.URL)
+    users, err := client.ListUsers(context.Background())
+    // ...
+}
+```
+
+## Context & Cancellation
+
+```go
+func TestOperationRespectsContext(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel() // already cancelled
+
+    _, err := service.DoExpensiveThing(ctx)
+    if !errors.Is(err, context.Canceled) {
+        t.Errorf("expected context.Canceled, got %v", err)
+    }
+}
+
+func TestOperationTimeout(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+    defer cancel()
+
+    time.Sleep(5 * time.Millisecond) // ensure timeout fires
+    _, err := service.DoThing(ctx)
+    if !errors.Is(err, context.DeadlineExceeded) {
+        t.Errorf("expected DeadlineExceeded, got %v", err)
+    }
+}
+```
+
+## Error Wrapping & Sentinel Checks
+
+```go
+// Verify errors are properly wrapped for caller inspection
+func TestErrorWrapping(t *testing.T) {
+    _, err := repo.GetUser(ctx, "nonexistent")
+
+    // Caller should be able to check the sentinel
+    if !errors.Is(err, ErrNotFound) {
+        t.Errorf("expected ErrNotFound, got %v", err)
+    }
+
+    // Verify context is preserved in the chain
+    var notFoundErr *NotFoundError
+    if !errors.As(err, &notFoundErr) {
+        t.Fatalf("expected *NotFoundError in chain, got %T", err)
+    }
+    if notFoundErr.Resource != "user" {
+        t.Errorf("resource = %q, want %q", notFoundErr.Resource, "user")
+    }
+}
+```
+
+## Adversarial Patterns for Go
+
+### Race condition detection
+
+```go
+// Run with: go test -race -count=100 ./...
+func TestConcurrentMapAccess(t *testing.T) {
+    cache := NewCache()
+    var wg sync.WaitGroup
+    for i := 0; i < 100; i++ {
+        wg.Add(2)
+        go func(n int) {
+            defer wg.Done()
+            cache.Set(fmt.Sprintf("key-%d", n), n)
+        }(i)
+        go func(n int) {
+            defer wg.Done()
+            cache.Get(fmt.Sprintf("key-%d", n))
+        }(i)
+    }
+    wg.Wait()
+}
+```
+
+### Goroutine leak detection
+
+```go
+import "go.uber.org/goleak"
+
+func TestMain(m *testing.M) {
+    goleak.VerifyTestMain(m)
+}
+```
+
+### Nil receiver
+
+```go
+func TestNilReceiver(t *testing.T) {
+    var s *Service // nil
+    // Should panic or return error, not silently misbehave
+    defer func() {
+        if r := recover(); r == nil {
+            t.Error("expected panic on nil receiver, got none")
+        }
+    }()
+    s.DoThing()
+}
+```
+
+### JSON marshaling edge cases
+
+```go
+func TestJSONRoundTrip(t *testing.T) {
+    cases := []struct {
+        name  string
+        input User
+    }{
+        {"zero value", User{}},
+        {"unicode name", User{Name: ""}},
+        {"null-byte in string", User{Name: "foo\x00bar"}},
+        {"max-length name", User{Name: strings.Repeat("a", 10000)}},
+    }
+    for _, tt := range cases {
+        t.Run(tt.name, func(t *testing.T) {
+            data, err := json.Marshal(tt.input)
+            if err != nil {
+                t.Fatalf("marshal: %v", err)
+            }
+            var got User
+            if err := json.Unmarshal(data, &got); err != nil {
+                t.Fatalf("unmarshal: %v", err)
+            }
+            if diff := cmp.Diff(tt.input, got); diff != "" {
+                t.Errorf("roundtrip mismatch (-want +got):\n%s", diff)
+            }
+        })
+    }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Tests without `t.Run` subtests (can't identify which case failed)
+- Missing `t.Parallel()` on independent tests (hides race conditions)
+- Using `t.Fatal` in goroutines (panics, doesn't fail the test properly)
+- Asserting on string representations of errors instead of `errors.Is`/`errors.As`
+- Tests that depend on file system state without `t.TempDir()`
+- Using `time.Sleep` instead of channels/contexts for synchronization
+- Not running with `-race` flag in CI

--- a/.kiro/skills/qa-author/references/htmx-lambda.md
+++ b/.kiro/skills/qa-author/references/htmx-lambda.md
@@ -1,0 +1,312 @@
+# HTMX + Lambda Testing Reference
+
+Stack-specific patterns for adversarial testing of HTMX applications served by
+AWS Lambda handlers. This pattern is uncommon — most internet testing guidance
+doesn't cover it. Reference the actual request/response cycle.
+
+## Architecture
+
+```
+Browser → API Gateway → Lambda Handler → HTML Fragment Response
+         (hx-get/post)                    (not JSON, not full page)
+```
+
+Key differences from typical API testing:
+- Responses are **HTML fragments**, not JSON
+- `hx-*` attributes drive client behavior — they ARE the API contract
+- `HX-Trigger` response headers drive event-driven UI updates
+- No SPA router — server decides what HTML to swap
+
+## HTML Fragment Assertions
+
+Use cheerio (Node.js) or jsdom to parse and assert on HTML responses.
+
+```typescript
+import * as cheerio from 'cheerio';
+
+test('GET /users returns user list fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+
+  // Assert structure, not exact HTML string
+  expect($('ul#user-list li')).toHaveLength(3);
+  expect($('li').first().text()).toContain('Alice');
+
+  // Verify hx-* attributes — these are the API contract
+  expect($('li').first().attr('hx-get')).toBe('/users/1');
+  expect($('li').first().attr('hx-target')).toBe('#user-detail');
+  expect($('li').first().attr('hx-swap')).toBe('innerHTML');
+});
+```
+
+## HX-Trigger Header Assertions
+
+`HX-Trigger` response headers tell the client to fire events. These are part of
+the contract — test them explicitly.
+
+```typescript
+test('POST /users triggers userAdded event', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Bob', email: 'bob@example.com' }),
+    headers: {
+      'HX-Request': 'true',
+      'Content-Type': 'application/json',
+    },
+  }));
+
+  expect(response.statusCode).toBe(201);
+
+  // HX-Trigger can be a string (event name) or JSON (event + data)
+  const trigger = JSON.parse(response.headers['HX-Trigger']);
+  expect(trigger).toHaveProperty('userAdded');
+  expect(trigger.userAdded).toMatchObject({ id: expect.any(String) });
+});
+
+test('DELETE /users/:id triggers userList refresh', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'DELETE',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  // After delete, the response should trigger a list refresh
+  expect(response.headers['HX-Trigger']).toContain('refreshUserList');
+});
+```
+
+## hx-* Attribute Testing
+
+The `hx-*` attributes in rendered HTML ARE the client-side routing. Test them
+like you'd test API routes.
+
+```typescript
+test('edit form has correct hx-put target', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123/edit',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  const form = $('form');
+
+  // These attributes define the mutation contract
+  expect(form.attr('hx-put')).toBe('/users/123');
+  expect(form.attr('hx-target')).toBe('#user-detail');
+  expect(form.attr('hx-swap')).toBe('outerHTML');
+
+  // Verify form inputs exist for all required fields
+  expect($('input[name="name"]')).toHaveLength(1);
+  expect($('input[name="email"]')).toHaveLength(1);
+
+  // Verify CSRF token is present if applicable
+  expect($('input[name="_csrf"]').val()).toBeTruthy();
+});
+```
+
+## Template Rendering Assertions
+
+Verify that data is actually bound into templates correctly.
+
+```typescript
+test('user detail renders all fields', async () => {
+  // Setup: user exists in DB
+  await createUser({ id: '123', name: 'Alice', email: 'alice@example.com', role: 'admin' });
+
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+
+  // Verify data binding — not just that it rendered, but the RIGHT data
+  expect($('[data-field="name"]').text()).toBe('Alice');
+  expect($('[data-field="email"]').text()).toBe('alice@example.com');
+  expect($('[data-field="role"]').text()).toBe('admin');
+
+  // XSS: verify HTML entities are escaped in user content
+  await updateUser('123', { name: '<script>alert("xss")</script>' });
+  const xssResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+  expect(xssResponse.body).not.toContain('<script>');
+  expect(xssResponse.body).toContain('&lt;script&gt;');
+});
+```
+
+## Lambda Handler Integration Tests
+
+Use the API Gateway event shape directly — no HTTP framework abstractions.
+
+```typescript
+// Helper to construct API Gateway proxy events
+function apiGatewayEvent(opts: {
+  method: string;
+  path: string;
+  body?: string;
+  headers?: Record<string, string>;
+  pathParameters?: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+}): APIGatewayProxyEvent {
+  return {
+    httpMethod: opts.method,
+    path: opts.path,
+    body: opts.body ?? null,
+    headers: { 'HX-Request': 'true', ...opts.headers },
+    pathParameters: opts.pathParameters ?? null,
+    queryStringParameters: opts.queryStringParameters ?? null,
+    // ... other required fields with defaults
+  } as APIGatewayProxyEvent;
+}
+```
+
+### Non-HTMX requests (progressive enhancement)
+
+```typescript
+test('non-HTMX request returns full page', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: {}, // No HX-Request header
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Full page should have html/head/body
+  expect($('html')).toHaveLength(1);
+  expect($('head title').text()).toBeTruthy();
+  expect($('body #user-list')).toHaveLength(1);
+});
+
+test('HTMX request returns fragment only', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Fragment should NOT have html/head/body wrappers
+  expect($('html')).toHaveLength(0);
+  expect($('head')).toHaveLength(0);
+});
+```
+
+## Adversarial Patterns for HTMX + Lambda
+
+### Swap target integrity
+
+```typescript
+// If hx-target references an element ID, that element must exist in the
+// page context. A missing target = silent failure (no visible error).
+test('all hx-target references resolve', async () => {
+  // Get the full page first
+  const pageResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/dashboard',
+    headers: {},
+  }));
+  const $page = cheerio.load(pageResponse.body);
+
+  // Find all hx-target attributes in fragment responses
+  const fragmentResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const $fragment = cheerio.load(fragmentResponse.body);
+
+  $fragment('[hx-target]').each((_, el) => {
+    const target = $fragment(el).attr('hx-target');
+    if (target && target.startsWith('#')) {
+      expect($page(target).length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+### Error responses as HTML
+
+```typescript
+// Errors must return HTML fragments (not JSON) for HTMX to display
+test('validation error returns HTML error fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: '', email: 'not-an-email' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  // Should be 422, not 400 (HTMX doesn't swap on non-2xx by default unless
+  // hx-target-error is set)
+  expect(response.statusCode).toBe(422);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+  expect($('.error-message')).toHaveLength(2); // name + email
+  expect($('.error-message').first().text()).toContain('required');
+});
+```
+
+### Out-of-band swaps (hx-swap-oob)
+
+```typescript
+test('response includes OOB update for notification area', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // OOB element should target the toast area
+  const oob = $('[hx-swap-oob="true"]');
+  expect(oob).toHaveLength(1);
+  expect(oob.attr('id')).toBe('notifications');
+  expect(oob.text()).toContain('User created');
+});
+```
+
+### Cold start / timeout behavior
+
+```typescript
+test('handler responds within API Gateway timeout', async () => {
+  const start = Date.now();
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const elapsed = Date.now() - start;
+
+  // API Gateway default timeout is 29s; Lambda should be well under
+  expect(elapsed).toBeLessThan(5000);
+  expect(response.statusCode).toBe(200);
+});
+```
+
+## Anti-Patterns to Catch
+
+- Asserting on HTML string equality (brittle — whitespace, attribute order)
+- Not testing the `HX-Request` header presence/absence fork
+- Returning JSON error responses to HTMX requests (won't render)
+- Missing `HX-Trigger` headers after mutations (client doesn't know to refresh)
+- `hx-target` pointing to IDs that don't exist in the page context
+- Not escaping user content in templates (XSS via HTML injection)
+- Testing with framework abstractions instead of raw API Gateway events
+- Ignoring `hx-swap` strategy in assertions (innerHTML vs outerHTML matters)

--- a/.kiro/skills/qa-author/references/nestjs.md
+++ b/.kiro/skills/qa-author/references/nestjs.md
@@ -1,0 +1,182 @@
+# NestJS Testing Reference
+
+Stack-specific patterns for adversarial testing of NestJS applications.
+
+## Unit Tests
+
+### Module setup
+
+```typescript
+const module = await Test.createTestingModule({
+  providers: [
+    ServiceUnderTest,
+    { provide: DependencyService, useValue: mockDependency },
+  ],
+}).compile();
+
+const service = module.get<ServiceUnderTest>(ServiceUnderTest);
+```
+
+### Provider override patterns
+
+```typescript
+// Override a single provider for isolation
+const module = await Test.createTestingModule({
+  imports: [AppModule],
+})
+  .overrideProvider(DatabaseService)
+  .useValue(mockDb)
+  .compile();
+```
+
+### Guard testing in isolation
+
+```typescript
+// Test guards independently from controllers
+const guard = new AuthGuard(mockReflector, mockAuthService);
+const context = createMockExecutionContext({ user: null });
+await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+```
+
+### Interceptor testing
+
+```typescript
+const interceptor = new TransformInterceptor();
+const context = createMockExecutionContext();
+const next = { handle: () => of(rawData) };
+const result = await lastValueFrom(interceptor.intercept(context, next));
+expect(result).toEqual(expectedTransformedShape);
+```
+
+## Integration / E2E Tests
+
+### Supertest patterns
+
+```typescript
+const app = moduleFixture.createNestApplication();
+// Apply the same pipes/guards as production
+app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+await app.init();
+
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send(payload)
+  .expect(201);
+
+// Assert response SHAPE, not just status
+expect(response.body).toMatchObject({
+  id: expect.any(String),
+  email: payload.email,
+  createdAt: expect.any(String),
+});
+
+// Assert headers when relevant
+expect(response.headers['content-type']).toMatch(/application\/json/);
+```
+
+### Transactional test DB
+
+```typescript
+// Per-test transaction rollback for isolation
+beforeEach(async () => {
+  queryRunner = dataSource.createQueryRunner();
+  await queryRunner.startTransaction();
+});
+
+afterEach(async () => {
+  await queryRunner.rollbackTransaction();
+  await queryRunner.release();
+});
+```
+
+### Testing error responses
+
+```typescript
+// Don't just check status — verify the error shape
+const response = await request(app.getHttpServer())
+  .get('/users/nonexistent-id')
+  .expect(404);
+
+expect(response.body).toMatchObject({
+  statusCode: 404,
+  message: expect.any(String),
+  // Should NOT contain stack traces or internal paths
+});
+expect(response.body.message).not.toMatch(/\/src\//);
+expect(response.body.message).not.toMatch(/Error:/);
+```
+
+## Adversarial Patterns for NestJS
+
+### DTO validation bypass
+
+```typescript
+// ValidationPipe with whitelist:true should strip unknown properties
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send({ ...validPayload, isAdmin: true, __proto__: { admin: true } })
+  .expect(201);
+
+// Verify the extra fields did NOT persist
+const user = await userRepo.findOne({ where: { id: response.body.id } });
+expect(user.isAdmin).toBeFalsy();
+```
+
+### Authorization boundary tests
+
+```typescript
+// User A accessing User B's resource
+const tokenA = await getToken(userA);
+const response = await request(app.getHttpServer())
+  .get(`/users/${userB.id}/settings`)
+  .set('Authorization', `Bearer ${tokenA}`)
+  .expect(403); // or 404 — don't reveal existence
+
+// Expired token
+const expiredToken = generateExpiredToken(userA);
+await request(app.getHttpServer())
+  .get('/protected')
+  .set('Authorization', `Bearer ${expiredToken}`)
+  .expect(401);
+```
+
+### Pipe/guard ordering
+
+NestJS applies guards before pipes before interceptors. Test that auth rejection
+happens BEFORE validation (don't leak validation errors to unauthenticated users):
+
+```typescript
+// Invalid body + no auth = should get 401, not 400
+await request(app.getHttpServer())
+  .post('/protected')
+  .send({ invalid: 'payload' })
+  // No auth header
+  .expect(401);
+```
+
+### Exception filter coverage
+
+```typescript
+// Verify custom exception filters handle all expected error types
+// and don't leak internal errors on unexpected ones
+const unknownError = new Error('unexpected internal failure');
+// Trigger via a mocked provider that throws
+mockService.doThing.mockRejectedValue(unknownError);
+
+const response = await request(app.getHttpServer())
+  .get('/endpoint-using-service')
+  .expect(500);
+
+// Generic message, no stack trace
+expect(response.body.message).toBe('Internal server error');
+expect(JSON.stringify(response.body)).not.toContain('unexpected internal failure');
+```
+
+## Anti-Patterns to Catch
+
+- Testing with `any` typed mocks that silently accept anything
+- Supertest assertions on status only (no body/header checks)
+- Tests that import and call the controller method directly (bypasses pipes/guards)
+- Mocking the repository inside a service test AND the service inside a
+  controller test — the integration gap is where bugs hide
+- Not testing validation pipe behavior (assuming DTOs "just work")

--- a/.kiro/skills/qa-author/references/react.md
+++ b/.kiro/skills/qa-author/references/react.md
@@ -1,0 +1,219 @@
+# React Testing Reference
+
+Stack-specific patterns for adversarial testing of React applications.
+
+## Philosophy
+
+Test behavior, not implementation. Users don't know about state variables,
+effect hooks, or component hierarchies — they know about clicking buttons and
+seeing results.
+
+## Rendering & Queries
+
+### Prefer accessible queries
+
+```typescript
+// Good — queries the way a screen reader does
+screen.getByRole('button', { name: /submit/i });
+screen.getByLabelText(/email address/i);
+screen.getByText(/no results found/i);
+
+// Bad — brittle, tests implementation
+container.querySelector('.submit-btn');
+screen.getByTestId('submit-button'); // last resort only
+```
+
+### Query priority (Testing Library)
+
+1. `getByRole` — accessible name/role (best)
+2. `getByLabelText` — form fields
+3. `getByPlaceholderText` — when no label exists
+4. `getByText` — non-interactive content
+5. `getByDisplayValue` — filled-in form fields
+6. `getByAltText` — images
+7. `getByTitle` — title attribute
+8. `getByTestId` — last resort (no semantic meaning)
+
+## User Interaction
+
+### Always use `userEvent` over `fireEvent`
+
+```typescript
+import userEvent from '@testing-library/user-event';
+
+const user = userEvent.setup();
+
+// Good — simulates real user behavior (focus, keydown, keyup, input, change)
+await user.click(screen.getByRole('button', { name: /save/i }));
+await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+await user.selectOptions(screen.getByRole('combobox'), 'option-value');
+
+// Bad — only fires a single synthetic event
+fireEvent.click(button);
+fireEvent.change(input, { target: { value: 'text' } });
+```
+
+### Keyboard navigation
+
+```typescript
+// Tab order matters for accessibility
+await user.tab();
+expect(screen.getByLabelText(/first name/i)).toHaveFocus();
+await user.tab();
+expect(screen.getByLabelText(/last name/i)).toHaveFocus();
+
+// Escape to close
+await user.keyboard('{Escape}');
+expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+```
+
+## Async Patterns
+
+### Waiting for state updates
+
+```typescript
+// Good — waits for the element to appear
+await waitFor(() => {
+  expect(screen.getByText(/success/i)).toBeInTheDocument();
+});
+
+// Good — for elements that appear after async operations
+const successMessage = await screen.findByText(/saved successfully/i);
+expect(successMessage).toBeInTheDocument();
+
+// Bad — arbitrary timeouts
+await new Promise(resolve => setTimeout(resolve, 1000));
+```
+
+### Act warnings
+
+If you see "act() warnings," the component is updating state outside of the
+test's awareness. Fix by:
+1. Using `waitFor` / `findBy` for async updates
+2. Ensuring all promises resolve before assertions
+
+```typescript
+// If a component fetches on mount:
+render(<UserProfile userId="123" />);
+// Wait for loading to finish
+await waitFor(() => {
+  expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+});
+// Now assert on the loaded state
+expect(screen.getByText(/John Doe/i)).toBeInTheDocument();
+```
+
+## Adversarial Patterns for React
+
+### Error boundary testing
+
+```typescript
+// Verify error boundaries catch and display fallback UI
+const ThrowingChild = () => { throw new Error('render failure'); };
+
+render(
+  <ErrorBoundary fallback={<div>Something went wrong</div>}>
+    <ThrowingChild />
+  </ErrorBoundary>
+);
+
+expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+// Verify the error didn't propagate to the whole page
+expect(screen.queryByText(/unhandled/i)).not.toBeInTheDocument();
+```
+
+### Loading / error / empty states
+
+```typescript
+// Every data-fetching component has three states — test all three
+// 1. Loading
+render(<UserList />);
+expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+// 2. Error
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.status(500))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+});
+
+// 3. Empty
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.json([]))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+});
+```
+
+### Form validation edge cases
+
+```typescript
+// Rapid submission (double-click prevention)
+const submitButton = screen.getByRole('button', { name: /submit/i });
+await user.click(submitButton);
+await user.click(submitButton); // immediate second click
+// Should only submit once
+expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+// Paste into validated field
+await user.click(screen.getByLabelText(/phone/i));
+await user.paste('not-a-phone-number');
+await user.click(submitButton);
+expect(screen.getByText(/invalid phone/i)).toBeInTheDocument();
+
+// Unicode in text inputs
+await user.type(screen.getByLabelText(/name/i), '');
+// Verify it renders correctly, doesn't crash, doesn't truncate
+expect(screen.getByLabelText(/name/i)).toHaveValue('');
+```
+
+### Accessibility assertions
+
+```typescript
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+const { container } = render(<MyComponent />);
+const results = await axe(container);
+expect(results).toHaveNoViolations();
+
+// Also verify ARIA states update correctly
+const expandButton = screen.getByRole('button', { name: /show details/i });
+expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+await user.click(expandButton);
+expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+```
+
+### Responsive / conditional rendering
+
+```typescript
+// Test that mobile-only elements aren't rendered on desktop viewport
+// (if using media queries that affect DOM structure)
+Object.defineProperty(window, 'innerWidth', { value: 1024 });
+window.dispatchEvent(new Event('resize'));
+render(<Navigation />);
+expect(screen.queryByRole('button', { name: /menu/i })).not.toBeInTheDocument();
+```
+
+### Unmount / cleanup
+
+```typescript
+// Verify no memory leaks: subscriptions, timers, listeners cleaned up
+const { unmount } = render(<RealTimeComponent />);
+unmount();
+// Advance timers — should not throw "setState on unmounted component"
+jest.advanceTimersByTime(5000);
+// No console.error about unmounted state updates
+expect(consoleSpy).not.toHaveBeenCalled();
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot tests as the sole assertion (they prove nothing broke, not that
+  anything works)
+- Testing state directly via component internals (e.g., accessing `.state`)
+- Querying by class name or CSS selector
+- `fireEvent` when `userEvent` is available
+- Missing `await` on async interactions (tests pass but are non-deterministic)
+- Testing that a mock was called instead of testing the visible effect
+- Not testing disabled/loading states of buttons during async operations

--- a/.kiro/skills/qa-bug-report/SKILL.md
+++ b/.kiro/skills/qa-bug-report/SKILL.md
@@ -111,7 +111,7 @@ If the user confirms, create a ticket:
 tkt create \
   --type Bug \
   --summary "<one-line summary>" \
-  --description "<full report body>" \
+  --body "<full report body>" \
   --priority "<severity-mapped-priority>"
 ```
 

--- a/skills/qa-author/references/cdk.md
+++ b/skills/qa-author/references/cdk.md
@@ -1,0 +1,267 @@
+# AWS CDK Testing Reference
+
+Stack-specific patterns for adversarial testing of AWS CDK infrastructure code.
+
+## Template Assertions
+
+### Basic resource property assertions
+
+```typescript
+import { Template, Match } from 'aws-cdk-lib/assertions';
+
+const template = Template.fromStack(stack);
+
+// Verify a resource exists with specific properties
+template.hasResourceProperties('AWS::Lambda::Function', {
+  Runtime: 'nodejs20.x',
+  Timeout: 30,
+  MemorySize: 256,
+  Environment: {
+    Variables: {
+      NODE_ENV: 'production',
+    },
+  },
+});
+
+// Verify resource COUNT (catches accidental duplicates or missing resources)
+template.resourceCountIs('AWS::Lambda::Function', 3);
+```
+
+### Security-focused assertions
+
+```typescript
+// S3 bucket encryption
+template.hasResourceProperties('AWS::S3::Bucket', {
+  BucketEncryption: {
+    ServerSideEncryptionConfiguration: [
+      {
+        ServerSideEncryptionByDefault: {
+          SSEAlgorithm: 'aws:kms',
+        },
+      },
+    ],
+  },
+  PublicAccessBlockConfiguration: {
+    BlockPublicAcls: true,
+    BlockPublicPolicy: true,
+    IgnorePublicAcls: true,
+    RestrictPublicBuckets: true,
+  },
+});
+
+// No public S3 buckets
+template.hasResourceProperties('AWS::S3::BucketPolicy', {
+  PolicyDocument: Match.not(
+    Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Principal: '*',
+          Effect: 'Allow',
+        }),
+      ]),
+    })
+  ),
+});
+
+// RDS encryption at rest
+template.hasResourceProperties('AWS::RDS::DBInstance', {
+  StorageEncrypted: true,
+  DeletionProtection: true,
+});
+
+// Security group — no 0.0.0.0/0 ingress on sensitive ports
+template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+  SecurityGroupIngress: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        CidrIp: '0.0.0.0/0',
+        FromPort: 5432, // postgres
+      }),
+    ])
+  ),
+});
+```
+
+### IAM least-privilege assertions
+
+```typescript
+// Lambda role should NOT have wildcard actions
+const roles = template.findResources('AWS::IAM::Role');
+for (const [logicalId, role] of Object.entries(roles)) {
+  const policies = role.Properties?.Policies ?? [];
+  for (const policy of policies) {
+    const statements = policy.PolicyDocument?.Statement ?? [];
+    for (const stmt of statements) {
+      if (stmt.Effect === 'Allow') {
+        expect(stmt.Action).not.toContain('*');
+        expect(stmt.Resource).not.toBe('*');
+      }
+    }
+  }
+}
+
+// Verify no inline policies with admin access
+template.hasResourceProperties('AWS::IAM::Role', {
+  Policies: Match.not(
+    Match.arrayWith([
+      Match.objectLike({
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: '*',
+              Resource: '*',
+            }),
+          ]),
+        }),
+      }),
+    ])
+  ),
+});
+```
+
+## Snapshot Tests — Acknowledge Limits
+
+Snapshot tests are a **diff alarm**, not a test. They tell you "something changed"
+— not whether the change is correct or incorrect.
+
+```typescript
+// Snapshot: useful as a change-detection alarm
+// BUT: reviewing a 5000-line JSON diff is meaningless
+// Use targeted assertions for actual correctness guarantees
+test('stack matches snapshot', () => {
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
+});
+```
+
+**When snapshots are useful:**
+- Catching unintended resource deletions during refactors
+- Detecting drift from expected resource counts
+
+**When snapshots are harmful:**
+- As the sole test (proves nothing about correctness)
+- When they get auto-updated without review (`-u` is dangerous)
+- When the snapshot is too large to meaningfully review
+
+## Aspects for Cross-Stack Policy
+
+```typescript
+import { Annotations, IAspect, Stack } from 'aws-cdk-lib';
+import { CfnBucket } from 'aws-cdk-lib/aws-s3';
+
+class BucketEncryptionAspect implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof CfnBucket) {
+      if (!node.bucketEncryption) {
+        Annotations.of(node).addError('All S3 buckets must have encryption enabled');
+      }
+    }
+  }
+}
+
+// In test:
+test('all buckets are encrypted', () => {
+  Aspects.of(stack).add(new BucketEncryptionAspect());
+  const annotations = Annotations.fromStack(stack);
+  annotations.hasNoError('/MyStack/*', Match.anyValue());
+});
+```
+
+## Adversarial Patterns for CDK
+
+### Removal protection
+
+```typescript
+// DynamoDB tables should have deletion protection
+template.hasResource('AWS::DynamoDB::Table', {
+  DeletionPolicy: 'Retain',
+  UpdateReplacePolicy: 'Retain',
+});
+
+// Critical resources should not be replaceable on update
+template.hasResource('AWS::RDS::DBInstance', {
+  UpdateReplacePolicy: Match.not('Delete'),
+});
+```
+
+### Environment separation
+
+```typescript
+// Production stack should NOT reference dev account IDs
+const templateJson = JSON.stringify(template.toJSON());
+expect(templateJson).not.toContain('123456789012'); // dev account
+expect(templateJson).not.toContain('dev-');
+
+// Production stack should have higher resource limits
+template.hasResourceProperties('AWS::Lambda::Function', {
+  MemorySize: Match.not(128), // 128 = default = probably not tuned for prod
+  Timeout: Match.not(3),      // 3s = default = probably not tuned for prod
+});
+```
+
+### VPC / Network isolation
+
+```typescript
+// Lambda in VPC should have both private subnets
+template.hasResourceProperties('AWS::Lambda::Function', {
+  VpcConfig: {
+    SubnetIds: Match.not(Match.arrayWith([])), // not empty
+    SecurityGroupIds: Match.not(Match.arrayWith([])),
+  },
+});
+
+// No resources in public subnets that shouldn't be
+const publicSubnetRefs = findPublicSubnetRefs(template);
+const lambdas = template.findResources('AWS::Lambda::Function');
+for (const [id, lambda] of Object.entries(lambdas)) {
+  const subnets = lambda.Properties?.VpcConfig?.SubnetIds ?? [];
+  for (const subnet of subnets) {
+    expect(publicSubnetRefs).not.toContainEqual(subnet);
+  }
+}
+```
+
+### Cost traps
+
+```typescript
+// NAT Gateways are expensive — verify they're intentional
+const natCount = Object.keys(
+  template.findResources('AWS::EC2::NatGateway')
+).length;
+expect(natCount).toBeLessThanOrEqual(expectedNatCount);
+
+// On-demand instances when spot would suffice
+template.hasResourceProperties('AWS::ECS::Service', {
+  CapacityProviderStrategy: Match.arrayWith([
+    Match.objectLike({
+      CapacityProvider: Match.stringLikeRegexp('FARGATE_SPOT'),
+    }),
+  ]),
+});
+```
+
+### Cross-stack reference integrity
+
+```typescript
+// When stacks export values, verify consumers actually use them
+// (orphaned exports are tech debt and can't be removed without deploy coordination)
+const exports = template.findOutputs('*');
+for (const [name, output] of Object.entries(exports)) {
+  if (output.Export) {
+    // Document why this export exists
+    expect(output.Description).toBeDefined();
+  }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot-only testing (no targeted assertions on security/permissions)
+- Testing synthesized template but not the construct inputs (garbage-in verification)
+- Missing `DeletionPolicy: Retain` on stateful resources (databases, buckets)
+- Wildcard IAM permissions (`*` on Action or Resource)
+- Hardcoded account IDs or region strings in constructs
+- No assertions on security group rules (default allows all egress)
+- Missing encryption on data-at-rest resources
+- Lambda functions with default 3s timeout and 128MB memory in production

--- a/skills/qa-author/references/go.md
+++ b/skills/qa-author/references/go.md
@@ -1,0 +1,295 @@
+# Go Testing Reference
+
+Stack-specific patterns for adversarial testing of Go applications.
+
+## Table-Driven Tests
+
+The standard Go pattern. Every test function should start here.
+
+```go
+func TestParseUserID(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int64
+        wantErr bool
+    }{
+        {"valid", "123", 123, false},
+        {"zero", "0", 0, false},
+        {"negative", "-1", 0, true},
+        {"empty string", "", 0, true},
+        {"whitespace", "  42  ", 0, true},    // or 42 if trimming is expected
+        {"overflow", "9223372036854775808", 0, true},
+        {"non-numeric", "abc", 0, true},
+        {"float", "3.14", 0, true},
+        {"leading zero", "007", 7, false},    // verify octal isn't assumed
+        {"max int64", "9223372036854775807", 9223372036854775807, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ParseUserID(tt.input)
+            if tt.wantErr {
+                if err == nil {
+                    t.Errorf("ParseUserID(%q) = %d, want error", tt.input, got)
+                }
+                return
+            }
+            if err != nil {
+                t.Fatalf("ParseUserID(%q) unexpected error: %v", tt.input, err)
+            }
+            if got != tt.want {
+                t.Errorf("ParseUserID(%q) = %d, want %d", tt.input, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Parallel Tests
+
+```go
+func TestConcurrentAccess(t *testing.T) {
+    t.Parallel() // marks this test as safe to run in parallel
+
+    tests := []struct{ name, input string }{...}
+    for _, tt := range tests {
+        tt := tt // capture range variable (required pre-Go 1.22)
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel() // subtests run in parallel with each other
+            // ...
+        })
+    }
+}
+```
+
+Use `t.Parallel()` aggressively to surface race conditions. Run with
+`-race` flag: `go test -race ./...`
+
+## Interface Mocks
+
+Prefer hand-written mocks over framework magic. A mock is just a struct that
+implements the interface.
+
+```go
+type mockStore struct {
+    getUserFunc func(ctx context.Context, id string) (*User, error)
+    calls       []string // track what was called
+}
+
+func (m *mockStore) GetUser(ctx context.Context, id string) (*User, error) {
+    m.calls = append(m.calls, "GetUser:"+id)
+    if m.getUserFunc != nil {
+        return m.getUserFunc(ctx, id)
+    }
+    return nil, errors.New("not configured")
+}
+```
+
+This makes test behavior explicit and avoids mock framework DSL overhead.
+
+## HTTP Handler Testing
+
+```go
+func TestGetUserHandler(t *testing.T) {
+    // Setup
+    store := &mockStore{
+        getUserFunc: func(ctx context.Context, id string) (*User, error) {
+            if id == "existing" {
+                return &User{ID: "existing", Name: "Alice"}, nil
+            }
+            return nil, ErrNotFound
+        },
+    }
+    handler := NewUserHandler(store)
+
+    tests := []struct {
+        name       string
+        method     string
+        path       string
+        wantStatus int
+        wantBody   string
+    }{
+        {"happy path", "GET", "/users/existing", 200, `"name":"Alice"`},
+        {"not found", "GET", "/users/missing", 404, `"error"`},
+        {"wrong method", "POST", "/users/existing", 405, ""},
+        {"empty id", "GET", "/users/", 400, ""},
+        {"path traversal", "GET", "/users/../admin", 400, ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            req := httptest.NewRequest(tt.method, tt.path, nil)
+            rec := httptest.NewRecorder()
+
+            handler.ServeHTTP(rec, req)
+
+            if rec.Code != tt.wantStatus {
+                t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+            }
+            if tt.wantBody != "" && !strings.Contains(rec.Body.String(), tt.wantBody) {
+                t.Errorf("body = %q, want substring %q", rec.Body.String(), tt.wantBody)
+            }
+        })
+    }
+}
+```
+
+### Test server for integration tests
+
+```go
+func TestClientIntegration(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        switch {
+        case r.URL.Path == "/api/users" && r.Method == "GET":
+            w.Header().Set("Content-Type", "application/json")
+            json.NewEncoder(w).Encode([]User{{ID: "1", Name: "Alice"}})
+        default:
+            w.WriteHeader(404)
+        }
+    }))
+    defer srv.Close()
+
+    client := NewAPIClient(srv.URL)
+    users, err := client.ListUsers(context.Background())
+    // ...
+}
+```
+
+## Context & Cancellation
+
+```go
+func TestOperationRespectsContext(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel() // already cancelled
+
+    _, err := service.DoExpensiveThing(ctx)
+    if !errors.Is(err, context.Canceled) {
+        t.Errorf("expected context.Canceled, got %v", err)
+    }
+}
+
+func TestOperationTimeout(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+    defer cancel()
+
+    time.Sleep(5 * time.Millisecond) // ensure timeout fires
+    _, err := service.DoThing(ctx)
+    if !errors.Is(err, context.DeadlineExceeded) {
+        t.Errorf("expected DeadlineExceeded, got %v", err)
+    }
+}
+```
+
+## Error Wrapping & Sentinel Checks
+
+```go
+// Verify errors are properly wrapped for caller inspection
+func TestErrorWrapping(t *testing.T) {
+    _, err := repo.GetUser(ctx, "nonexistent")
+
+    // Caller should be able to check the sentinel
+    if !errors.Is(err, ErrNotFound) {
+        t.Errorf("expected ErrNotFound, got %v", err)
+    }
+
+    // Verify context is preserved in the chain
+    var notFoundErr *NotFoundError
+    if !errors.As(err, &notFoundErr) {
+        t.Fatalf("expected *NotFoundError in chain, got %T", err)
+    }
+    if notFoundErr.Resource != "user" {
+        t.Errorf("resource = %q, want %q", notFoundErr.Resource, "user")
+    }
+}
+```
+
+## Adversarial Patterns for Go
+
+### Race condition detection
+
+```go
+// Run with: go test -race -count=100 ./...
+func TestConcurrentMapAccess(t *testing.T) {
+    cache := NewCache()
+    var wg sync.WaitGroup
+    for i := 0; i < 100; i++ {
+        wg.Add(2)
+        go func(n int) {
+            defer wg.Done()
+            cache.Set(fmt.Sprintf("key-%d", n), n)
+        }(i)
+        go func(n int) {
+            defer wg.Done()
+            cache.Get(fmt.Sprintf("key-%d", n))
+        }(i)
+    }
+    wg.Wait()
+}
+```
+
+### Goroutine leak detection
+
+```go
+import "go.uber.org/goleak"
+
+func TestMain(m *testing.M) {
+    goleak.VerifyTestMain(m)
+}
+```
+
+### Nil receiver
+
+```go
+func TestNilReceiver(t *testing.T) {
+    var s *Service // nil
+    // Should panic or return error, not silently misbehave
+    defer func() {
+        if r := recover(); r == nil {
+            t.Error("expected panic on nil receiver, got none")
+        }
+    }()
+    s.DoThing()
+}
+```
+
+### JSON marshaling edge cases
+
+```go
+func TestJSONRoundTrip(t *testing.T) {
+    cases := []struct {
+        name  string
+        input User
+    }{
+        {"zero value", User{}},
+        {"unicode name", User{Name: ""}},
+        {"null-byte in string", User{Name: "foo\x00bar"}},
+        {"max-length name", User{Name: strings.Repeat("a", 10000)}},
+    }
+    for _, tt := range cases {
+        t.Run(tt.name, func(t *testing.T) {
+            data, err := json.Marshal(tt.input)
+            if err != nil {
+                t.Fatalf("marshal: %v", err)
+            }
+            var got User
+            if err := json.Unmarshal(data, &got); err != nil {
+                t.Fatalf("unmarshal: %v", err)
+            }
+            if diff := cmp.Diff(tt.input, got); diff != "" {
+                t.Errorf("roundtrip mismatch (-want +got):\n%s", diff)
+            }
+        })
+    }
+}
+```
+
+## Anti-Patterns to Catch
+
+- Tests without `t.Run` subtests (can't identify which case failed)
+- Missing `t.Parallel()` on independent tests (hides race conditions)
+- Using `t.Fatal` in goroutines (panics, doesn't fail the test properly)
+- Asserting on string representations of errors instead of `errors.Is`/`errors.As`
+- Tests that depend on file system state without `t.TempDir()`
+- Using `time.Sleep` instead of channels/contexts for synchronization
+- Not running with `-race` flag in CI

--- a/skills/qa-author/references/htmx-lambda.md
+++ b/skills/qa-author/references/htmx-lambda.md
@@ -1,0 +1,312 @@
+# HTMX + Lambda Testing Reference
+
+Stack-specific patterns for adversarial testing of HTMX applications served by
+AWS Lambda handlers. This pattern is uncommon — most internet testing guidance
+doesn't cover it. Reference the actual request/response cycle.
+
+## Architecture
+
+```
+Browser → API Gateway → Lambda Handler → HTML Fragment Response
+         (hx-get/post)                    (not JSON, not full page)
+```
+
+Key differences from typical API testing:
+- Responses are **HTML fragments**, not JSON
+- `hx-*` attributes drive client behavior — they ARE the API contract
+- `HX-Trigger` response headers drive event-driven UI updates
+- No SPA router — server decides what HTML to swap
+
+## HTML Fragment Assertions
+
+Use cheerio (Node.js) or jsdom to parse and assert on HTML responses.
+
+```typescript
+import * as cheerio from 'cheerio';
+
+test('GET /users returns user list fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+
+  // Assert structure, not exact HTML string
+  expect($('ul#user-list li')).toHaveLength(3);
+  expect($('li').first().text()).toContain('Alice');
+
+  // Verify hx-* attributes — these are the API contract
+  expect($('li').first().attr('hx-get')).toBe('/users/1');
+  expect($('li').first().attr('hx-target')).toBe('#user-detail');
+  expect($('li').first().attr('hx-swap')).toBe('innerHTML');
+});
+```
+
+## HX-Trigger Header Assertions
+
+`HX-Trigger` response headers tell the client to fire events. These are part of
+the contract — test them explicitly.
+
+```typescript
+test('POST /users triggers userAdded event', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Bob', email: 'bob@example.com' }),
+    headers: {
+      'HX-Request': 'true',
+      'Content-Type': 'application/json',
+    },
+  }));
+
+  expect(response.statusCode).toBe(201);
+
+  // HX-Trigger can be a string (event name) or JSON (event + data)
+  const trigger = JSON.parse(response.headers['HX-Trigger']);
+  expect(trigger).toHaveProperty('userAdded');
+  expect(trigger.userAdded).toMatchObject({ id: expect.any(String) });
+});
+
+test('DELETE /users/:id triggers userList refresh', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'DELETE',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  expect(response.statusCode).toBe(200);
+  // After delete, the response should trigger a list refresh
+  expect(response.headers['HX-Trigger']).toContain('refreshUserList');
+});
+```
+
+## hx-* Attribute Testing
+
+The `hx-*` attributes in rendered HTML ARE the client-side routing. Test them
+like you'd test API routes.
+
+```typescript
+test('edit form has correct hx-put target', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123/edit',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  const form = $('form');
+
+  // These attributes define the mutation contract
+  expect(form.attr('hx-put')).toBe('/users/123');
+  expect(form.attr('hx-target')).toBe('#user-detail');
+  expect(form.attr('hx-swap')).toBe('outerHTML');
+
+  // Verify form inputs exist for all required fields
+  expect($('input[name="name"]')).toHaveLength(1);
+  expect($('input[name="email"]')).toHaveLength(1);
+
+  // Verify CSRF token is present if applicable
+  expect($('input[name="_csrf"]').val()).toBeTruthy();
+});
+```
+
+## Template Rendering Assertions
+
+Verify that data is actually bound into templates correctly.
+
+```typescript
+test('user detail renders all fields', async () => {
+  // Setup: user exists in DB
+  await createUser({ id: '123', name: 'Alice', email: 'alice@example.com', role: 'admin' });
+
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+
+  // Verify data binding — not just that it rendered, but the RIGHT data
+  expect($('[data-field="name"]').text()).toBe('Alice');
+  expect($('[data-field="email"]').text()).toBe('alice@example.com');
+  expect($('[data-field="role"]').text()).toBe('admin');
+
+  // XSS: verify HTML entities are escaped in user content
+  await updateUser('123', { name: '<script>alert("xss")</script>' });
+  const xssResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users/123',
+    headers: { 'HX-Request': 'true' },
+  }));
+  expect(xssResponse.body).not.toContain('<script>');
+  expect(xssResponse.body).toContain('&lt;script&gt;');
+});
+```
+
+## Lambda Handler Integration Tests
+
+Use the API Gateway event shape directly — no HTTP framework abstractions.
+
+```typescript
+// Helper to construct API Gateway proxy events
+function apiGatewayEvent(opts: {
+  method: string;
+  path: string;
+  body?: string;
+  headers?: Record<string, string>;
+  pathParameters?: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+}): APIGatewayProxyEvent {
+  return {
+    httpMethod: opts.method,
+    path: opts.path,
+    body: opts.body ?? null,
+    headers: { 'HX-Request': 'true', ...opts.headers },
+    pathParameters: opts.pathParameters ?? null,
+    queryStringParameters: opts.queryStringParameters ?? null,
+    // ... other required fields with defaults
+  } as APIGatewayProxyEvent;
+}
+```
+
+### Non-HTMX requests (progressive enhancement)
+
+```typescript
+test('non-HTMX request returns full page', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: {}, // No HX-Request header
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Full page should have html/head/body
+  expect($('html')).toHaveLength(1);
+  expect($('head title').text()).toBeTruthy();
+  expect($('body #user-list')).toHaveLength(1);
+});
+
+test('HTMX request returns fragment only', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // Fragment should NOT have html/head/body wrappers
+  expect($('html')).toHaveLength(0);
+  expect($('head')).toHaveLength(0);
+});
+```
+
+## Adversarial Patterns for HTMX + Lambda
+
+### Swap target integrity
+
+```typescript
+// If hx-target references an element ID, that element must exist in the
+// page context. A missing target = silent failure (no visible error).
+test('all hx-target references resolve', async () => {
+  // Get the full page first
+  const pageResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/dashboard',
+    headers: {},
+  }));
+  const $page = cheerio.load(pageResponse.body);
+
+  // Find all hx-target attributes in fragment responses
+  const fragmentResponse = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const $fragment = cheerio.load(fragmentResponse.body);
+
+  $fragment('[hx-target]').each((_, el) => {
+    const target = $fragment(el).attr('hx-target');
+    if (target && target.startsWith('#')) {
+      expect($page(target).length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+### Error responses as HTML
+
+```typescript
+// Errors must return HTML fragments (not JSON) for HTMX to display
+test('validation error returns HTML error fragment', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: '', email: 'not-an-email' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  // Should be 422, not 400 (HTMX doesn't swap on non-2xx by default unless
+  // hx-target-error is set)
+  expect(response.statusCode).toBe(422);
+  expect(response.headers['Content-Type']).toMatch(/text\/html/);
+
+  const $ = cheerio.load(response.body);
+  expect($('.error-message')).toHaveLength(2); // name + email
+  expect($('.error-message').first().text()).toContain('required');
+});
+```
+
+### Out-of-band swaps (hx-swap-oob)
+
+```typescript
+test('response includes OOB update for notification area', async () => {
+  const response = await handler(apiGatewayEvent({
+    method: 'POST',
+    path: '/users',
+    body: JSON.stringify({ name: 'Alice', email: 'alice@example.com' }),
+    headers: { 'HX-Request': 'true', 'Content-Type': 'application/json' },
+  }));
+
+  const $ = cheerio.load(response.body);
+  // OOB element should target the toast area
+  const oob = $('[hx-swap-oob="true"]');
+  expect(oob).toHaveLength(1);
+  expect(oob.attr('id')).toBe('notifications');
+  expect(oob.text()).toContain('User created');
+});
+```
+
+### Cold start / timeout behavior
+
+```typescript
+test('handler responds within API Gateway timeout', async () => {
+  const start = Date.now();
+  const response = await handler(apiGatewayEvent({
+    method: 'GET',
+    path: '/users',
+    headers: { 'HX-Request': 'true' },
+  }));
+  const elapsed = Date.now() - start;
+
+  // API Gateway default timeout is 29s; Lambda should be well under
+  expect(elapsed).toBeLessThan(5000);
+  expect(response.statusCode).toBe(200);
+});
+```
+
+## Anti-Patterns to Catch
+
+- Asserting on HTML string equality (brittle — whitespace, attribute order)
+- Not testing the `HX-Request` header presence/absence fork
+- Returning JSON error responses to HTMX requests (won't render)
+- Missing `HX-Trigger` headers after mutations (client doesn't know to refresh)
+- `hx-target` pointing to IDs that don't exist in the page context
+- Not escaping user content in templates (XSS via HTML injection)
+- Testing with framework abstractions instead of raw API Gateway events
+- Ignoring `hx-swap` strategy in assertions (innerHTML vs outerHTML matters)

--- a/skills/qa-author/references/nestjs.md
+++ b/skills/qa-author/references/nestjs.md
@@ -1,0 +1,182 @@
+# NestJS Testing Reference
+
+Stack-specific patterns for adversarial testing of NestJS applications.
+
+## Unit Tests
+
+### Module setup
+
+```typescript
+const module = await Test.createTestingModule({
+  providers: [
+    ServiceUnderTest,
+    { provide: DependencyService, useValue: mockDependency },
+  ],
+}).compile();
+
+const service = module.get<ServiceUnderTest>(ServiceUnderTest);
+```
+
+### Provider override patterns
+
+```typescript
+// Override a single provider for isolation
+const module = await Test.createTestingModule({
+  imports: [AppModule],
+})
+  .overrideProvider(DatabaseService)
+  .useValue(mockDb)
+  .compile();
+```
+
+### Guard testing in isolation
+
+```typescript
+// Test guards independently from controllers
+const guard = new AuthGuard(mockReflector, mockAuthService);
+const context = createMockExecutionContext({ user: null });
+await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+```
+
+### Interceptor testing
+
+```typescript
+const interceptor = new TransformInterceptor();
+const context = createMockExecutionContext();
+const next = { handle: () => of(rawData) };
+const result = await lastValueFrom(interceptor.intercept(context, next));
+expect(result).toEqual(expectedTransformedShape);
+```
+
+## Integration / E2E Tests
+
+### Supertest patterns
+
+```typescript
+const app = moduleFixture.createNestApplication();
+// Apply the same pipes/guards as production
+app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+await app.init();
+
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send(payload)
+  .expect(201);
+
+// Assert response SHAPE, not just status
+expect(response.body).toMatchObject({
+  id: expect.any(String),
+  email: payload.email,
+  createdAt: expect.any(String),
+});
+
+// Assert headers when relevant
+expect(response.headers['content-type']).toMatch(/application\/json/);
+```
+
+### Transactional test DB
+
+```typescript
+// Per-test transaction rollback for isolation
+beforeEach(async () => {
+  queryRunner = dataSource.createQueryRunner();
+  await queryRunner.startTransaction();
+});
+
+afterEach(async () => {
+  await queryRunner.rollbackTransaction();
+  await queryRunner.release();
+});
+```
+
+### Testing error responses
+
+```typescript
+// Don't just check status — verify the error shape
+const response = await request(app.getHttpServer())
+  .get('/users/nonexistent-id')
+  .expect(404);
+
+expect(response.body).toMatchObject({
+  statusCode: 404,
+  message: expect.any(String),
+  // Should NOT contain stack traces or internal paths
+});
+expect(response.body.message).not.toMatch(/\/src\//);
+expect(response.body.message).not.toMatch(/Error:/);
+```
+
+## Adversarial Patterns for NestJS
+
+### DTO validation bypass
+
+```typescript
+// ValidationPipe with whitelist:true should strip unknown properties
+const response = await request(app.getHttpServer())
+  .post('/users')
+  .send({ ...validPayload, isAdmin: true, __proto__: { admin: true } })
+  .expect(201);
+
+// Verify the extra fields did NOT persist
+const user = await userRepo.findOne({ where: { id: response.body.id } });
+expect(user.isAdmin).toBeFalsy();
+```
+
+### Authorization boundary tests
+
+```typescript
+// User A accessing User B's resource
+const tokenA = await getToken(userA);
+const response = await request(app.getHttpServer())
+  .get(`/users/${userB.id}/settings`)
+  .set('Authorization', `Bearer ${tokenA}`)
+  .expect(403); // or 404 — don't reveal existence
+
+// Expired token
+const expiredToken = generateExpiredToken(userA);
+await request(app.getHttpServer())
+  .get('/protected')
+  .set('Authorization', `Bearer ${expiredToken}`)
+  .expect(401);
+```
+
+### Pipe/guard ordering
+
+NestJS applies guards before pipes before interceptors. Test that auth rejection
+happens BEFORE validation (don't leak validation errors to unauthenticated users):
+
+```typescript
+// Invalid body + no auth = should get 401, not 400
+await request(app.getHttpServer())
+  .post('/protected')
+  .send({ invalid: 'payload' })
+  // No auth header
+  .expect(401);
+```
+
+### Exception filter coverage
+
+```typescript
+// Verify custom exception filters handle all expected error types
+// and don't leak internal errors on unexpected ones
+const unknownError = new Error('unexpected internal failure');
+// Trigger via a mocked provider that throws
+mockService.doThing.mockRejectedValue(unknownError);
+
+const response = await request(app.getHttpServer())
+  .get('/endpoint-using-service')
+  .expect(500);
+
+// Generic message, no stack trace
+expect(response.body.message).toBe('Internal server error');
+expect(JSON.stringify(response.body)).not.toContain('unexpected internal failure');
+```
+
+## Anti-Patterns to Catch
+
+- Testing with `any` typed mocks that silently accept anything
+- Supertest assertions on status only (no body/header checks)
+- Tests that import and call the controller method directly (bypasses pipes/guards)
+- Mocking the repository inside a service test AND the service inside a
+  controller test — the integration gap is where bugs hide
+- Not testing validation pipe behavior (assuming DTOs "just work")

--- a/skills/qa-author/references/react.md
+++ b/skills/qa-author/references/react.md
@@ -1,0 +1,219 @@
+# React Testing Reference
+
+Stack-specific patterns for adversarial testing of React applications.
+
+## Philosophy
+
+Test behavior, not implementation. Users don't know about state variables,
+effect hooks, or component hierarchies — they know about clicking buttons and
+seeing results.
+
+## Rendering & Queries
+
+### Prefer accessible queries
+
+```typescript
+// Good — queries the way a screen reader does
+screen.getByRole('button', { name: /submit/i });
+screen.getByLabelText(/email address/i);
+screen.getByText(/no results found/i);
+
+// Bad — brittle, tests implementation
+container.querySelector('.submit-btn');
+screen.getByTestId('submit-button'); // last resort only
+```
+
+### Query priority (Testing Library)
+
+1. `getByRole` — accessible name/role (best)
+2. `getByLabelText` — form fields
+3. `getByPlaceholderText` — when no label exists
+4. `getByText` — non-interactive content
+5. `getByDisplayValue` — filled-in form fields
+6. `getByAltText` — images
+7. `getByTitle` — title attribute
+8. `getByTestId` — last resort (no semantic meaning)
+
+## User Interaction
+
+### Always use `userEvent` over `fireEvent`
+
+```typescript
+import userEvent from '@testing-library/user-event';
+
+const user = userEvent.setup();
+
+// Good — simulates real user behavior (focus, keydown, keyup, input, change)
+await user.click(screen.getByRole('button', { name: /save/i }));
+await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+await user.selectOptions(screen.getByRole('combobox'), 'option-value');
+
+// Bad — only fires a single synthetic event
+fireEvent.click(button);
+fireEvent.change(input, { target: { value: 'text' } });
+```
+
+### Keyboard navigation
+
+```typescript
+// Tab order matters for accessibility
+await user.tab();
+expect(screen.getByLabelText(/first name/i)).toHaveFocus();
+await user.tab();
+expect(screen.getByLabelText(/last name/i)).toHaveFocus();
+
+// Escape to close
+await user.keyboard('{Escape}');
+expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+```
+
+## Async Patterns
+
+### Waiting for state updates
+
+```typescript
+// Good — waits for the element to appear
+await waitFor(() => {
+  expect(screen.getByText(/success/i)).toBeInTheDocument();
+});
+
+// Good — for elements that appear after async operations
+const successMessage = await screen.findByText(/saved successfully/i);
+expect(successMessage).toBeInTheDocument();
+
+// Bad — arbitrary timeouts
+await new Promise(resolve => setTimeout(resolve, 1000));
+```
+
+### Act warnings
+
+If you see "act() warnings," the component is updating state outside of the
+test's awareness. Fix by:
+1. Using `waitFor` / `findBy` for async updates
+2. Ensuring all promises resolve before assertions
+
+```typescript
+// If a component fetches on mount:
+render(<UserProfile userId="123" />);
+// Wait for loading to finish
+await waitFor(() => {
+  expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+});
+// Now assert on the loaded state
+expect(screen.getByText(/John Doe/i)).toBeInTheDocument();
+```
+
+## Adversarial Patterns for React
+
+### Error boundary testing
+
+```typescript
+// Verify error boundaries catch and display fallback UI
+const ThrowingChild = () => { throw new Error('render failure'); };
+
+render(
+  <ErrorBoundary fallback={<div>Something went wrong</div>}>
+    <ThrowingChild />
+  </ErrorBoundary>
+);
+
+expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+// Verify the error didn't propagate to the whole page
+expect(screen.queryByText(/unhandled/i)).not.toBeInTheDocument();
+```
+
+### Loading / error / empty states
+
+```typescript
+// Every data-fetching component has three states — test all three
+// 1. Loading
+render(<UserList />);
+expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+// 2. Error
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.status(500))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+});
+
+// 3. Empty
+server.use(rest.get('/api/users', (req, res, ctx) => res(ctx.json([]))));
+render(<UserList />);
+await waitFor(() => {
+  expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+});
+```
+
+### Form validation edge cases
+
+```typescript
+// Rapid submission (double-click prevention)
+const submitButton = screen.getByRole('button', { name: /submit/i });
+await user.click(submitButton);
+await user.click(submitButton); // immediate second click
+// Should only submit once
+expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+// Paste into validated field
+await user.click(screen.getByLabelText(/phone/i));
+await user.paste('not-a-phone-number');
+await user.click(submitButton);
+expect(screen.getByText(/invalid phone/i)).toBeInTheDocument();
+
+// Unicode in text inputs
+await user.type(screen.getByLabelText(/name/i), '');
+// Verify it renders correctly, doesn't crash, doesn't truncate
+expect(screen.getByLabelText(/name/i)).toHaveValue('');
+```
+
+### Accessibility assertions
+
+```typescript
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+const { container } = render(<MyComponent />);
+const results = await axe(container);
+expect(results).toHaveNoViolations();
+
+// Also verify ARIA states update correctly
+const expandButton = screen.getByRole('button', { name: /show details/i });
+expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+await user.click(expandButton);
+expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+```
+
+### Responsive / conditional rendering
+
+```typescript
+// Test that mobile-only elements aren't rendered on desktop viewport
+// (if using media queries that affect DOM structure)
+Object.defineProperty(window, 'innerWidth', { value: 1024 });
+window.dispatchEvent(new Event('resize'));
+render(<Navigation />);
+expect(screen.queryByRole('button', { name: /menu/i })).not.toBeInTheDocument();
+```
+
+### Unmount / cleanup
+
+```typescript
+// Verify no memory leaks: subscriptions, timers, listeners cleaned up
+const { unmount } = render(<RealTimeComponent />);
+unmount();
+// Advance timers — should not throw "setState on unmounted component"
+jest.advanceTimersByTime(5000);
+// No console.error about unmounted state updates
+expect(consoleSpy).not.toHaveBeenCalled();
+```
+
+## Anti-Patterns to Catch
+
+- Snapshot tests as the sole assertion (they prove nothing broke, not that
+  anything works)
+- Testing state directly via component internals (e.g., accessing `.state`)
+- Querying by class name or CSS selector
+- `fireEvent` when `userEvent` is available
+- Missing `await` on async interactions (tests pass but are non-deterministic)
+- Testing that a mock was called instead of testing the visible effect
+- Not testing disabled/loading states of buttons during async operations

--- a/skills/qa-bug-report/SKILL.md
+++ b/skills/qa-bug-report/SKILL.md
@@ -111,7 +111,7 @@ If the user confirms, create a ticket:
 tkt create \
   --type Bug \
   --summary "<one-line summary>" \
-  --description "<full report body>" \
+  --body "<full report body>" \
   --priority "<severity-mapped-priority>"
 ```
 


### PR DESCRIPTION
Follow-up to #20, which noted these were left out. The QA suite shipped to
Claude Code, Kiro, and Codex but not to Copilot: `.github/prompts/` entries are
condensed translations rather than byte-identical copies, so the five QA skills
could not be mirrored mechanically and needed an authoring pass.

## The prompts

`qa-strategy`, `qa-author`, `qa-critique`, `qa-flake-triage`, `qa-bug-report` —
32–51 lines each, matching the existing prompts' shape (`# Title` / `## Steps` /
`## Output` / `## Rules`) and the `~60 line` ceiling in `sync-skills`.

Condensing these is lossy by design, so the parts that carry the method were
kept in full rather than summarized away: the Break-It Checklist dimensions, the
mandatory red-before-green rule, the forbidden-cheats list (`.skip()`, weakened
assertions, `sleep()`, mocking the unit under test), and the
real-fix-vs-workaround table in flake triage. A prompt that dropped those would
read as generic "write good tests" advice.

## Two defects found while translating

**`qa-bug-report` documented a flag that does not exist.** It called
`tkt create --description "<full report body>"`. The verb takes `--body`
(`AGENTS.md` verb table, `adapters/base.Adapter.create`), so anyone following the
skill's own instructions would have hit a usage error.

**`qa-author`'s stack-reference table was dangling.** The skill routes to
`references/nestjs.md`, `references/react.md`, `references/go.md`,
`references/cdk.md`, and `references/htmx-lambda.md` — none of which were ported
with the skill in #20. All five added (1,275 lines); they contain no
backend-specific or downstream-specific content.

Tier-A mirrors (`.kiro/skills`, `.agents/skills`) now sync every file in a skill
directory rather than `SKILL.md` alone, so bundled references reach Kiro and
Codex too.

## Verification

- All 7 `scripts/smoke-sync-pack.sh` cases pass — `case1` now reports
  `skills=19 prompts=19 kiro=19 agents=6 steering=4`
- 58 unit tests pass
- `sync-pack --check` clean; a fresh consumer receives all 5 prompts and all 5
  bundled references
- Every Tier-A mirror byte-identical to source, bundled files included
