### PR TITLE
feat(plan-ticket): require regression test for bugs

### DIFF
--- a/.agents/skills/plan-ticket/SKILL.md
+++ b/.agents/skills/plan-ticket/SKILL.md
@@ -27,6 +27,15 @@ doc — the skill is repo-agnostic.
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
 
+### 2a. Bug tickets: regression test first
+
+If the ticket type is a bug (`tkt view "$KEY" --json | jq -r .type` matches
+bug/defect), the plan MUST list a failing regression test as change #1 — one
+that reproduces the reported behaviour and fails against current code. Name the
+test and the assertion in the Changes list, not just Test Strategy. No fix step
+precedes it. If the bug can't be reproduced in a test, say so explicitly under
+Risks and state why.
+
 ### 3. Produce the plan
 
 ```markdown
@@ -43,6 +52,7 @@ or shared-lib change. Note the typical files touched for each.
 - New tests: <describe>
 - Modified tests: <describe>
 - Regression: run the suite for affected packages
+- Regression (bugs): <failing test written first, per §2a>
 
 ### Risks
 - <anything that could go wrong / external schema or API deps>

--- a/.agents/workflows/plan-ticket.md
+++ b/.agents/workflows/plan-ticket.md
@@ -17,6 +17,7 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    ```
 2. Read existing code for affected packages.
 3. Classify the change scope.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.augment/commands/plan-ticket.md
+++ b/.augment/commands/plan-ticket.md
@@ -7,6 +7,7 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
 1. Read the ticket: `tkt view "$KEY" --json`.
 2. Read existing code for affected packages.
 3. Classify the change scope.
+   - **Bug tickets:** plan MUST list a failing regression test (reproduces the bug, fails now) as change #1, named under Changes; if not reproducible, say why under Risks.
 4. Produce a markdown plan: Summary, Changes, Test Strategy, Risks, Out of Scope, Estimated Size.
 5. Validate each acceptance criterion is covered.
 6. If >400 lines, comment and pause for confirmation.

--- a/.clinerules/workflows/plan-ticket.md
+++ b/.clinerules/workflows/plan-ticket.md
@@ -10,6 +10,7 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    ```
 2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.cursor/commands/plan-ticket.md
+++ b/.cursor/commands/plan-ticket.md
@@ -25,6 +25,10 @@ For each affected package, read relevant entry points (route handlers, types, sc
 
 Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
 
+### 3a. Bug tickets: regression test first
+
+If the ticket type is a bug (`tkt view "$KEY" --json | jq -r .type` matches bug/defect), the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and the assertion in the Changes list, not just Test Strategy. No fix step precedes it. If the bug can't be reproduced in a test, say so explicitly under Risks and state why.
+
 ### 4. Produce the plan
 
 ```markdown
@@ -41,6 +45,7 @@ Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
 - New tests: <describe>
 - Modified tests: <describe>
 - Regression: run the suite for affected packages
+- Regression (bugs): <failing test written first, per §3a>
 
 ### Risks
 - <anything that could go wrong / external schema or API deps>

--- a/.cursor/skills/plan-ticket/SKILL.md
+++ b/.cursor/skills/plan-ticket/SKILL.md
@@ -14,6 +14,7 @@ BEFORE any code changes. Ticketing access via `tkt`.
 1. Read the ticket: `tkt view "$KEY" --json`.
 2. Read existing code for affected packages.
 3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.github/prompts/plan-ticket.prompt.md
+++ b/.github/prompts/plan-ticket.prompt.md
@@ -16,6 +16,7 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    ```
 2. For each affected package, read relevant code (route handlers, types, schemas, tests, API specs).
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan with:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.kiro/skills/plan-ticket/SKILL.md
+++ b/.kiro/skills/plan-ticket/SKILL.md
@@ -27,6 +27,15 @@ doc — the skill is repo-agnostic.
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
 
+### 2a. Bug tickets: regression test first
+
+If the ticket type is a bug (`tkt view "$KEY" --json | jq -r .type` matches
+bug/defect), the plan MUST list a failing regression test as change #1 — one
+that reproduces the reported behaviour and fails against current code. Name the
+test and the assertion in the Changes list, not just Test Strategy. No fix step
+precedes it. If the bug can't be reproduced in a test, say so explicitly under
+Risks and state why.
+
 ### 3. Produce the plan
 
 ```markdown
@@ -43,6 +52,7 @@ or shared-lib change. Note the typical files touched for each.
 - New tests: <describe>
 - Modified tests: <describe>
 - Regression: run the suite for affected packages
+- Regression (bugs): <failing test written first, per §2a>
 
 ### Risks
 - <anything that could go wrong / external schema or API deps>

--- a/.opencode/commands/plan-ticket.md
+++ b/.opencode/commands/plan-ticket.md
@@ -9,6 +9,7 @@ Planning happens BEFORE any code changes.
 1. Read the ticket with `tkt view "$KEY" --json` and extract key, summary, acceptance criteria, and affected packages.
 2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc.
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan with these sections:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.windsurf/workflows/plan-ticket.md
+++ b/.windsurf/workflows/plan-ticket.md
@@ -10,6 +10,7 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    ```
 2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   - **Bug tickets:** the plan MUST list a failing regression test as change #1 — one that reproduces the reported behaviour and fails against current code. Name the test and assertion under Changes, not just Test Strategy; no fix step precedes it. If it can't be reproduced in a test, say so under Risks with the reason.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/skills/plan-ticket/SKILL.md
+++ b/skills/plan-ticket/SKILL.md
@@ -27,6 +27,15 @@ doc — the skill is repo-agnostic.
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
 
+### 2a. Bug tickets: regression test first
+
+If the ticket type is a bug (`tkt view "$KEY" --json | jq -r .type` matches
+bug/defect), the plan MUST list a failing regression test as change #1 — one
+that reproduces the reported behaviour and fails against current code. Name the
+test and the assertion in the Changes list, not just Test Strategy. No fix step
+precedes it. If the bug can't be reproduced in a test, say so explicitly under
+Risks and state why.
+
 ### 3. Produce the plan
 
 ```markdown
@@ -43,6 +52,7 @@ or shared-lib change. Note the typical files touched for each.
 - New tests: <describe>
 - Modified tests: <describe>
 - Regression: run the suite for affected packages
+- Regression (bugs): <failing test written first, per §2a>
 
 ### Risks
 - <anything that could go wrong / external schema or API deps>


### PR DESCRIPTION
## What

`plan-ticket` now requires that bug tickets plan a **failing regression test as change #1** — one that reproduces the reported behaviour and fails against current code. The test and its assertion must appear in the Changes list, not just Test Strategy, and no fix step may precede it. If the bug cannot be reproduced in a test, the plan says so explicitly under Risks with the reason.

## Why type, not type_class

The gate reads the ticket's provider `type` (matching bug/defect), **not** `type_class`. `type_class` is only `full_sdlc | deliverable | unknown` (`core/schema.py:18`), and Story and Bug both land in `full_sdlc` (`examples/config.markdown.toml:31`) — it cannot distinguish them.

## Files

- `skills/plan-ticket/SKILL.md` — new `### 2a` section + a Test Strategy template line
- Ten harness mirrors updated per `sync-skills` format rules: `.kiro/skills/` and `.agents/skills/` are byte-identical copies; `.cursor/commands/` gets the section form as `### 3a` (its §3 is change scope); the numbered-list variants get a sub-bullet under the classify step; `.augment/commands/` is condensed to match that file's one-line style.

No renumbering anywhere — inserted as `2a`/`3a`/sub-bullet, so existing step references stay valid.

## Notes

- `jq` is already used by ten other skills, so no new dependency.
- Frontmatter `description` is untouched, so the generated `AGENTS.md` block in consumer repos is unchanged. Consumers pick this up on their next `tkt sync-pack`.