### PR TITLE
feat(skills): add mex code-graph guidance

### DIFF
--- a/.agents/skills/plan-ticket/SKILL.md
+++ b/.agents/skills/plan-ticket/SKILL.md
@@ -18,6 +18,19 @@ Re-read anytime with `tkt view "$KEY" --json`.
 
 ### 1. Read existing code
 
+If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to
+code through the graph before opening files:
+
+```shell
+mex graph scope "<ticket summary>"        # compact JSONL neighborhood for the task
+mex graph query where-defined <symbol>    # exact lookup when a name is known
+mex graph get <id> --detail source        # expand only the 1-3 nodes that matter
+```
+
+Scope matches words, not meaning — if the manifest looks irrelevant, reword at
+most once, then fall back to reading files. Treat source the graph returns as
+already read.
+
 For each affected package, read the relevant entry points (route handlers, types,
 schemas, tests, API specs). Keep this mapping in the project's own conventions
 doc — the skill is repo-agnostic.
@@ -26,6 +39,9 @@ doc — the skill is repo-agnostic.
 
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
+
+With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints
+shows the transitive blast radius — fold surprises into the plan's Risks.
 
 ### 3. Produce the plan
 

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -18,6 +18,10 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
+If the repo has a mex code graph (`.mex/graph.db` exists), run
+`mex impact <changed-file>` on the changed files: transitive callers *outside*
+the diff feed the **Breaking** row below and belong in the findings.
+
 ### 2. Review as adversary (→ `sdlc-reviewer`)
 
 **Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The

--- a/.agents/workflows/plan-ticket.md
+++ b/.agents/workflows/plan-ticket.md
@@ -15,8 +15,17 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    // turbo
    tkt view "$KEY" --json
    ```
-2. Read existing code for affected packages.
-3. Classify the change scope.
+2. Read existing code for affected packages. If the repo has a mex code graph
+   (`.mex/graph.db` exists), map the ticket to code through it first:
+   ```shell
+   mex graph scope "<summary>"
+   mex graph query where-defined <symbol>
+   mex graph get <id> --detail source
+   ```
+   Reword a poor scope match once, then fall back to reading files; treat source the
+   graph returns as already read.
+3. Classify the change scope. With a code graph present, `mex impact <symbol-or-file>`
+   on the main touchpoints shows the transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.agents/workflows/self-review.md
+++ b/.agents/workflows/self-review.md
@@ -15,6 +15,9 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
    // turbo
    git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
    ```
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>`
+   on the changed files: transitive callers outside the diff feed the breaking-change
+   category and belong in the findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.augment/commands/plan-ticket.md
+++ b/.augment/commands/plan-ticket.md
@@ -5,8 +5,8 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
 ## Steps
 
 1. Read the ticket: `tkt view "$KEY" --json`.
-2. Read existing code for affected packages.
-3. Classify the change scope.
+2. Read existing code for affected packages. If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code first with `mex graph scope "<summary>"` and `mex graph query where-defined <symbol>`, expanding only the 1-3 nodes that matter via `mex graph get <id> --detail source`; fall back to reading files if scope misses.
+3. Classify the change scope. With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan: Summary, Changes, Test Strategy, Risks, Out of Scope, Estimated Size.
 5. Validate each acceptance criterion is covered.
 6. If >400 lines, comment and pause for confirmation.

--- a/.augment/commands/self-review.md
+++ b/.augment/commands/self-review.md
@@ -4,7 +4,7 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
 
 ## Steps
 
-1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`. If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on the changed files: transitive callers outside the diff are breaking-change findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity, description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.clinerules/workflows/plan-ticket.md
+++ b/.clinerules/workflows/plan-ticket.md
@@ -9,7 +9,13 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    tkt view "$KEY" --json
    ```
 2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
+   If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it
+   first: `mex graph scope "<summary>"`, `mex graph query where-defined <symbol>`, then
+   `mex graph get <id> --detail source` for the 1-3 nodes that matter. Reword a poor scope match
+   once, then fall back to reading files; treat source the graph returns as already read.
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the
+   transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.clinerules/workflows/self-review.md
+++ b/.clinerules/workflows/self-review.md
@@ -5,6 +5,9 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
 ## Steps
 
 1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on
+   the changed files: transitive callers outside the diff feed the breaking-change category and
+   belong in the findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.continue/prompts/plan-ticket.prompt
+++ b/.continue/prompts/plan-ticket.prompt
@@ -9,8 +9,8 @@ invokable: true
 Produce a structured implementation plan from a triaged ticket. Planning happens BEFORE any code changes.
 
 1. Read the ticket with `tkt view "$KEY" --json`.
-2. Read existing code for affected packages.
-3. Classify the change scope.
+2. Read existing code for affected packages. If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code first with `mex graph scope "<summary>"` and `mex graph query where-defined <symbol>`, expanding only the 1-3 nodes that matter via `mex graph get <id> --detail source`; fall back to reading files if scope misses.
+3. Classify the change scope. With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan with Summary, Changes, Test Strategy, Risks, Out of Scope, Estimated Size.
 5. Validate each acceptance criterion is covered.
 6. If >400 lines, comment and pause for confirmation.

--- a/.continue/prompts/self-review.prompt
+++ b/.continue/prompts/self-review.prompt
@@ -8,7 +8,7 @@ invokable: true
 
 Adversarial review of your own changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
 
-1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`. If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on the changed files: transitive callers outside the diff are breaking-change findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.cursor/commands/plan-ticket.md
+++ b/.cursor/commands/plan-ticket.md
@@ -19,11 +19,15 @@ Extract: `key`, `type` + `type_class`, `summary`, `acceptance`, affected package
 
 ### 2. Read existing code
 
+If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it first: `mex graph scope "<summary>"`, `mex graph query where-defined <symbol>`, then `mex graph get <id> --detail source` for the 1-3 nodes that matter. Reword a poor scope match once, then fall back to reading files; treat source the graph returns as already read.
+
 For each affected package, read relevant entry points (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc.
 
 ### 3. Identify change scope
 
 Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+
+With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the transitive blast radius — fold surprises into Risks.
 
 ### 4. Produce the plan
 

--- a/.cursor/commands/self-review.md
+++ b/.cursor/commands/self-review.md
@@ -8,6 +8,7 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
    ```shell
    git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
    ```
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on the changed files: transitive callers outside the diff feed the Breaking category below and belong in the findings.
 2. Review as adversary across:
    - Security: injection, auth bypass, secrets, unvalidated input
    - Types: loose types, missing null checks

--- a/.cursor/skills/plan-ticket/SKILL.md
+++ b/.cursor/skills/plan-ticket/SKILL.md
@@ -12,8 +12,14 @@ BEFORE any code changes. Ticketing access via `tkt`.
 ## Steps
 
 1. Read the ticket: `tkt view "$KEY" --json`.
-2. Read existing code for affected packages.
-3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+2. Read existing code for affected packages. If the repo has a mex code graph
+   (`.mex/graph.db` exists), map the ticket to code through it first: `mex graph scope
+   "<summary>"`, `mex graph query where-defined <symbol>`, then `mex graph get <id>
+   --detail source` for the 1-3 nodes that matter. Reword a poor scope match once, then
+   fall back to reading files; treat source the graph returns as already read.
+3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change. With a
+   code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the
+   transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.cursor/skills/self-review/SKILL.md
+++ b/.cursor/skills/self-review/SKILL.md
@@ -13,6 +13,9 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 ## Steps
 
 1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>`
+   on the changed files: transitive callers outside the diff feed the breaking-change
+   category and belong in the findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.gemini/commands/plan-ticket.toml
+++ b/.gemini/commands/plan-ticket.toml
@@ -5,8 +5,14 @@ Produce a structured implementation plan for ticket {{args}}. Planning happens B
 
 Steps:
 1. `tkt view "{{args}}" --json` — read summary, acceptance, affected packages
-2. For each affected package, read relevant code (handlers, types, schemas, tests, API specs)
-3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change
+2. For each affected package, read relevant code (handlers, types, schemas, tests, API specs).
+   If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it
+   first: `mex graph scope "<summary>"`, `mex graph query where-defined <symbol>`, then
+   `mex graph get <id> --detail source` for the 1-3 nodes that matter. Reword a poor scope match
+   once, then fall back to reading files; treat source the graph returns as already read
+3. Classify: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the
+   transitive blast radius — fold surprises into Risks
 4. Produce a markdown plan with:
    - Summary (one sentence)
    - Changes (numbered path — what)

--- a/.gemini/commands/self-review.toml
+++ b/.gemini/commands/self-review.toml
@@ -4,7 +4,10 @@ prompt = """
 Adversarial self-review of changes. Run AFTER implementation + tests pass, BEFORE opening a PR.
 
 Steps:
-1. Generate diff: `git diff $(git merge-base HEAD origin/!{tkt cfg vcs.default_branch})...HEAD`
+1. Generate diff: `git diff $(git merge-base HEAD origin/!{tkt cfg vcs.default_branch})...HEAD`.
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on
+   the changed files: transitive callers outside the diff feed the Breaking category below and
+   belong in the findings
 2. Review as adversary across:
    - Security: injection, auth bypass, secrets, unvalidated input
    - Types: unjustified loose types, missing null checks

--- a/.github/prompts/plan-ticket.prompt.md
+++ b/.github/prompts/plan-ticket.prompt.md
@@ -15,7 +15,13 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    tkt view "$KEY" --json
    ```
 2. For each affected package, read relevant code (route handlers, types, schemas, tests, API specs).
+   If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it
+   first: `mex graph scope "<summary>"`, `mex graph query where-defined <symbol>`, then
+   `mex graph get <id> --detail source` for the 1-3 nodes that matter. Reword a poor scope match
+   once, then fall back to reading files; treat source the graph returns as already read.
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the
+   transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan with:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.github/prompts/self-review.prompt.md
+++ b/.github/prompts/self-review.prompt.md
@@ -11,6 +11,9 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
 ## Steps
 
 1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on
+   the changed files: transitive callers *outside* the diff feed the breaking-change category and
+   belong in the findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.kiro/skills/plan-ticket/SKILL.md
+++ b/.kiro/skills/plan-ticket/SKILL.md
@@ -18,6 +18,19 @@ Re-read anytime with `tkt view "$KEY" --json`.
 
 ### 1. Read existing code
 
+If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to
+code through the graph before opening files:
+
+```shell
+mex graph scope "<ticket summary>"        # compact JSONL neighborhood for the task
+mex graph query where-defined <symbol>    # exact lookup when a name is known
+mex graph get <id> --detail source        # expand only the 1-3 nodes that matter
+```
+
+Scope matches words, not meaning — if the manifest looks irrelevant, reword at
+most once, then fall back to reading files. Treat source the graph returns as
+already read.
+
 For each affected package, read the relevant entry points (route handlers, types,
 schemas, tests, API specs). Keep this mapping in the project's own conventions
 doc — the skill is repo-agnostic.
@@ -26,6 +39,9 @@ doc — the skill is repo-agnostic.
 
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
+
+With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints
+shows the transitive blast radius — fold surprises into the plan's Risks.
 
 ### 3. Produce the plan
 

--- a/.kiro/skills/self-review/SKILL.md
+++ b/.kiro/skills/self-review/SKILL.md
@@ -18,6 +18,10 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
+If the repo has a mex code graph (`.mex/graph.db` exists), run
+`mex impact <changed-file>` on the changed files: transitive callers *outside*
+the diff feed the **Breaking** row below and belong in the findings.
+
 ### 2. Review as adversary (→ `sdlc-reviewer`)
 
 **Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The

--- a/.opencode/commands/plan-ticket.md
+++ b/.opencode/commands/plan-ticket.md
@@ -7,8 +7,8 @@ Produce a structured implementation plan for ticket: $ARGUMENTS
 Planning happens BEFORE any code changes.
 
 1. Read the ticket with `tkt view "$KEY" --json` and extract key, summary, acceptance criteria, and affected packages.
-2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc.
-3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs). Keep the package→file mapping in the project's own conventions doc. If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it first with `mex graph scope "<summary>"` and `mex graph query where-defined <symbol>`, expanding only the 1-3 nodes that matter via `mex graph get <id> --detail source`; reword a poor scope match once, then fall back to reading files.
+3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change. With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan with these sections:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.opencode/commands/self-review.md
+++ b/.opencode/commands/self-review.md
@@ -4,7 +4,7 @@ description: Adversarial self-review of changes before PR via tkt config
 
 Run an adversarial self-review of the current branch's changes: $ARGUMENTS
 
-1. Generate the diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+1. Generate the diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`. If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on the changed files: transitive callers outside the diff are breaking-change findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings with file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/.windsurf/workflows/plan-ticket.md
+++ b/.windsurf/workflows/plan-ticket.md
@@ -9,7 +9,13 @@ Produce a structured implementation plan from a triaged ticket. Planning happens
    tkt view "$KEY" --json
    ```
 2. Read existing code for each affected package (route handlers, types, schemas, tests, API specs).
+   If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to code through it
+   first: `mex graph scope "<summary>"`, `mex graph query where-defined <symbol>`, then
+   `mex graph get <id> --detail source` for the 1-3 nodes that matter. Reword a poor scope match
+   once, then fall back to reading files; treat source the graph returns as already read.
 3. Classify the change: new endpoint, bug fix, new feature, refactor, or shared-lib change.
+   With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints shows the
+   transitive blast radius — fold surprises into Risks.
 4. Produce a markdown plan:
    - Summary (one sentence)
    - Changes (numbered `path — what`)

--- a/.windsurf/workflows/self-review.md
+++ b/.windsurf/workflows/self-review.md
@@ -5,6 +5,9 @@ Adversarial review of your own changes. Run AFTER implementation + tests pass, B
 ## Steps
 
 1. Generate diff: `git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD`.
+   If the repo has a mex code graph (`.mex/graph.db` exists), run `mex impact <changed-file>` on
+   the changed files: transitive callers outside the diff feed the breaking-change category and
+   belong in the findings.
 2. Review as adversary across: security, types, errors, tests, style, breaking changes, performance, edge cases.
 3. List findings: file+line, severity (blocker/warning/nit), description, suggested fix.
 4. Fix all blockers and warnings.

--- a/agents/sdlc-executor.md
+++ b/agents/sdlc-executor.md
@@ -25,6 +25,10 @@ how to verify.
 
 - `git add`, `git status`, `git diff` (staging only — no push)
 - `tkt cfg` for reading config values
+- If the repo has a mex code graph (`.mex/graph.db` exists):
+  `mex graph query where-defined <symbol>` + `mex graph get <id> --detail source`
+  to find code without scanning, and `mex impact <symbol|file>` before editing a
+  shared symbol to see its callers
 
 ## Guardrails
 
@@ -39,7 +43,7 @@ how to verify.
 ## Workflow
 
 1. Read the plan.
-2. Read existing code before editing.
+2. Read existing code before editing (via the code graph when one is present).
 3. Implement per plan — minimal, idiomatic changes matching surrounding code.
 4. Run build + test after each logical unit.
 5. If tests fail, diagnose and fix (up to 3 attempts per failure).

--- a/agents/sdlc-planner.md
+++ b/agents/sdlc-planner.md
@@ -26,6 +26,13 @@ do not assume the author's intent was met.
 - `tkt blockers <KEY> --json` — check blockers
 - `tkt list --query <name> --json` — search tickets
 - `git log`, `git diff`, `git show` — read history
+- If the repo has a mex code graph (`.mex/graph.db` exists), prefer it over
+  scanning source: `mex graph scope "<task>"` for a compact neighborhood,
+  `mex graph query <who-calls|what-calls|where-defined> <symbol>` for exact
+  lookups, `mex graph get <id> --detail source` to expand the few nodes that
+  matter, and `mex impact <symbol|file>` for blast radius to feed Risks. All
+  read-only. Scope matches words, not meaning — reword at most once, then
+  fall back to reading files.
 
 ## Guardrails
 

--- a/agents/sdlc-reviewer.md
+++ b/agents/sdlc-reviewer.md
@@ -23,6 +23,10 @@ do not assume the author's intent was met.
 - `git diff`, `git log`, `git show` — read changes and history
 - `tkt view <KEY> --json` — read the ticket for requirement context
 - `tkt cfg <DOTTED.KEY>` — read project config
+- If the repo has a mex code graph (`.mex/graph.db` exists):
+  `mex impact <symbol|file>` on changed symbols surfaces callers *outside* the
+  diff (feeds the **Breaking** row); `mex graph query who-calls <symbol>` for
+  exact caller lookups. Both read-only.
 
 ## Guardrails
 

--- a/skills/plan-ticket/SKILL.md
+++ b/skills/plan-ticket/SKILL.md
@@ -18,6 +18,19 @@ Re-read anytime with `tkt view "$KEY" --json`.
 
 ### 1. Read existing code
 
+If the repo has a mex code graph (`.mex/graph.db` exists), map the ticket to
+code through the graph before opening files:
+
+```shell
+mex graph scope "<ticket summary>"        # compact JSONL neighborhood for the task
+mex graph query where-defined <symbol>    # exact lookup when a name is known
+mex graph get <id> --detail source        # expand only the 1-3 nodes that matter
+```
+
+Scope matches words, not meaning — if the manifest looks irrelevant, reword at
+most once, then fall back to reading files. Treat source the graph returns as
+already read.
+
 For each affected package, read the relevant entry points (route handlers, types,
 schemas, tests, API specs). Keep this mapping in the project's own conventions
 doc — the skill is repo-agnostic.
@@ -26,6 +39,9 @@ doc — the skill is repo-agnostic.
 
 Classify the work: new endpoint, bug fix, new feature (cross-cutting), refactor,
 or shared-lib change. Note the typical files touched for each.
+
+With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints
+shows the transitive blast radius — fold surprises into the plan's Risks.
 
 ### 3. Produce the plan
 

--- a/skills/plan-ticket/SKILL.md
+++ b/skills/plan-ticket/SKILL.md
@@ -42,6 +42,7 @@ or shared-lib change. Note the typical files touched for each.
 
 With a code graph present, `mex impact <symbol-or-file>` on the main touchpoints
 shows the transitive blast radius — fold surprises into the plan's Risks.
+
 ### 2a. Bug tickets: regression test first
 
 If the ticket type is a bug (`tkt view "$KEY" --json | jq -r .type` matches

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -18,6 +18,10 @@ BEFORE opening a PR. Loops until no blockers remain. Toolchain comes from
 git diff $(git merge-base HEAD origin/$(tkt cfg vcs.default_branch))...HEAD
 ```
 
+If the repo has a mex code graph (`.mex/graph.db` exists), run
+`mex impact <changed-file>` on the changed files: transitive callers *outside*
+the diff feed the **Breaking** row below and belong in the findings.
+
 ### 2. Review as adversary (→ `sdlc-reviewer`)
 
 **Delegate to `sdlc-reviewer`**, passing the diff and the plan/ticket summary. The


### PR DESCRIPTION
## Summary

Teach the SDLC pack's planning and review surfaces to use a [mex](https://github.com/olddognewflex/mex) code graph when the consumer repo provides one (`.mex/graph.db` present):

- **plan-ticket** — map the ticket to code via `mex graph scope/query/get` before opening files; `mex impact` on the main touchpoints feeds the plan's Risks.
- **self-review** — `mex impact` on changed files surfaces transitive callers *outside* the diff as breaking-change findings.
- **sdlc-planner / sdlc-executor / sdlc-reviewer** — graph verbs added to their (read-only where applicable) tool lists.

All guidance is presence-gated and optional, per the pack's portability rules (no hard tool dependency, degrades silently in repos without mex). Skill frontmatter descriptions are unchanged, so the `sync-pack` managed block in consumer repos does not churn.

Harness translations regenerated per `sync-skills` tiers: byte-identical Tier A copies (`.agents/skills`, `.kiro/skills`) plus condensed Copilot / Gemini / Cursor / Windsurf / Cline / Continue / Augment / Antigravity / OpenCode variants.

## Verification

- `.gemini/commands/*.toml` parse via `tomllib`
- Tier A copies verified byte-identical to canonical (`diff -q`)
- Condensed insertions spot-checked for presence-gated phrasing and per-format register