### PR TITLE
feat(pack): add named harness selection to sync-pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ separate harness-specific files).
 | `tkt cfg DOTTED.KEY [--pkg/--ticket/--slug]` | read config + template substitution |
 | `tkt cfg priorities` | backend-aware priority list, highest-first |
 | `tkt init --provider P [--dir D] [--link-skills] [--sample] [--force] [--no-detect-build]` | scaffold `.sdlc/` (seeds `[build]` from the project's package manager) |
-| `tkt sync-pack [--dir D] [--all-harnesses] [--check]` | install the pack into a consumer repo as committed copies |
+| `tkt sync-pack [HARNESS...] [--dir D] [--all-harnesses] [--list-harnesses] [--check]` | install the pack into a consumer repo as committed copies |
 | `tkt run [KEY] [--status] [--stop] [--max-iterations N] [--dry-run]` | external loop driver: one pipeline phase per harness invocation |
 | `tkt doctor` | validate auth + reachability + board model + pack sync |
 
@@ -159,6 +159,29 @@ In a consumer repo it also maintains a generated block inside that repo's
 `AGENTS.md`, delimited by markers — content outside the markers is preserved
 verbatim. `tkt sync-pack --check` reports missing/locally-modified/out-of-date
 pack files and exits 1; `tkt doctor` folds the same check in.
+
+### Harness selection
+
+A bare `tkt sync-pack` installs the default harnesses (`claude`, `copilot`,
+`kiro`). Name others to add them to an already-synced project:
+
+```sh
+tkt sync-pack cursor              # add Cursor to this repo
+tkt sync-pack cursor windsurf     # several at once
+tkt sync-pack --all-harnesses     # every known harness
+tkt sync-pack --list-harnesses    # names, target dirs, what's installed here
+```
+
+Selection is **additive and sticky**: the resulting set is recorded under
+`harnesses` in `.sdlc/pack-manifest.json`, so a later bare `tkt sync-pack` keeps
+every added harness up to date rather than reverting to the default three.
+Removing a harness means dropping it from that list by hand — `sync-pack` never
+deletes files.
+
+The defaults apply only when nothing is named **and** nothing is recorded. So in
+a repo that was set up with `tkt init --link-skills` (symlinked `.claude/`, no
+manifest), `tkt sync-pack cursor` installs `.cursor/` and the `AGENTS.md` block
+and nothing else — it will not drop committed copies on top of the symlinks.
 
 This file — the pack repo's own `AGENTS.md` — has no managed block and is
 hand-maintained.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,10 @@ Two layers, connected only by the verb contract and the normalized schema:
   - `pack.py` — implements `tkt sync-pack` and its `doctor` check. Copies pack files
     into a consumer tree, tracks them in `.sdlc/pack-manifest.json`, and maintains a
     marker-delimited managed block in the consumer's `AGENTS.md`. Never deletes, never
-    writes outside recorded paths, and is idempotent.
+    writes outside recorded paths, and is idempotent. `_HARNESSES` is the registry of
+    named harnesses → (pack source, consumer dest) dirs; the installed set is
+    additive and persisted in the manifest's `harnesses` list, so a bare re-run
+    refreshes every harness the project ever added.
   - `errors.py` — typed errors → exit codes (see `AGENTS.md` for the table). Errors
     always go to stderr with a non-zero exit so skills branch on codes.
   - `toolchain.py` — best-effort detection of a project's build/test/typecheck/lint

--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ the full guide.
 - `tkt sync-pack` writes real, tracked files into the repo (`.claude/skills`,
   `.github/prompts`, `.kiro/skills`, an `AGENTS.md` managed block, and a
   `.sdlc/pack-manifest.json`). Cloud harnesses, CI, and teammates only see tracked
-  files, so this is the option that works off your machine. Add `--all-harnesses`
-  for the curated long tail (Gemini, Cursor, Windsurf, Cline, Continue, Augment,
-  OpenCode, Antigravity).
+  files, so this is the option that works off your machine.
+- Adding a harness to a project that is already set up: name it —
+  `tkt sync-pack cursor`. The choice is additive and sticky (recorded in the
+  manifest), so later bare `tkt sync-pack` runs keep it in sync. `--all-harnesses`
+  takes the whole long tail (Gemini, Cursor, Windsurf, Cline, Continue, Augment,
+  OpenCode, AGENTS.md-native); `--list-harnesses` shows the names, their target
+  dirs, and which ones the project already installs.
 - `tkt init --link-skills` symlinks the pack into `.claude/` — fine for solo local
   work, invisible to git/CI. Use committed copies for anything shared.
 - Updating: `git pull` the pack clone, re-run `tkt sync-pack` per consumer repo;

--- a/core/cli.py
+++ b/core/cli.py
@@ -159,9 +159,18 @@ def build_parser() -> argparse.ArgumentParser:
                          "them from the project's package manager")
 
     sp = add("sync-pack")
+    sp.add_argument("harnesses", nargs="*", metavar="HARNESS",
+                    help="harness(es) to add to this project, e.g. `cursor`. "
+                         "Additive and sticky: once added, later bare runs keep "
+                         "them in sync. Omit to refresh what is already installed")
+    sp.add_argument("--harness", action="append", default=[], dest="harness_flag",
+                    metavar="NAME", help="same as a positional HARNESS; repeatable")
+    sp.add_argument("--list-harnesses", action="store_true", dest="list_harnesses",
+                    help="list harness names, their target dirs, and which ones "
+                         "this project already installs; writes nothing")
     sp.add_argument("--all-harnesses", action="store_true", dest="all_harnesses",
-                    help="also install the curated Tier-B harness dirs "
-                         "(.gemini, .cursor, .windsurf, ...) path-verbatim")
+                    help="install every known harness (.cursor, .gemini, "
+                         ".windsurf, ...) path-verbatim")
     sp.add_argument("--dir", default=".",
                     help="consumer repo to install the pack into (default cwd)")
     sp.add_argument("--check", action="store_true",
@@ -266,8 +275,13 @@ def main(argv: list[str]) -> int:
         # `sync-pack` installs pack files into a consumer tree; it needs no
         # config and may run before `tkt init`.
         if args.verb == "sync-pack":
-            from .pack import sync_pack
-            return sync_pack(args.dir, args.all_harnesses, args.check)
+            from .pack import list_harnesses, sync_pack
+            if args.list_harnesses:
+                return list_harnesses(args.dir)
+            names = [n.strip()
+                     for raw in (args.harnesses + args.harness_flag)
+                     for n in raw.split(",") if n.strip()]
+            return sync_pack(args.dir, args.all_harnesses, args.check, names)
 
         config = Config.load(args.config)
 

--- a/core/pack.py
+++ b/core/pack.py
@@ -37,20 +37,59 @@ END = "<!-- tkt-pack:end -->"
 # Pack-internal meta skill; never shipped to a consumer.
 _EXCLUDE_SKILLS = {"sync-skills"}
 
-# Curated Tier-B / extra harness dirs, copied path-verbatim only with
-# --all-harnesses. Only files present in THIS repo are copied.
-_EXTRA_HARNESS_DIRS = [
-    ".gemini/commands",
-    ".agents/skills",
-    ".agents/workflows",
-    ".cursor/skills",
-    ".cursor/commands",
-    ".windsurf/workflows",
-    ".clinerules/workflows",
-    ".continue/prompts",
-    ".augment/commands",
-    ".opencode/commands",
-]
+# Named harnesses. Each maps to (pack-relative source, consumer-relative dest)
+# pairs; every Tier-B dir is copied path-verbatim, so source == dest for all but
+# Claude Code (whose sources are the pack's top-level skills/ and agents/).
+# Only files present in THIS repo are copied — an absent source is a no-op.
+_HARNESSES: dict[str, tuple[str, list[tuple[str, str]]]] = {
+    "claude": ("Claude Code", [
+        ("skills", ".claude/skills"),
+        ("agents", ".claude/agents"),
+    ]),
+    "copilot": ("GitHub Copilot", [
+        (".github/prompts", ".github/prompts"),
+    ]),
+    # Kiro does not read AGENTS.md — steering is its only project-convention
+    # surface, so it ships by default rather than opt-in.
+    "kiro": ("Kiro", [
+        (".kiro/skills", ".kiro/skills"),
+        (".kiro/steering", ".kiro/steering"),
+        (".kiro/agents", ".kiro/agents"),
+    ]),
+    "cursor": ("Cursor", [
+        (".cursor/skills", ".cursor/skills"),
+        (".cursor/commands", ".cursor/commands"),
+    ]),
+    "gemini": ("Gemini CLI", [
+        (".gemini/commands", ".gemini/commands"),
+    ]),
+    "agents": ("Antigravity / Junie / Codex", [
+        (".agents/skills", ".agents/skills"),
+        (".agents/workflows", ".agents/workflows"),
+    ]),
+    "windsurf": ("Windsurf", [
+        (".windsurf/workflows", ".windsurf/workflows"),
+    ]),
+    "cline": ("Cline", [
+        (".clinerules/workflows", ".clinerules/workflows"),
+    ]),
+    "continue": ("Continue", [
+        (".continue/prompts", ".continue/prompts"),
+    ]),
+    "augment": ("Augment", [
+        (".augment/commands", ".augment/commands"),
+    ]),
+    "opencode": ("OpenCode", [
+        (".opencode/commands", ".opencode/commands"),
+    ]),
+}
+
+# Installed unless the caller narrows the set.
+_DEFAULT_HARNESSES = ("claude", "copilot", "kiro")
+
+
+def harness_names() -> list[str]:
+    return list(_HARNESSES)
 
 
 # ---- hashing / small helpers ----------------------------------------------
@@ -101,24 +140,73 @@ def _add_tree(plan: list, base: Path, dest_prefix: str) -> None:
         plan.append((f, f"{dest_prefix}/{rel_in.as_posix()}"))
 
 
-def _default_plan() -> list:
+def _plan_for(harnesses: list[str]) -> list:
+    """Source→dest plan for the selected harnesses, de-duplicated on dest so two
+    harnesses sharing a directory can't queue the same write twice."""
     plan: list = []
-    _add_tree(plan, PACK_ROOT / "skills", ".claude/skills")
-    _add_tree(plan, PACK_ROOT / "agents", ".claude/agents")
-    _add_tree(plan, PACK_ROOT / ".github" / "prompts", ".github/prompts")
-    _add_tree(plan, PACK_ROOT / ".kiro" / "skills", ".kiro/skills")
-    # Kiro does not read AGENTS.md — steering is its only project-convention
-    # surface, so it ships by default rather than under --all-harnesses.
-    _add_tree(plan, PACK_ROOT / ".kiro" / "steering", ".kiro/steering")
-    _add_tree(plan, PACK_ROOT / ".kiro" / "agents", ".kiro/agents")
+    seen: set[str] = set()
+    for name in harnesses:
+        for src_rel, dest_rel in _HARNESSES[name][1]:
+            for src, rel in _sub_plan(src_rel, dest_rel):
+                if rel in seen:
+                    continue
+                seen.add(rel)
+                plan.append((src, rel))
     return plan
 
 
-def _extra_plan() -> list:
+def _sub_plan(src_rel: str, dest_rel: str) -> list:
     plan: list = []
-    for d in _EXTRA_HARNESS_DIRS:
-        _add_tree(plan, PACK_ROOT / d, d)
+    _add_tree(plan, PACK_ROOT / src_rel, dest_rel)
     return plan
+
+
+def _resolve_harnesses(requested: list[str], all_harnesses: bool,
+                       manifest: dict) -> list[str]:
+    """Selection is ADDITIVE and STICKY: the harnesses recorded by a previous
+    sync stay installed, and `--harness X` adds X to that set permanently. This
+    is what makes a later bare `tkt sync-pack` keep every harness up to date
+    instead of silently reverting to the default three."""
+    selected = set(_manifest_harnesses(manifest))
+    if all_harnesses:
+        selected |= set(_HARNESSES)
+    for name in requested:
+        if name not in _HARNESSES:
+            raise UsageError(
+                f"unknown harness '{name}'. Available: "
+                f"{', '.join(_HARNESSES)} (or --list-harnesses)")
+        selected.add(name)
+    if not selected:
+        selected = set(_DEFAULT_HARNESSES)
+    # Stable order: registry order, which puts the defaults first.
+    return [n for n in _HARNESSES if n in selected]
+
+
+def _manifest_harnesses(manifest: dict) -> list[str]:
+    """Harnesses a previous sync installed. Understands the pre-registry
+    manifests that recorded only `harness_set: default|all`."""
+    recorded = manifest.get("harnesses")
+    if isinstance(recorded, list):
+        return [n for n in recorded if n in _HARNESSES]
+    if manifest.get("harness_set") == "all":
+        return list(_HARNESSES)
+    if manifest.get("harness_set") == "default":
+        return list(_DEFAULT_HARNESSES)
+    return []
+
+
+def list_harnesses(target_dir: str) -> int:
+    installed = set(_manifest_harnesses(
+        _load_manifest(Path(target_dir).expanduser().resolve() / MANIFEST_REL)))
+    for name, (label, dirs) in _HARNESSES.items():
+        mark = "*" if name in installed else " "
+        default = " (default)" if name in _DEFAULT_HARNESSES else ""
+        print(f" {mark} {name:<10} {label}{default}")
+        print(f"     {', '.join(d for _, d in dirs)}")
+    print()
+    print("  * = recorded in this project's pack manifest")
+    print("  add one with: tkt sync-pack <name>")
+    return 0
 
 
 # ---- AGENTS.md managed block ----------------------------------------------
@@ -215,7 +303,8 @@ def _report_check(missing: list, locally_mod: list, outdated: list) -> None:
 
 # ---- entry point -----------------------------------------------------------
 
-def sync_pack(target_dir: str, all_harnesses: bool, check: bool) -> int:
+def sync_pack(target_dir: str, all_harnesses: bool, check: bool,
+              harnesses: list[str] | None = None) -> int:
     target = Path(target_dir).expanduser().resolve()
 
     # Guardrail: never install into the pack checkout itself.
@@ -224,15 +313,13 @@ def sync_pack(target_dir: str, all_harnesses: bool, check: bool) -> int:
             f"--dir {target} is inside the pack checkout ({PACK_ROOT}); "
             "sync-pack installs INTO a separate consumer repo, not over the pack")
 
-    plan = _default_plan()
-    harness_set = "default"
-    if all_harnesses:
-        plan += _extra_plan()
-        harness_set = "all"
-
     manifest_path = target / MANIFEST_REL
     old = _load_manifest(manifest_path)
     old_files = old.get("files", {}) if isinstance(old.get("files"), dict) else {}
+
+    selected = _resolve_harnesses(harnesses or [], all_harnesses, old)
+    added = [n for n in selected if n not in _manifest_harnesses(old)]
+    plan = _plan_for(selected)
 
     new_files: dict[str, str] = {}
     missing: list[str] = []
@@ -299,6 +386,7 @@ def sync_pack(target_dir: str, all_harnesses: bool, check: bool) -> int:
                     locally_mod.append(f"{AGENTS_REL} (tkt-pack block)")
                 if cur_region_sha != block_sha:
                     outdated.append(f"{AGENTS_REL} (tkt-pack block)")
+        print(f"harnesses: {', '.join(selected)}")
         _report_check(missing, locally_mod, outdated)
         return 1 if (missing or locally_mod or outdated) else 0
 
@@ -325,10 +413,10 @@ def sync_pack(target_dir: str, all_harnesses: bool, check: bool) -> int:
     material = {
         "pack_commit": _git_head(PACK_ROOT),
         "pack_root": str(PACK_ROOT),
-        "harness_set": harness_set,
+        "harnesses": selected,
         "files": new_files,
     }
-    old_material = {k: old.get(k) for k in ("pack_commit", "pack_root", "harness_set", "files")}
+    old_material = {k: old.get(k) for k in ("pack_commit", "pack_root", "harnesses", "files")}
     wrote_manifest = False
     if material != old_material or not manifest_path.exists():
         manifest = dict(material)
@@ -338,6 +426,8 @@ def sync_pack(target_dir: str, all_harnesses: bool, check: bool) -> int:
             json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         wrote_manifest = True
 
+    if added:
+        print(f"harnesses added: {', '.join(added)}")
     if writes == 0 and not warnings and not wrote_manifest:
         print(f"sync-pack: up to date ({len(new_files)} entries) at {target}")
     else:

--- a/core/scaffold.py
+++ b/core/scaffold.py
@@ -100,6 +100,8 @@ def init(provider: str | None, target_dir: str, force: bool,
     if not link_skills:
         print("  4. Activate skills: `tkt sync-pack` (committed copies — best for "
               "cloud/CI harnesses like Copilot) or `tkt init --link-skills` (symlinks)")
+        print("     add a harness later with `tkt sync-pack cursor` "
+              "(`--list-harnesses` for the names)")
     return 0
 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,27 +57,45 @@ before you install.
 
 ## 3. What gets installed
 
-`tkt sync-pack` copies a **default harness set**. Add `--all-harnesses` to also
-install the curated long tail of other harnesses, path-verbatim.
+`tkt sync-pack` copies a **default harness set**. Name any other harness to add
+it, or use `--all-harnesses` for the whole curated long tail, path-verbatim.
 
-| Destination | Harness | Default | `--all-harnesses` |
-|---|---|:---:|:---:|
-| `.claude/skills/` (19 skills) | Claude Code | ✓ | ✓ |
-| `.claude/agents/` (6 subagents) | Claude Code | ✓ | ✓ |
-| `.github/prompts/` | GitHub Copilot | ✓ | ✓ |
-| `.kiro/skills/` | AWS Kiro (invocable skills) | ✓ | ✓ |
-| `.kiro/steering/` | AWS Kiro (project conventions) | ✓ | ✓ |
-| `.kiro/agents/` | AWS Kiro (sub-agent definitions) | ✓ | ✓ |
-| `AGENTS.md` managed block (`<!-- tkt-pack:begin/end -->`) | Universal fallback (Codex, Amp, Devin, …) | ✓ | ✓ |
-| `.gemini/commands/` | Gemini CLI | | ✓ |
-| `.agents/skills/` | Antigravity, Junie, Codex | | ✓ |
-| `.agents/workflows/` | Antigravity | | ✓ |
-| `.cursor/skills/` + `.cursor/commands/` | Cursor | | ✓ |
-| `.windsurf/workflows/` | Windsurf | | ✓ |
-| `.clinerules/workflows/` | Cline | | ✓ |
-| `.continue/prompts/` | Continue | | ✓ |
-| `.augment/commands/` | Augment | | ✓ |
-| `.opencode/commands/` | OpenCode | | ✓ |
+| Name | Destination | Harness | Default |
+|---|---|---|:---:|
+| `claude` | `.claude/skills/` (19 skills) + `.claude/agents/` (6 subagents) | Claude Code | ✓ |
+| `copilot` | `.github/prompts/` | GitHub Copilot | ✓ |
+| `kiro` | `.kiro/skills/` + `.kiro/steering/` + `.kiro/agents/` | AWS Kiro (skills, project conventions, sub-agents) | ✓ |
+| — | `AGENTS.md` managed block (`<!-- tkt-pack:begin/end -->`) | Universal fallback (Codex, Amp, Devin, …) — always written | ✓ |
+| `cursor` | `.cursor/skills/` + `.cursor/commands/` | Cursor | |
+| `gemini` | `.gemini/commands/` | Gemini CLI | |
+| `agents` | `.agents/skills/` + `.agents/workflows/` | Antigravity, Junie, Codex | |
+| `windsurf` | `.windsurf/workflows/` | Windsurf | |
+| `cline` | `.clinerules/workflows/` | Cline | |
+| `continue` | `.continue/prompts/` | Continue | |
+| `augment` | `.augment/commands/` | Augment | |
+| `opencode` | `.opencode/commands/` | OpenCode | |
+
+### Adding a harness later
+
+A project that was set up with the default set can pick up another harness at any
+time — no re-init, no `--force`:
+
+```sh
+tkt sync-pack cursor              # add Cursor
+tkt sync-pack cursor windsurf     # several at once
+tkt sync-pack --list-harnesses    # names, dirs, and what this repo installs
+```
+
+The selection is **additive and sticky**: it is recorded under `harnesses` in
+`.sdlc/pack-manifest.json`, so subsequent bare `tkt sync-pack` runs (and
+`--check`) cover every added harness instead of reverting to the default three.
+`sync-pack` never deletes, so removing a harness means dropping its name from
+that manifest list and deleting its directory by hand.
+
+The default set applies only when you name nothing **and** the manifest records
+nothing. A repo set up with `tkt init --link-skills` has symlinks in `.claude/`
+and no manifest, so `tkt sync-pack cursor` there installs `.cursor/` plus the
+`AGENTS.md` block only — it will not lay committed copies over the symlinks.
 
 Notes:
 - The `sync-skills` meta-skill is pack-internal and never shipped to a consumer.

--- a/scripts/smoke-sync-pack.sh
+++ b/scripts/smoke-sync-pack.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Smoke test for `tkt sync-pack`. Exercises fresh install, idempotency, local
-# modification restore + warning, --check exit status, --all-harnesses, and
-# AGENTS.md custom-content preservation. Prints PASS/FAIL per case.
+# modification restore + warning, --check exit status, --all-harnesses,
+# AGENTS.md custom-content preservation, and named/sticky harness selection.
+# Prints PASS/FAIL per case.
 set -euo pipefail
 
 PACK="$(cd "$(dirname "$0")/.." && pwd)"
@@ -19,7 +20,7 @@ git_init() {
 }
 
 C="$(mktemp -d)"
-trap 'rm -rf "$C" "${C2:-}" "${C3:-}" "${C4:-}"' EXIT
+trap 'rm -rf "$C" "${C2:-}" "${C3:-}" "${C4:-}" "${C5:-}" "${C6:-}"' EXIT
 
 # ---- case 1: fresh install --------------------------------------------------
 # Expected counts are derived from the pack, not hardcoded, so adding a skill
@@ -118,6 +119,39 @@ if echo "$out7" | grep -q "pre-existing file overwritten" && [ "$replaced" = "1"
 else
   fail "case7 pre-existing file (warned? / replaced=$replaced)"
   echo "$out7" | sed 's/^/    /'
+fi
+
+# ---- case 8: named harness is added and sticks ------------------------------
+# The point of `tkt sync-pack cursor` on an already-synced project: .cursor/ shows
+# up, and a later BARE run keeps it in sync instead of reverting to the defaults.
+C5="$(mktemp -d)"
+git_init "$C5"
+"$TKT" sync-pack --dir "$C5" >/dev/null
+before=$([ -d "$C5/.cursor" ] && echo yes || echo no)
+"$TKT" sync-pack cursor --dir "$C5" >/dev/null
+git -C "$C5" add -A && git -C "$C5" commit -qm "sync + cursor"
+# Bare re-run must be a no-op AND must still consider .cursor part of the set.
+"$TKT" sync-pack --dir "$C5" >/dev/null
+dirty=$(git -C "$C5" status --porcelain | wc -l | tr -d ' ')
+listed=$(grep -c '"cursor"' "$C5/.sdlc/pack-manifest.json" || true)
+checked=$("$TKT" sync-pack --check --dir "$C5" 2>&1 | grep -c 'harnesses:.*cursor' || true)
+if [ "$before" = "no" ] && [ -f "$C5/.cursor/commands/select-ticket.md" ] \
+   && [ "$dirty" = "0" ] && [ "$listed" -ge 1 ] && [ "$checked" -ge 1 ]; then
+  pass "case8 named harness added, recorded, and sticky across bare re-runs"
+else
+  fail "case8 named harness (before=$before dirty=$dirty manifest=$listed check=$checked)"
+fi
+
+# ---- case 9: unknown harness name is a usage error --------------------------
+C6="$(mktemp -d)"
+set +e
+out9="$("$TKT" sync-pack definitely-not-a-harness --dir "$C6" 2>&1)"
+rc9=$?
+set -e
+if [ "$rc9" = "64" ] && echo "$out9" | grep -q "unknown harness"; then
+  pass "case9 unknown harness name rejected with exit 64"
+else
+  fail "case9 unknown harness (rc=$rc9): $out9"
 fi
 
 echo


### PR DESCRIPTION
## Why

`tkt sync-pack` offered only two choices: the default harness set (`claude`, `copilot`, `kiro`) or `--all-harnesses`. A project already set up with the defaults had no way to pick up one more surface — e.g. adding `.cursor/` to a repo that only has `.claude/` — without taking the whole long tail.

## What

- `_HARNESSES` registry in `core/pack.py`: name → label + (pack source, consumer dest) dirs. Eleven names: `claude`, `copilot`, `kiro` (defaults), `cursor`, `gemini`, `agents`, `windsurf`, `cline`, `continue`, `augment`, `opencode`.
- Harness names accepted as positionals or `--harness` (repeatable, comma-separated):

  ```sh
  tkt sync-pack cursor              # add Cursor to an initialized project
  tkt sync-pack cursor windsurf     # several at once
  tkt sync-pack --list-harnesses    # names, target dirs, what this repo installs
  tkt sync-pack --all-harnesses     # unchanged: everything
  ```

- **Additive and sticky.** The resulting set is recorded under `harnesses` in `.sdlc/pack-manifest.json`, so a later bare `tkt sync-pack` (and `--check`) refreshes every harness the project ever added rather than reverting to the default three.
- **Backward compatible.** Manifests written before this change record `harness_set: default|all`; those are read and mapped onto the registry.
- Unknown name → `UsageError` (exit 64) listing the available names.

## Selection semantics

The default set applies only when nothing is named **and** nothing is recorded. That matters for repos set up with `tkt init --link-skills`, which have symlinks in `.claude/` and no manifest: `tkt sync-pack cursor` there installs `.cursor/` plus the `AGENTS.md` block and nothing else, rather than laying committed copies over the symlinks. Verified by hand on a scratch `--link-skills` repo — symlinks intact, no `.github/prompts` written.

`sync-pack` still never deletes, so removing a harness means dropping its name from the manifest list and removing the directory by hand. Documented.

## Verification

`scripts/smoke-sync-pack.sh` — 9/9 PASS, including two new cases:

- **case8** named harness added, recorded in the manifest, and sticky across a bare re-run (git status stays clean).
- **case9** unknown harness name rejected with exit 64.

Also checked manually: legacy `harness_set: all` / `default` manifests resolve correctly, `--all-harnesses` still installs the full set, and re-runs remain idempotent.

## Docs

`AGENTS.md` (verb table + new "Harness selection"), `README.md` (org section), `docs/install.md` (harness table gains a Name column, new "Adding a harness later"), `CLAUDE.md` (`pack.py` bullet), and the `tkt init` next-steps hint.